### PR TITLE
openamp-xlnx: parse memory carveouts

### DIFF
--- a/assists/openamp-xlnx.py
+++ b/assists/openamp-xlnx.py
@@ -111,9 +111,9 @@ def parse_ipis_for_rpu(sdt, domain_node, rpu_cpu_node, options):
         verbose = 0
 
     ipi_list = []
-    for k,v in sdt.tree.__nodes__.items():
-        if "ps_ipi" in k:
-            ipi_list.append((v["reg"]).hex()[0])
+    for node in sdt.tree:
+        if "ps_ipi" in node.abs_path:
+            ipi_list.append(node["reg"].hex()[0])
 
     if verbose:
         print( "[INFO]: Dedicated IPIs for OpenAMP: %s" % ipi_list)
@@ -129,9 +129,9 @@ def parse_memory_carevouts_for_rpu(sdt, domain_node, rpu_cpu_node, options):
         verbose = 0
 
     carveout_list = []
-    for k,v in sdt.tree.__nodes__.items():
-        if "channel" in k and "openamp,xlnx,mem-carveout" in str(v['compatible']):
-            carveout_list.append( ( (str(v), str(v['reg']).replace("reg = <","").replace(">;","").split(" ")) ))
+    for node in sdt.tree:
+        if "channel" in node.abs_path and "openamp,xlnx,mem-carveout" in node['compatible'].value[0]:
+            carveout_list.append( ( (str(node), str(node['reg']).replace("reg = <","").replace(">;","").split(" ")) ))
 
     return carveout_list
 

--- a/device-trees/system-device-tree.dts
+++ b/device-trees/system-device-tree.dts
@@ -80,63 +80,62 @@
 		#size-cells = <2>;
 		reg = <0xFF370000 0x1000>;
 	};
-
-        channel0vdev0vring0: channel0vdev0vring0@3ed40000 {
-                no-map;
+	channel0vdev0vring0: channel0vdev0vring0@3ed40000 {
+		no-map;
 		#address-cells = <2>;
 		#size-cells = <2>;
-                reg = <0x3ed40000 0x4000>;
+		reg = <0x3ed40000 0x4000>;
 		compatible = "openamp,xlnx,mem-carveout";
-        };
-        channel0vdev0vring1: channel0vdev0vring1@3ed44000 {
-                no-map;
+	};
+	channel0vdev0vring1: channel0vdev0vring1@3ed44000 {
+		no-map;
 		#address-cells = <2>;
 		#size-cells = <2>;
-                reg = <0x3ed44000 0x4000>;
-                compatible = "openamp,xlnx,mem-carveout";
-        };
-        channel0vdev0buffer: channel0vdev0buffer@3ed48000 {
-                no-map;
-		#address-cells = <2>;
-		#size-cells = <2>;
-                reg = <0x3ed48000 0x100000>;
-                compatible = "openamp,xlnx,mem-carveout";
-        };
-        channel0_elfload: channel0_elfload@3ed000000 {
-                no-map;
-		#address-cells = <2>;
-		#size-cells = <2>;
-                reg = <0x3ed00000 0x40000>;
-                compatible = "openamp,xlnx,mem-carveout";
-        };
-        channel1vdev0vring0: channel1vdev0vring0@3ef40000 {
-                no-map;
-		#address-cells = <2>;
-		#size-cells = <2>;
-                reg = <0x3ef40000 0x4000>;
+		reg = <0x3ed44000 0x4000>;
 		compatible = "openamp,xlnx,mem-carveout";
-        };
-        channel1vdev0vring1: channel1vdev0vring1@3ef44000 {
-                no-map;
+	};
+	channel0vdev0buffer: channel0vdev0buffer@3ed48000 {
+		no-map;
 		#address-cells = <2>;
 		#size-cells = <2>;
-                reg = <0x3ef44000 0x4000>;
-                compatible = "openamp,xlnx,mem-carveout";
-        };
-        channel1vdev0buffer: channel1vdev0buffer@3ef48000 {
-                no-map;
+		reg = <0x3ed48000 0x100000>;
+		compatible = "openamp,xlnx,mem-carveout";
+	};
+	channel0_elfload: channel0_elfload@3ed000000 {
+		no-map;
 		#address-cells = <2>;
 		#size-cells = <2>;
-                reg = <0x3ef48000 0x100000>;
-                compatible = "openamp,xlnx,mem-carveout";
-        };
-        channel1_elfload: channel1_elfload@3ef000000 {
-                no-map;
+		reg = <0x3ed00000 0x40000>;
+		compatible = "openamp,xlnx,mem-carveout";
+	};
+	channel1vdev0vring0: channel1vdev0vring0@3ef40000 {
+		no-map;
 		#address-cells = <2>;
 		#size-cells = <2>;
-                reg = <0x3ef00000 0x40000>;
-                compatible = "openamp,xlnx,mem-carveout";
-        };
+		reg = <0x3ef40000 0x4000>;
+		compatible = "openamp,xlnx,mem-carveout";
+	};
+	channel1vdev0vring1: channel1vdev0vring1@3ef44000 {
+		no-map;
+		#address-cells = <2>;
+		#size-cells = <2>;
+		reg = <0x3ef44000 0x4000>;
+		compatible = "openamp,xlnx,mem-carveout";
+	};
+	channel1vdev0buffer: channel1vdev0buffer@3ef48000 {
+		no-map;
+		#address-cells = <2>;
+		#size-cells = <2>;
+		reg = <0x3ef48000 0x100000>;
+		compatible = "openamp,xlnx,mem-carveout";
+	};
+	channel1_elfload: channel1_elfload@3ef000000 {
+		no-map;
+		#address-cells = <2>;
+		#size-cells = <2>;
+		reg = <0x3ef00000 0x40000>;
+		compatible = "openamp,xlnx,mem-carveout";
+	};
 
 	cpus_r5: cpus-cluster@0 {
 		#address-cells = <0x1>;

--- a/device-trees/system-device-tree.dts
+++ b/device-trees/system-device-tree.dts
@@ -81,6 +81,63 @@
 		reg = <0xFF370000 0x1000>;
 	};
 
