### PR TITLE
assists: openamp-xlnx.py: output mem carveouts to r5 mem nodes

### DIFF
--- a/assists/openamp-xlnx.py
+++ b/assists/openamp-xlnx.py
@@ -142,7 +142,7 @@ def parse_memory_carevouts_for_rpu(sdt, domain_node, rpu_cpu_node, memory_node, 
     rpu_path = memory_node.abs_path
 
     # output to DT
-    for i in range(1,2):
+    for i in range(0,1):
         name = "/memory_r5@"+str(i)
         try:
             rpu_mem_node = sdt.tree[ memory_node.abs_path + name ]

--- a/lops/lop-domain-r5.dts
+++ b/lops/lop-domain-r5.dts
@@ -109,7 +109,7 @@
                   };
                   lop_15 {
                          compatible = "system-device-tree-v1,lop,output";
-                         outfile = "r5.dtb";
+                         outfile = "r5.dts";
                          // * is "all nodes"
                          nodes = "ps_ipi_*", "channel*", "cpus*","fpga*", "amba_rpu","tcm","memory_r5@0";
                   };

--- a/lops/lop-domain-r5.dts
+++ b/lops/lop-domain-r5.dts
@@ -107,6 +107,13 @@
                          // * is "all nodes"
                          nodes = "*";
                   };
+                  lop_15 {
+                         compatible = "system-device-tree-v1,lop,output";
+                         outfile = "r5.dtb";
+                         // * is "all nodes"
+                         nodes = "ps_ipi_*", "channel*", "cpus*","fpga*", "amba_rpu","tcm","memory_r5@0";
+                  };
+
                   lop_16 {
                          compatible = "system-device-tree-v1,lop,modify";
                          modify = "/amba/.*ethernet.*phy.*:testprop:testvalue";


### PR DESCRIPTION
As the openamp related memory carveouts as described in the input system DT and are output into the openamp specific header file, they should also be available for validation in output DTs. 

output the values to memory-region property in the corresponding R5 mem nodes to further this effort.

Signed-off-by: Ben Levinsky <ben.levinsky@xilinx.com>