### PR TITLE
 openamp-xlnx: Parse non-dedicated IPIs for OpenAMP channels

### DIFF
--- a/assists/openamp-xlnx.py
+++ b/assists/openamp-xlnx.py
@@ -26,16 +26,20 @@ from lopper import LopperFmt
 import lopper
 from lopper_tree import *
 
-openamp_file_name = "openamp_lopper_gen.h"
 
 # given interrupt list, write interrupt base addresses and adequate register width to header file
 # TODO append memory carveout-related info
-def generate_openamp_file(ipi_list):
-    f = open(openamp_file_name, "w")
-    # for each pair of ipi's present, write a master+remote ipi
+def generate_openamp_file(ipi_list, options):
+    if (len(options["args"])) > 0:
+        f_name = options["args"][0]
+    else:
+        f_name = "openamp_lopper_info.h"
+
+    f = open(f_name, "w")
     f.write("#ifndef OPENAMP_LOPPER_INFO_H_\n")
     f.write("#define OPENAMP_LOPPER_INFO_H_\n\n")
 
+    # for each pair of ipi's present, write a master+remote ipi
     for index,value in enumerate(ipi_list):
         f.write("#define ")
         # first ipi in pair for master, second for remote
@@ -323,7 +327,7 @@ def xlnx_openamp_rpu( tgt_node, sdt, options ):
                 rpu_cpu_node.sync( sdt.FDT )
 
     ipis = parse_ipis_for_rpu(sdt, domain_node, rpu_cpu_node, options)
-    generate_openamp_file(ipis)
+    generate_openamp_file(ipis,options)
 
     return True
 

--- a/device-trees/system-device-tree.dts
+++ b/device-trees/system-device-tree.dts
@@ -94,8 +94,6 @@
 		              <0xf9000000 &amba_rpu 0xf9000000 0x10000>,
 		              <0x0 &memory 0x0 0x80000000>,
 		              <0x0 &tcm 0xFFE90000 0x10000>;
-//			      <0x0 &ps_ipi_0 0xFF340000 0x1000>,
-//			      <0x0 &ps_ipi_1 0xFF350000 0x1000>;
 		cpu@0 {
 			compatible = "arm,cortex-r5";
 			device_type = "cpu";
@@ -813,7 +811,6 @@
 			 */
 			access = <&tcm 0x1>, <&ethernet0 0x0>;
 
-			//ipis =	<&ps_ipi_0 0x0>,  <&ps_ipi_1 0x1>;
 			chosen {
 				bootargs = "console=ttyAMA0";
 			};

--- a/device-trees/system-device-tree.dts
+++ b/device-trees/system-device-tree.dts
@@ -56,25 +56,25 @@
 			};
 		};
 	};
-	ps_ipi_1 {
+	ps_ipi_1: ps_ipi@ff340000 {
 		compatible = "ps-interrupt";
 		#address-cells = <2>;
 		#size-cells = <2>;
 		reg = <0xFF340000 0x1000>;
 	};
-	ps_ipi_2 {
+	ps_ipi_2: ps_ipi@ff350000 {
 		compatible = "ps-interrupt";
 		#address-cells = <2>;
 		#size-cells = <2>;
 		reg = <0xFF350000 0x1000>;
 	};
-	ps_ipi_3 {
+	ps_ipi_3: ps_ipi@ff360000 {
 		compatible = "ps-interrupt";
 		#address-cells = <2>;
 		#size-cells = <2>;
 		reg = <0xFF360000 0x1000>;
 	};
-	ps_ipi_4 {
+	ps_ipi_4: ps_ipi@ff370000 {
 		compatible = "ps-interrupt";
 		#address-cells = <2>;
 		#size-cells = <2>;

--- a/device-trees/system-device-tree.dts
+++ b/device-trees/system-device-tree.dts
@@ -15,6 +15,8 @@
 	#size-cells = <0x2>;
 	model = "Xilinx Versal A2197 Processor board revA";
 
+
+
 	cpus {
 		#address-cells = <0x1>;
 		#size-cells = <0x0>;
@@ -54,6 +56,30 @@
 			};
 		};
 	};
+	ps_ipi_1 {
+		compatible = "ps-interrupt";
+		#address-cells = <2>;
+		#size-cells = <2>;
+		reg = <0xFF340000 0x1000>;
+	};
+	ps_ipi_2 {
+		compatible = "ps-interrupt";
+		#address-cells = <2>;
+		#size-cells = <2>;
+		reg = <0xFF350000 0x1000>;
+	};
+	ps_ipi_3 {
+		compatible = "ps-interrupt";
+		#address-cells = <2>;
+		#size-cells = <2>;
+		reg = <0xFF360000 0x1000>;
+	};
+	ps_ipi_4 {
+		compatible = "ps-interrupt";
+		#address-cells = <2>;
+		#size-cells = <2>;
+		reg = <0xFF370000 0x1000>;
+	};
 
 	cpus_r5: cpus-cluster@0 {
 		#address-cells = <0x1>;
@@ -68,7 +94,8 @@
 		              <0xf9000000 &amba_rpu 0xf9000000 0x10000>,
 		              <0x0 &memory 0x0 0x80000000>,
 		              <0x0 &tcm 0xFFE90000 0x10000>;
-
+//			      <0x0 &ps_ipi_0 0xFF340000 0x1000>,
+//			      <0x0 &ps_ipi_1 0xFF350000 0x1000>;
 		cpu@0 {
 			compatible = "arm,cortex-r5";
 			device_type = "cpu";
@@ -188,7 +215,6 @@
 			reg = <0x0 0xf9000000 0x0 0x1000 0x0 0xf9000000 0x0 0x100>;
 		};
 	};
-
 	amba: bus@f1000000 {
 		compatible = "simple-bus";
 		#address-cells = <0x2>;
@@ -787,6 +813,7 @@
 			 */
 			access = <&tcm 0x1>, <&ethernet0 0x0>;
 
+			//ipis =	<&ps_ipi_0 0x0>,  <&ps_ipi_1 0x1>;
 			chosen {
 				bootargs = "console=ttyAMA0";
 			};

--- a/lops/lop-domain-r5.dts
+++ b/lops/lop-domain-r5.dts
@@ -92,6 +92,7 @@
                           compatible = "system-device-tree-v1,lop,assist-v1";
                           id = "openamp,xlnx-rpu";
                           node = "/domains/openamp_r5";
+                          options = "openamp_channel_info.h";
                   };
                   lop_13 {
                          compatible = "system-device-tree-v1,lop,output";


### PR DESCRIPTION
 As OpenAMP uses channel information to configure IPC,
 add the follwing:

 - sample ipi's in input system DT
 - parsing for ipis in  openamp-xlnx assist
 - file generation in openamp-xlnx assist

Signed-off-by: Ben Levinsky <ben.levinsky@xilinx.com>