+        channel0vdev0vring0: channel0vdev0vring0@3ed40000 {
+                no-map;
+		#address-cells = <2>;
+		#size-cells = <2>;
+                reg = <0x3ed40000 0x4000>;
+		compatible = "openamp,xlnx,mem-carveout";
+        };
+        channel0vdev0vring1: channel0vdev0vring1@3ed44000 {
+                no-map;
+		#address-cells = <2>;
+		#size-cells = <2>;
+                reg = <0x3ed44000 0x4000>;
+                compatible = "openamp,xlnx,mem-carveout";
+        };
+        channel0vdev0buffer: channel0vdev0buffer@3ed48000 {
+                no-map;
+		#address-cells = <2>;
+		#size-cells = <2>;
+                reg = <0x3ed48000 0x100000>;
+                compatible = "openamp,xlnx,mem-carveout";
+        };
+        channel0_elfload: channel0_elfload@3ed000000 {
+                no-map;
+		#address-cells = <2>;
+		#size-cells = <2>;
+                reg = <0x3ed00000 0x40000>;
+                compatible = "openamp,xlnx,mem-carveout";
+        };
+        channel1vdev0vring0: channel1vdev0vring0@3ef40000 {
+                no-map;
+		#address-cells = <2>;
+		#size-cells = <2>;
+                reg = <0x3ef40000 0x4000>;
+		compatible = "openamp,xlnx,mem-carveout";
+        };
+        channel1vdev0vring1: channel1vdev0vring1@3ef44000 {
+                no-map;
+		#address-cells = <2>;
+		#size-cells = <2>;
+                reg = <0x3ef44000 0x4000>;
+                compatible = "openamp,xlnx,mem-carveout";
+        };
+        channel1vdev0buffer: channel1vdev0buffer@3ef48000 {
+                no-map;
+		#address-cells = <2>;
+		#size-cells = <2>;
+                reg = <0x3ef48000 0x100000>;
+                compatible = "openamp,xlnx,mem-carveout";
+        };
+        channel1_elfload: channel1_elfload@3ef000000 {
+                no-map;
+		#address-cells = <2>;
+		#size-cells = <2>;
+                reg = <0x3ef00000 0x40000>;
+                compatible = "openamp,xlnx,mem-carveout";
+        };
+
 	cpus_r5: cpus-cluster@0 {
 		#address-cells = <0x1>;
 		#size-cells = <0x0>;


### PR DESCRIPTION
Output remoteproc and rpmsg compatible carveout information
into header for OpenAMP consumers

Signed-off-by: Ben Levinsky <ben.levinsky@xilinx.com>