### PR TITLE
assists: openamp-xlnx.py: add additional information for OpenAMP setup

### DIFF
--- a/assists/openamp-xlnx.py
+++ b/assists/openamp-xlnx.py
@@ -69,6 +69,7 @@ def write_openamp_virtio_rpmsg_info(f, carveout_list, options):
                 f.write("#define "+symbol_name+"RING_RX\t"+i[1][0]+"\n")
             elif "elfload" in i[0]:
                 f.write("#define "+symbol_name+"RSC_MEM_PA\t"+hex( int( i[1][0],16)+0x20000 )+"\n")
+                f.write("#define "+symbol_name+"SHM_DEV_NAME\t\""+hex( int( i[1][0],16)+0x20000 ).replace("0x","")+".shm\"\n")
                 f.write("#define "+symbol_name+"SHARED_BUF_SIZE\t"+i[1][1]+"\n")
                 current_channel_count += 1
 
@@ -85,6 +86,8 @@ def write_openamp_virtio_rpmsg_info(f, carveout_list, options):
                 f.write("#define "+symbol_name+"VRING_ALIGN\t0x1000\n")
                 f.write("#define "+symbol_name+"VRING_SIZE\t256\n")
                 f.write("#define "+symbol_name+"NUM_TABLE_ENTRIES\t1\n")
+                f.write("#define MASTER_BUS_NAME\t\"platform\"\n")
+                f.write("#define REMOTE_BUS_NAME\t\"generic\"\n")
 
 
 def write_mem_carveouts(f, carveout_list, options):
@@ -156,6 +159,7 @@ def generate_openamp_file(ipi_list, carveout_list, options, platform):
         else:
             ipi += "_REMOTE_"
         f.write(ipi+"IPI_BASE_ADDR\t"+value+"\n")
+        f.write("#define "+ipi+"IPI_NAME\t\""+value.replace("0x","")+".ipi\"\n")
 
         try:
             ipi_details_list = None
@@ -180,7 +184,7 @@ def generate_openamp_file(ipi_list, carveout_list, options, platform):
     f.write("\n")
     write_mem_carveouts(f, carveout_list, options)
     write_openamp_virtio_rpmsg_info(f, carveout_list, options)
-    f.write("\n\n#endif /* OPENAMP_LOPPER_INFO_H_\n")
+    f.write("\n\n#endif /* OPENAMP_LOPPER_INFO_H_ */\n")
     f.close()
 
 def parse_ipis_for_rpu(sdt, domain_node, rpu_cpu_node, options):

--- a/device-trees/system-device-tree-zynqmp.dts
+++ b/device-trees/system-device-tree-zynqmp.dts
@@ -1,0 +1,2330 @@
+/dts-v1/;
+
+/ {
+	compatible = "xlnx,zynqmp-zcu102-rev1.0", "xlnx,zynqmp-zcu102", "xlnx,zynqmp";
+	#address-cells = <0x2>;
+	#size-cells = <0x2>;
+	model = "ZynqMP ZCU102 Rev1.0";
+
+
+	ps_ipi_3: ps_ipi@ff340000 {
+		compatible = "ps-interrupt";
+		#address-cells = <2>;
+		#size-cells = <2>;
+		reg = <0xFF340000 0x1000>;
+	};
+	ps_ipi_1: ps_ipi@ff310000 {
+		compatible = "ps-interrupt";
+		#address-cells = <2>;
+		#size-cells = <2>;
+		reg = <0xFF310000 0x1000>;
+	};
+	channel0vdev0vring0: channel0vdev0vring0@3ed40000 {
+		no-map;
+		#address-cells = <2>;
+		#size-cells = <2>;
+		reg = <0x3ed40000 0x4000>;
+		compatible = "openamp,xlnx,mem-carveout";
+	};
+	channel0vdev0vring1: channel0vdev0vring1@3ed44000 {
+		no-map;
+		#address-cells = <2>;
+		#size-cells = <2>;
+		reg = <0x3ed44000 0x4000>;
+		compatible = "openamp,xlnx,mem-carveout";
+	};
+	channel0vdev0buffer: channel0vdev0buffer@3ed48000 {
+		no-map;
+		#address-cells = <2>;
+		#size-cells = <2>;
+		reg = <0x3ed48000 0x100000>;
+		compatible = "openamp,xlnx,mem-carveout";
+	};
+	channel0_elfload: channel0_elfload@3ed000000 {
+		no-map;
+		#address-cells = <2>;
+		#size-cells = <2>;
+		reg = <0x3ed00000 0x40000>;
+		compatible = "openamp,xlnx,mem-carveout";
+	};
+	
+
+        cpus_r5: cpus-cluster@0 {
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+		#cpus-mask-cells = <0x1>;
+		compatible = "cpus,cluster";
+
+		#ranges-size-cells = <0x1>;
+		#ranges-address-cells = <0x1>;
+
+		address-map = <0xf1000000 &amba 0xf1000000 0xeb00000>,
+		              <0xf9000000 &amba_rpu 0xf9000000 0x10000>,
+		              <0x0 &memory 0x0 0x80000000>,
+		              <0x0 &tcm 0xFFE90000 0x10000>;
+		cpu@0 {
+			compatible = "arm,cortex-r5";
+			device_type = "cpu";
+			reg = <0x0>;
+		};
+
+		cpu@1 {
+			compatible = "arm,cortex-r5";
+			device_type = "cpu";
+			reg = <0x1>;
+		};
+	};
+
+	cpu-opp-table {
+		compatible = "operating-points-v2";
+		opp-shared;
+		phandle = <0x1>;
+
+		opp00 {
+			opp-hz = <0x0 0x47868bf4>;
+			opp-microvolt = <0xf4240>;
+			clock-latency-ns = <0x7a120>;
+		};
+
+		opp01 {
+			opp-hz = <0x0 0x23c345fa>;
+			opp-microvolt = <0xf4240>;
+			clock-latency-ns = <0x7a120>;
+		};
+
+		opp02 {
+			opp-hz = <0x0 0x17d783fc>;
+			opp-microvolt = <0xf4240>;
+			clock-latency-ns = <0x7a120>;
+		};
+
+		opp03 {
+			opp-hz = <0x0 0x11e1a2fd>;
+			opp-microvolt = <0xf4240>;
+			clock-latency-ns = <0x7a120>;
+		};
+	};
+
+	dcc {
+		compatible = "arm,dcc";
+		status = "disabled";
+		u-boot,dm-pre-reloc;
+	};
+
+	pmu {
+		compatible = "arm,armv8-pmuv3";
+		interrupt-parent = <0x4>;
+		interrupts = <0x0 0x8f 0x4 0x0 0x90 0x4 0x0 0x91 0x4 0x0 0x92 0x4>;
+	};
+
+	psci {
+		compatible = "arm,psci-0.2";
+		method = "smc";
+	};
+
+	firmware {
+
+		zynqmp-firmware {
+			compatible = "xlnx,zynqmp-firmware";
+			u-boot,dm-pre-reloc;
+			method = "smc";
+			#power-domain-cells = <0x1>;
+			phandle = <0xc>;
+
+			pcap {
+				compatible = "xlnx,zynqmp-pcap-fpga";
+				clock-names = "ref_clk";
+				clocks = <0x3 0x29>;
+				phandle = <0xb>;
+			};
+
+			zynqmp-power {
+				u-boot,dm-pre-reloc;
+				compatible = "xlnx,zynqmp-power";
+				interrupt-parent = <0x4>;
+				interrupts = <0x0 0x23 0x4>;
+				mboxes = <0x5 0x0 0x5 0x1>;
+				mbox-names = "tx", "rx";
+			};
+
+			reset-controller {
+				compatible = "xlnx,zynqmp-reset";
+				#reset-cells = <0x1>;
+				phandle = <0x1a>;
+			};
+
+			pinctrl {
+				compatible = "xlnx,zynqmp-pinctrl";
+				status = "okay";
+
+				i2c0-default {
+					phandle = <0x12>;
+
+					mux {
+						groups = "i2c0_3_grp";
+						function = "i2c0";
+					};
+
+					conf {
+						groups = "i2c0_3_grp";
+						bias-pull-up;
+						slew-rate = <0x1>;
+						io-standard = <0x1>;
+					};
+				};
+
+				i2c0-gpio {
+					phandle = <0x13>;
+
+					mux {
+						groups = "gpio0_14_grp", "gpio0_15_grp";
+						function = "gpio0";
+					};
+
+					conf {
+						groups = "gpio0_14_grp", "gpio0_15_grp";
+						slew-rate = <0x1>;
+						io-standard = <0x1>;
+					};
+				};
+
+				i2c1-default {
+					phandle = <0x15>;
+
+					mux {
+						groups = "i2c1_4_grp";
+						function = "i2c1";
+					};
+
+					conf {
+						groups = "i2c1_4_grp";
+						bias-pull-up;
+						slew-rate = <0x1>;
+						io-standard = <0x1>;
+					};
+				};
+
+				i2c1-gpio {
+					phandle = <0x16>;
+
+					mux {
+						groups = "gpio0_16_grp", "gpio0_17_grp";
+						function = "gpio0";
+					};
+
+					conf {
+						groups = "gpio0_16_grp", "gpio0_17_grp";
+						slew-rate = <0x1>;
+						io-standard = <0x1>;
+					};
+				};
+
+				uart0-default {
+					phandle = <0x1d>;
+
+					mux {
+						groups = "uart0_4_grp";
+						function = "uart0";
+					};
+
+					conf {
+						groups = "uart0_4_grp";
+						slew-rate = <0x1>;
+						io-standard = <0x1>;
+					};
+
+					conf-rx {
+						pins = "MIO18";
+						bias-high-impedance;
+					};
+
+					conf-tx {
+						pins = "MIO19";
+						bias-disable;
+					};
+				};
+
+				uart1-default {
+					phandle = <0x1e>;
+
+					mux {
+						groups = "uart1_5_grp";
+						function = "uart1";
+					};
+
+					conf {
+						groups = "uart1_5_grp";
+						slew-rate = <0x1>;
+						io-standard = <0x1>;
+					};
+
+					conf-rx {
+						pins = "MIO21";
+						bias-high-impedance;
+					};
+
+					conf-tx {
+						pins = "MIO20";
+						bias-disable;
+					};
+				};
+
+				usb0-default {
+					phandle = <0x1f>;
+
+					mux {
+						groups = "usb0_0_grp";
+						function = "usb0";
+					};
+
+					conf {
+						groups = "usb0_0_grp";
+						slew-rate = <0x1>;
+						io-standard = <0x1>;
+					};
+
+					conf-rx {
+						pins = "MIO52", "MIO53", "MIO55";
+						bias-high-impedance;
+					};
+
+					conf-tx {
+						pins = "MIO54", "MIO56", "MIO57", "MIO58", "MIO59", "MIO60", "MIO61", "MIO62", "MIO63";
+						bias-disable;
+					};
+				};
+
+				gem3-default {
+					phandle = <0x10>;
+
+					mux {
+						function = "ethernet3";
+						groups = "ethernet3_0_grp";
+					};
+
+					conf {
+						groups = "ethernet3_0_grp";
+						slew-rate = <0x1>;
+						io-standard = <0x1>;
+					};
+
+					conf-rx {
+						pins = "MIO70", "MIO71", "MIO72", "MIO73", "MIO74", "MIO75";
+						bias-high-impedance;
+						low-power-disable;
+					};
+
+					conf-tx {
+						pins = "MIO64", "MIO65", "MIO66", "MIO67", "MIO68", "MIO69";
+						bias-disable;
+						low-power-enable;
+					};
+
+					mux-mdio {
+						function = "mdio3";
+						groups = "mdio3_0_grp";
+					};
+
+					conf-mdio {
+						groups = "mdio3_0_grp";
+						slew-rate = <0x1>;
+						io-standard = <0x1>;
+						bias-disable;
+					};
+				};
+
+				can1-default {
+					phandle = <0xd>;
+
+					mux {
+						function = "can1";
+						groups = "can1_6_grp";
+					};
+
+					conf {
+						groups = "can1_6_grp";
+						slew-rate = <0x1>;
+						io-standard = <0x1>;
+					};
+
+					conf-rx {
+						pins = "MIO25";
+						bias-high-impedance;
+					};
+
+					conf-tx {
+						pins = "MIO24";
+						bias-disable;
+					};
+				};
+
+				sdhci1-default {
+					phandle = <0x1c>;
+
+					mux {
+						groups = "sdio1_0_grp";
+						function = "sdio1";
+					};
+
+					conf {
+						groups = "sdio1_0_grp";
+						slew-rate = <0x1>;
+						io-standard = <0x1>;
+						bias-disable;
+					};
+
+					mux-cd {
+						groups = "sdio1_cd_0_grp";
+						function = "sdio1_cd";
+					};
+
+					conf-cd {
+						groups = "sdio1_cd_0_grp";
+						bias-high-impedance;
+						bias-pull-up;
+						slew-rate = <0x1>;
+						io-standard = <0x1>;
+					};
+
+					mux-wp {
+						groups = "sdio1_wp_0_grp";
+						function = "sdio1_wp";
+					};
+
+					conf-wp {
+						groups = "sdio1_wp_0_grp";
+						bias-high-impedance;
+						bias-pull-up;
+						slew-rate = <0x1>;
+						io-standard = <0x1>;
+					};
+				};
+
+				gpio-default {
+					phandle = <0x11>;
+
+					mux-sw {
+						function = "gpio0";
+						groups = "gpio0_22_grp", "gpio0_23_grp";
+					};
+
+					conf-sw {
+						groups = "gpio0_22_grp", "gpio0_23_grp";
+						slew-rate = <0x1>;
+						io-standard = <0x1>;
+					};
+
+					mux-msp {
+						function = "gpio0";
+						groups = "gpio0_13_grp", "gpio0_38_grp";
+					};
+
+					conf-msp {
+						groups = "gpio0_13_grp", "gpio0_38_grp";
+						slew-rate = <0x1>;
+						io-standard = <0x1>;
+					};
+
+					conf-pull-up {
+						pins = "MIO22", "MIO23";
+						bias-pull-up;
+					};
+
+					conf-pull-none {
+						pins = "MIO13", "MIO38";
+						bias-disable;
+					};
+				};
+			};
+
+			clock-controller {
+				u-boot,dm-pre-reloc;
+				#clock-cells = <0x1>;
+				compatible = "xlnx,zynqmp-clk";
+				clocks = <0x6 0x7 0x8 0x9 0xa>;
+				clock-names = "pss_ref_clk", "video_clk", "pss_alt_ref_clk", "aux_ref_clk", "gt_crx_ref_clk";
+				phandle = <0x3>;
+			};
+		};
+	};
+
+	timer {
+		compatible = "arm,armv8-timer";
+		interrupt-parent = <0x4>;
+		interrupts = <0x1 0xd 0xf08 0x1 0xe 0xf08 0x1 0xb 0xf08 0x1 0xa 0xf08>;
+	};
+
+	edac {
+		compatible = "arm,cortex-a53-edac";
+	};
+
+	fpga-full {
+		compatible = "fpga-region";
+		fpga-mgr = <0xb>;
+		#address-cells = <0x2>;
+		#size-cells = <0x2>;
+		ranges;
+	};
+
+	nvmem_firmware {
+		compatible = "xlnx,zynqmp-nvmem-fw";
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+
+		soc_revision@0 {
+			reg = <0x0 0x4>;
+			phandle = <0x19>;
+		};
+
+		efuse_dna@c {
+			reg = <0xc 0xc>;
+		};
+
+		efuse_usr0@20 {
+			reg = <0x20 0x4>;
+		};
+
+		efuse_usr1@24 {
+			reg = <0x24 0x4>;
+		};
+
+		efuse_usr2@28 {
+			reg = <0x28 0x4>;
+		};
+
+		efuse_usr3@2c {
+			reg = <0x2c 0x4>;
+		};
+
+		efuse_usr4@30 {
+			reg = <0x30 0x4>;
+		};
+
+		efuse_usr5@34 {
+			reg = <0x34 0x4>;
+		};
+
+		efuse_usr6@38 {
+			reg = <0x38 0x4>;
+		};
+
+		efuse_usr7@3c {
+			reg = <0x3c 0x4>;
+		};
+
+		efuse_miscusr@40 {
+			reg = <0x40 0x4>;
+		};
+
+		efuse_chash@50 {
+			reg = <0x50 0x4>;
+		};
+
+		efuse_pufmisc@54 {
+			reg = <0x54 0x4>;
+		};
+
+		efuse_sec@58 {
+			reg = <0x58 0x4>;
+		};
+
+		efuse_spkid@5c {
+			reg = <0x5c 0x4>;
+		};
+
+		efuse_ppk0hash@a0 {
+			reg = <0xa0 0x30>;
+		};
+
+		efuse_ppk1hash@d0 {
+			reg = <0xd0 0x30>;
+		};
+	};
+
+	zynqmp_rsa {
+		compatible = "xlnx,zynqmp-rsa";
+	};
+
+	sha384 {
+		compatible = "xlnx,zynqmp-keccak-384";
+	};
+
+	zynqmp_aes {
+		compatible = "xlnx,zynqmp-aes";
+	};
+
+	amba-apu@0 {
+		compatible = "simple-bus";
+		#address-cells = <0x2>;
+		#size-cells = <0x1>;
+		ranges = <0x0 0x0 0x0 0x0 0xffffffff>;
+
+		interrupt-controller@f9010000 {
+			compatible = "arm,gic-400";
+			#interrupt-cells = <0x3>;
+			reg = <0x0 0xf9010000 0x10000 0x0 0xf9020000 0x20000 0x0 0xf9040000 0x20000 0x0 0xf9060000 0x20000>;
+			interrupt-controller;
+			interrupt-parent = <0x4>;
+			interrupts = <0x1 0x9 0xf04>;
+			num_cpus = <0x2>;
+			num_interrupts = <0x60>;
+			phandle = <0x4>;
+		};
+	};
+
+	smmu@fd800000 {
+		compatible = "arm,mmu-500";
+		reg = <0x0 0xfd800000 0x0 0x20000>;
+		#iommu-cells = <0x1>;
+		status = "disabled";
+		#global-interrupts = <0x1>;
+		interrupt-parent = <0x4>;
+		interrupts = <0x0 0x9b 0x4 0x0 0x9b 0x4 0x0 0x9b 0x4 0x0 0x9b 0x4 0x0 0x9b 0x4 0x0 0x9b 0x4 0x0 0x9b 0x4 0x0 0x9b 0x4 0x0 0x9b 0x4 0x0 0x9b 0x4 0x0 0x9b 0x4 0x0 0x9b 0x4 0x0 0x9b 0x4 0x0 0x9b 0x4 0x0 0x9b 0x4 0x0 0x9b 0x4 0x0 0x9b 0x4>;
+		phandle = <0xe>;
+	};
+	amba_rpu: indirect-bus@0 {
+		compatible = "indirect-bus";
+		#address-cells = <0x2>;
+		#size-cells = <0x2>;
+
+		gic_r5: interrupt-controller@f9000000 {
+			compatible = "arm,pl390";
+			#interrupt-cells = <3>;
+			interrupt-controller;
+			reg = <0x0 0xf9000000 0x0 0x1000 0x0 0xf9000000 0x0 0x100>;
+		};
+	};
+
+	amba {
+		compatible = "simple-bus";
+		u-boot,dm-pre-reloc;
+		#address-cells = <0x2>;
+		#size-cells = <0x2>;
+		ranges;
+
+		can@ff060000 {
+			compatible = "xlnx,zynq-can-1.0";
+			status = "disabled";
+			clock-names = "can_clk", "pclk";
+			reg = <0x0 0xff060000 0x0 0x1000>;
+			interrupts = <0x0 0x17 0x4>;
+			interrupt-parent = <0x4>;
+			tx-fifo-depth = <0x40>;
+			rx-fifo-depth = <0x40>;
+			power-domains = <0xc 0x2f>;
+			clocks = <0x3 0x3f 0x3 0x1f>;
+		};
+
+		can@ff070000 {
+			compatible = "xlnx,zynq-can-1.0";
+			status = "okay";
+			clock-names = "can_clk", "pclk";
+			reg = <0x0 0xff070000 0x0 0x1000>;
+			interrupts = <0x0 0x18 0x4>;
+			interrupt-parent = <0x4>;
+			tx-fifo-depth = <0x40>;
+			rx-fifo-depth = <0x40>;
+			power-domains = <0xc 0x30>;
+			clocks = <0x3 0x40 0x3 0x1f>;
+			pinctrl-names = "default";
+			pinctrl-0 = <0xd>;
+		};
+
+		cci@fd6e0000 {
+			compatible = "arm,cci-400";
+			status = "okay";
+			reg = <0x0 0xfd6e0000 0x0 0x9000>;
+			ranges = <0x0 0x0 0xfd6e0000 0x10000>;
+			#address-cells = <0x1>;
+			#size-cells = <0x1>;
+
+			pmu@9000 {
+				compatible = "arm,cci-400-pmu,r1";
+				reg = <0x9000 0x5000>;
+				interrupt-parent = <0x4>;
+				interrupts = <0x0 0x7b 0x4 0x0 0x7b 0x4 0x0 0x7b 0x4 0x0 0x7b 0x4 0x0 0x7b 0x4>;
+			};
+		};
+
+		dma@fd500000 {
+			status = "okay";
+			compatible = "xlnx,zynqmp-dma-1.0";
+			reg = <0x0 0xfd500000 0x0 0x1000>;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x7c 0x4>;
+			clock-names = "clk_main", "clk_apb";
+			xlnx,bus-width = <0x80>;
+			#stream-id-cells = <0x1>;
+			iommus = <0xe 0x14e8>;
+			power-domains = <0xc 0x2a>;
+			clocks = <0x3 0x13 0x3 0x1f>;
+		};
+
+		dma@fd510000 {
+			status = "okay";
+			compatible = "xlnx,zynqmp-dma-1.0";
+			reg = <0x0 0xfd510000 0x0 0x1000>;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x7d 0x4>;
+			clock-names = "clk_main", "clk_apb";
+			xlnx,bus-width = <0x80>;
+			#stream-id-cells = <0x1>;
+			iommus = <0xe 0x14e9>;
+			power-domains = <0xc 0x2a>;
+			clocks = <0x3 0x13 0x3 0x1f>;
+		};
+
+		dma@fd520000 {
+			status = "okay";
+			compatible = "xlnx,zynqmp-dma-1.0";
+			reg = <0x0 0xfd520000 0x0 0x1000>;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x7e 0x4>;
+			clock-names = "clk_main", "clk_apb";
+			xlnx,bus-width = <0x80>;
+			#stream-id-cells = <0x1>;
+			iommus = <0xe 0x14ea>;
+			power-domains = <0xc 0x2a>;
+			clocks = <0x3 0x13 0x3 0x1f>;
+		};
+
+		dma@fd530000 {
+			status = "okay";
+			compatible = "xlnx,zynqmp-dma-1.0";
+			reg = <0x0 0xfd530000 0x0 0x1000>;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x7f 0x4>;
+			clock-names = "clk_main", "clk_apb";
+			xlnx,bus-width = <0x80>;
+			#stream-id-cells = <0x1>;
+			iommus = <0xe 0x14eb>;
+			power-domains = <0xc 0x2a>;
+			clocks = <0x3 0x13 0x3 0x1f>;
+		};
+
+		dma@fd540000 {
+			status = "okay";
+			compatible = "xlnx,zynqmp-dma-1.0";
+			reg = <0x0 0xfd540000 0x0 0x1000>;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x80 0x4>;
+			clock-names = "clk_main", "clk_apb";
+			xlnx,bus-width = <0x80>;
+			#stream-id-cells = <0x1>;
+			iommus = <0xe 0x14ec>;
+			power-domains = <0xc 0x2a>;
+			clocks = <0x3 0x13 0x3 0x1f>;
+		};
+
+		dma@fd550000 {
+			status = "okay";
+			compatible = "xlnx,zynqmp-dma-1.0";
+			reg = <0x0 0xfd550000 0x0 0x1000>;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x81 0x4>;
+			clock-names = "clk_main", "clk_apb";
+			xlnx,bus-width = <0x80>;
+			#stream-id-cells = <0x1>;
+			iommus = <0xe 0x14ed>;
+			power-domains = <0xc 0x2a>;
+			clocks = <0x3 0x13 0x3 0x1f>;
+		};
+
+		dma@fd560000 {
+			status = "okay";
+			compatible = "xlnx,zynqmp-dma-1.0";
+			reg = <0x0 0xfd560000 0x0 0x1000>;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x82 0x4>;
+			clock-names = "clk_main", "clk_apb";
+			xlnx,bus-width = <0x80>;
+			#stream-id-cells = <0x1>;
+			iommus = <0xe 0x14ee>;
+			power-domains = <0xc 0x2a>;
+			clocks = <0x3 0x13 0x3 0x1f>;
+		};
+
+		dma@fd570000 {
+			status = "okay";
+			compatible = "xlnx,zynqmp-dma-1.0";
+			reg = <0x0 0xfd570000 0x0 0x1000>;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x83 0x4>;
+			clock-names = "clk_main", "clk_apb";
+			xlnx,bus-width = <0x80>;
+			#stream-id-cells = <0x1>;
+			iommus = <0xe 0x14ef>;
+			power-domains = <0xc 0x2a>;
+			clocks = <0x3 0x13 0x3 0x1f>;
+		};
+
+		gpu@fd4b0000 {
+			status = "okay";
+			compatible = "arm,mali-400", "arm,mali-utgard";
+			reg = <0x0 0xfd4b0000 0x0 0x10000>;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x84 0x4 0x0 0x84 0x4 0x0 0x84 0x4 0x0 0x84 0x4 0x0 0x84 0x4 0x0 0x84 0x4>;
+			interrupt-names = "IRQGP", "IRQGPMMU", "IRQPP0", "IRQPPMMU0", "IRQPP1", "IRQPPMMU1";
+			clock-names = "gpu", "gpu_pp0", "gpu_pp1";
+			power-domains = <0xc 0x3a>;
+			clocks = <0x3 0x18 0x3 0x19 0x3 0x1a>;
+			xlnx,tz-nonsecure = <0x1>;
+		};
+
+		dma@ffa80000 {
+			status = "okay";
+			compatible = "xlnx,zynqmp-dma-1.0";
+			reg = <0x0 0xffa80000 0x0 0x1000>;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x4d 0x4>;
+			clock-names = "clk_main", "clk_apb";
+			xlnx,bus-width = <0x40>;
+			#stream-id-cells = <0x1>;
+			power-domains = <0xc 0x2b>;
+			clocks = <0x3 0x44 0x3 0x1f>;
+		};
+
+		dma@ffa90000 {
+			status = "okay";
+			compatible = "xlnx,zynqmp-dma-1.0";
+			reg = <0x0 0xffa90000 0x0 0x1000>;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x4e 0x4>;
+			clock-names = "clk_main", "clk_apb";
+			xlnx,bus-width = <0x40>;
+			#stream-id-cells = <0x1>;
+			power-domains = <0xc 0x2b>;
+			clocks = <0x3 0x44 0x3 0x1f>;
+		};
+
+		dma@ffaa0000 {
+			status = "okay";
+			compatible = "xlnx,zynqmp-dma-1.0";
+			reg = <0x0 0xffaa0000 0x0 0x1000>;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x4f 0x4>;
+			clock-names = "clk_main", "clk_apb";
+			xlnx,bus-width = <0x40>;
+			#stream-id-cells = <0x1>;
+			power-domains = <0xc 0x2b>;
+			clocks = <0x3 0x44 0x3 0x1f>;
+		};
+
+		dma@ffab0000 {
+			status = "okay";
+			compatible = "xlnx,zynqmp-dma-1.0";
+			reg = <0x0 0xffab0000 0x0 0x1000>;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x50 0x4>;
+			clock-names = "clk_main", "clk_apb";
+			xlnx,bus-width = <0x40>;
+			#stream-id-cells = <0x1>;
+			power-domains = <0xc 0x2b>;
+			clocks = <0x3 0x44 0x3 0x1f>;
+		};
+
+		dma@ffac0000 {
+			status = "okay";
+			compatible = "xlnx,zynqmp-dma-1.0";
+			reg = <0x0 0xffac0000 0x0 0x1000>;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x51 0x4>;
+			clock-names = "clk_main", "clk_apb";
+			xlnx,bus-width = <0x40>;
+			#stream-id-cells = <0x1>;
+			power-domains = <0xc 0x2b>;
+			clocks = <0x3 0x44 0x3 0x1f>;
+		};
+
+		dma@ffad0000 {
+			status = "okay";
+			compatible = "xlnx,zynqmp-dma-1.0";
+			reg = <0x0 0xffad0000 0x0 0x1000>;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x52 0x4>;
+			clock-names = "clk_main", "clk_apb";
+			xlnx,bus-width = <0x40>;
+			#stream-id-cells = <0x1>;
+			power-domains = <0xc 0x2b>;
+			clocks = <0x3 0x44 0x3 0x1f>;
+		};
+
+		dma@ffae0000 {
+			status = "okay";
+			compatible = "xlnx,zynqmp-dma-1.0";
+			reg = <0x0 0xffae0000 0x0 0x1000>;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x53 0x4>;
+			clock-names = "clk_main", "clk_apb";
+			xlnx,bus-width = <0x40>;
+			#stream-id-cells = <0x1>;
+			power-domains = <0xc 0x2b>;
+			clocks = <0x3 0x44 0x3 0x1f>;
+		};
+
+		dma@ffaf0000 {
+			status = "okay";
+			compatible = "xlnx,zynqmp-dma-1.0";
+			reg = <0x0 0xffaf0000 0x0 0x1000>;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x54 0x4>;
+			clock-names = "clk_main", "clk_apb";
+			xlnx,bus-width = <0x40>;
+			#stream-id-cells = <0x1>;
+			power-domains = <0xc 0x2b>;
+			clocks = <0x3 0x44 0x3 0x1f>;
+		};
+
+		memory-controller@fd070000 {
+			compatible = "xlnx,zynqmp-ddrc-2.40a";
+			reg = <0x0 0xfd070000 0x0 0x30000>;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x70 0x4>;
+		};
+
+		nand@ff100000 {
+			compatible = "arasan,nfc-v3p10";
+			status = "disabled";
+			reg = <0x0 0xff100000 0x0 0x1000>;
+			clock-names = "clk_sys", "clk_flash";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0xe 0x4>;
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			#stream-id-cells = <0x1>;
+			iommus = <0xe 0x872>;
+			power-domains = <0xc 0x2c>;
+			clocks = <0x3 0x3c 0x3 0x1f>;
+		};
+
+		ethernet@ff0b0000 {
+			compatible = "cdns,zynqmp-gem", "cdns,gem";
+			status = "disabled";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x39 0x4 0x0 0x39 0x4>;
+			reg = <0x0 0xff0b0000 0x0 0x1000>;
+			clock-names = "pclk", "hclk", "tx_clk", "rx_clk", "tsu_clk";
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			#stream-id-cells = <0x1>;
+			iommus = <0xe 0x874>;
+			power-domains = <0xc 0x1d>;
+			clocks = <0x3 0x1f 0x3 0x68 0x3 0x2d 0x3 0x31 0x3 0x2c>;
+		};
+
+		ethernet@ff0c0000 {
+			compatible = "cdns,zynqmp-gem", "cdns,gem";
+			status = "disabled";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x3b 0x4 0x0 0x3b 0x4>;
+			reg = <0x0 0xff0c0000 0x0 0x1000>;
+			clock-names = "pclk", "hclk", "tx_clk", "rx_clk", "tsu_clk";
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			#stream-id-cells = <0x1>;
+			iommus = <0xe 0x875>;
+			power-domains = <0xc 0x1e>;
+			clocks = <0x3 0x1f 0x3 0x69 0x3 0x2e 0x3 0x32 0x3 0x2c>;
+		};
+
+		ethernet@ff0d0000 {
+			compatible = "cdns,zynqmp-gem", "cdns,gem";
+			status = "disabled";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x3d 0x4 0x0 0x3d 0x4>;
+			reg = <0x0 0xff0d0000 0x0 0x1000>;
+			clock-names = "pclk", "hclk", "tx_clk", "rx_clk", "tsu_clk";
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			#stream-id-cells = <0x1>;
+			iommus = <0xe 0x876>;
+			power-domains = <0xc 0x1f>;
+			clocks = <0x3 0x1f 0x3 0x6a 0x3 0x2f 0x3 0x33 0x3 0x2c>;
+		};
+
+		ethernet@ff0e0000 {
+			compatible = "cdns,zynqmp-gem", "cdns,gem";
+			status = "okay";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x3f 0x4 0x0 0x3f 0x4>;
+			reg = <0x0 0xff0e0000 0x0 0x1000>;
+			clock-names = "pclk", "hclk", "tx_clk", "rx_clk", "tsu_clk";
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			#stream-id-cells = <0x1>;
+			iommus = <0xe 0x877>;
+			power-domains = <0xc 0x20>;
+			clocks = <0x3 0x1f 0x3 0x6b 0x3 0x30 0x3 0x34 0x3 0x2c>;
+			phy-handle = <0xf>;
+			pinctrl-names = "default";
+			pinctrl-0 = <0x10>;
+			phy-mode = "rgmii-id";
+			xlnx,ptp-enet-clock = <0x0>;
+			local-mac-address = [00 0a 35 00 22 01];
+
+			ethernet-phy@c {
+				reg = <0xc>;
+				ti,rx-internal-delay = <0x8>;
+				ti,tx-internal-delay = <0xa>;
+				ti,fifo-depth = <0x1>;
+				ti,dp83867-rxctrl-strap-quirk;
+				phandle = <0xf>;
+			};
+		};
+
+		gpio@ff0a0000 {
+			compatible = "xlnx,zynqmp-gpio-1.0";
+			status = "okay";
+			#gpio-cells = <0x2>;
+			gpio-controller;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x10 0x4>;
+			interrupt-controller;
+			#interrupt-cells = <0x2>;
+			reg = <0x0 0xff0a0000 0x0 0x1000>;
+			power-domains = <0xc 0x2e>;
+			clocks = <0x3 0x1f>;
+			pinctrl-names = "default";
+			pinctrl-0 = <0x11>;
+			emio-gpio-width = <0x20>;
+			gpio-mask-high = <0x0>;
+			gpio-mask-low = <0x5600>;
+			phandle = <0x14>;
+		};
+
+		i2c@ff020000 {
+			compatible = "cdns,i2c-r1p14", "cdns,i2c-r1p10";
+			status = "okay";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x11 0x4>;
+			reg = <0x0 0xff020000 0x0 0x1000>;
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			power-domains = <0xc 0x25>;
+			clocks = <0x3 0x3d>;
+			pinctrl-names = "default", "gpio";
+			pinctrl-0 = <0x12>;
+			pinctrl-1 = <0x13>;
+			scl-gpios = <0x14 0xe 0x0>;
+			sda-gpios = <0x14 0xf 0x0>;
+			clock-frequency = <0x61a80>;
+
+			gpio@20 {
+				compatible = "ti,tca6416";
+				reg = <0x20>;
+				gpio-controller;
+				#gpio-cells = <0x2>;
+				gpio-line-names = "PS_GTR_LAN_SEL0", "PS_GTR_LAN_SEL1", "PS_GTR_LAN_SEL2", "PS_GTR_LAN_SEL3", "PCI_CLK_DIR_SEL", "IIC_MUX_RESET_B", "GEM3_EXP_RESET_B", "", "", "", "", "", "", "", "", "";
+			};
+
+			gpio@21 {
+				compatible = "ti,tca6416";
+				reg = <0x21>;
+				gpio-controller;
+				#gpio-cells = <0x2>;
+				gpio-line-names = "VCCPSPLL_EN", "MGTRAVCC_EN", "MGTRAVTT_EN", "VCCPSDDRPLL_EN", "MIO26_PMU_INPUT_LS", "PL_PMBUS_ALERT", "PS_PMBUS_ALERT", "MAXIM_PMBUS_ALERT", "PL_DDR4_VTERM_EN", "PL_DDR4_VPP_2V5_EN", "PS_DIMM_VDDQ_TO_PSVCCO_ON", "PS_DIMM_SUSPEND_EN", "PS_DDR4_VTERM_EN", "PS_DDR4_VPP_2V5_EN", "", "";
+			};
+
+			i2c-mux@75 {
+				compatible = "nxp,pca9544";
+				#address-cells = <0x1>;
+				#size-cells = <0x0>;
+				reg = <0x75>;
+
+				i2c@0 {
+					#address-cells = <0x1>;
+					#size-cells = <0x0>;
+					reg = <0x0>;
+
+					ina226@40 {
+						compatible = "ti,ina226";
+						#io-channel-cells = <0x1>;
+						label = "ina226-u76";
+						reg = <0x40>;
+						shunt-resistor = <0x1388>;
+						phandle = <0x27>;
+					};
+
+					ina226@41 {
+						compatible = "ti,ina226";
+						#io-channel-cells = <0x1>;
+						label = "ina226-u77";
+						reg = <0x41>;
+						shunt-resistor = <0x1388>;
+						phandle = <0x28>;
+					};
+
+					ina226@42 {
+						compatible = "ti,ina226";
+						#io-channel-cells = <0x1>;
+						label = "ina226-u78";
+						reg = <0x42>;
+						shunt-resistor = <0x1388>;
+						phandle = <0x29>;
+					};
+
+					ina226@43 {
+						compatible = "ti,ina226";
+						#io-channel-cells = <0x1>;
+						label = "ina226-u87";
+						reg = <0x43>;
+						shunt-resistor = <0x1388>;
+						phandle = <0x2a>;
+					};
+
+					ina226@44 {
+						compatible = "ti,ina226";
+						#io-channel-cells = <0x1>;
+						label = "ina226-u85";
+						reg = <0x44>;
+						shunt-resistor = <0x1388>;
+						phandle = <0x2b>;
+					};
+
+					ina226@45 {
+						compatible = "ti,ina226";
+						#io-channel-cells = <0x1>;
+						label = "ina226-u86";
+						reg = <0x45>;
+						shunt-resistor = <0x1388>;
+						phandle = <0x2c>;
+					};
+
+					ina226@46 {
+						compatible = "ti,ina226";
+						#io-channel-cells = <0x1>;
+						label = "ina226-u93";
+						reg = <0x46>;
+						shunt-resistor = <0x1388>;
+						phandle = <0x2d>;
+					};
+
+					ina226@47 {
+						compatible = "ti,ina226";
+						#io-channel-cells = <0x1>;
+						label = "ina226-u88";
+						reg = <0x47>;
+						shunt-resistor = <0x1388>;
+						phandle = <0x2e>;
+					};
+
+					ina226@4a {
+						compatible = "ti,ina226";
+						#io-channel-cells = <0x1>;
+						label = "ina226-u15";
+						reg = <0x4a>;
+						shunt-resistor = <0x1388>;
+						phandle = <0x2f>;
+					};
+
+					ina226@4b {
+						compatible = "ti,ina226";
+						#io-channel-cells = <0x1>;
+						label = "ina226-u92";
+						reg = <0x4b>;
+						shunt-resistor = <0x1388>;
+						phandle = <0x30>;
+					};
+				};
+
+				i2c@1 {
+					#address-cells = <0x1>;
+					#size-cells = <0x0>;
+					reg = <0x1>;
+
+					ina226@40 {
+						compatible = "ti,ina226";
+						#io-channel-cells = <0x1>;
+						label = "ina226-u79";
+						reg = <0x40>;
+						shunt-resistor = <0x7d0>;
+						phandle = <0x31>;
+					};
+
+					ina226@41 {
+						compatible = "ti,ina226";
+						#io-channel-cells = <0x1>;
+						label = "ina226-u81";
+						reg = <0x41>;
+						shunt-resistor = <0x1388>;
+						phandle = <0x32>;
+					};
+
+					ina226@42 {
+						compatible = "ti,ina226";
+						#io-channel-cells = <0x1>;
+						label = "ina226-u80";
+						reg = <0x42>;
+						shunt-resistor = <0x1388>;
+						phandle = <0x33>;
+					};
+
+					ina226@43 {
+						compatible = "ti,ina226";
+						#io-channel-cells = <0x1>;
+						label = "ina226-u84";
+						reg = <0x43>;
+						shunt-resistor = <0x1388>;
+						phandle = <0x34>;
+					};
+
+					ina226@44 {
+						compatible = "ti,ina226";
+						#io-channel-cells = <0x1>;
+						label = "ina226-u16";
+						reg = <0x44>;
+						shunt-resistor = <0x1388>;
+						phandle = <0x35>;
+					};
+
+					ina226@45 {
+						compatible = "ti,ina226";
+						#io-channel-cells = <0x1>;
+						label = "ina226-u65";
+						reg = <0x45>;
+						shunt-resistor = <0x1388>;
+						phandle = <0x36>;
+					};
+
+					ina226@46 {
+						compatible = "ti,ina226";
+						#io-channel-cells = <0x1>;
+						label = "ina226-u74";
+						reg = <0x46>;
+						shunt-resistor = <0x1388>;
+						phandle = <0x37>;
+					};
+
+					ina226@47 {
+						compatible = "ti,ina226";
+						#io-channel-cells = <0x1>;
+						label = "ina226-u75";
+						reg = <0x47>;
+						shunt-resistor = <0x1388>;
+						phandle = <0x38>;
+					};
+				};
+
+				i2c@2 {
+					#address-cells = <0x1>;
+					#size-cells = <0x0>;
+					reg = <0x2>;
+
+					max15301@a {
+						compatible = "maxim,max15301";
+						reg = <0xa>;
+					};
+
+					max15303@b {
+						compatible = "maxim,max15303";
+						reg = <0xb>;
+					};
+
+					max15303@10 {
+						compatible = "maxim,max15303";
+						reg = <0x10>;
+					};
+
+					max15301@13 {
+						compatible = "maxim,max15301";
+						reg = <0x13>;
+					};
+
+					max15303@14 {
+						compatible = "maxim,max15303";
+						reg = <0x14>;
+					};
+
+					max15303@15 {
+						compatible = "maxim,max15303";
+						reg = <0x15>;
+					};
+
+					max15303@16 {
+						compatible = "maxim,max15303";
+						reg = <0x16>;
+					};
+
+					max15303@17 {
+						compatible = "maxim,max15303";
+						reg = <0x17>;
+					};
+
+					max15301@18 {
+						compatible = "maxim,max15301";
+						reg = <0x18>;
+					};
+
+					max15303@1a {
+						compatible = "maxim,max15303";
+						reg = <0x1a>;
+					};
+
+					max15303@1b {
+						compatible = "maxim,max15303";
+						reg = <0x1b>;
+					};
+
+					max15303@1d {
+						compatible = "maxim,max15303";
+						reg = <0x1d>;
+					};
+
+					max20751@72 {
+						compatible = "maxim,max20751";
+						reg = <0x72>;
+					};
+
+					max20751@73 {
+						compatible = "maxim,max20751";
+						reg = <0x73>;
+					};
+				};
+			};
+		};
+
+		i2c@ff030000 {
+			compatible = "cdns,i2c-r1p14", "cdns,i2c-r1p10";
+			status = "okay";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x12 0x4>;
+			reg = <0x0 0xff030000 0x0 0x1000>;
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			power-domains = <0xc 0x26>;
+			clocks = <0x3 0x3e>;
+			pinctrl-names = "default", "gpio";
+			pinctrl-0 = <0x15>;
+			pinctrl-1 = <0x16>;
+			scl-gpios = <0x14 0x10 0x0>;
+			sda-gpios = <0x14 0x11 0x0>;
+			clock-frequency = <0x61a80>;
+
+			i2c-mux@74 {
+				compatible = "nxp,pca9548";
+				#address-cells = <0x1>;
+				#size-cells = <0x0>;
+				reg = <0x74>;
+
+				i2c@0 {
+					#address-cells = <0x1>;
+					#size-cells = <0x0>;
+					reg = <0x0>;
+
+					eeprom@54 {
+						compatible = "atmel,24c08";
+						reg = <0x54>;
+						#address-cells = <0x1>;
+						#size-cells = <0x1>;
+
+						board-sn@0 {
+							reg = <0x0 0x14>;
+						};
+
+						eth-mac@20 {
+							reg = <0x20 0x6>;
+						};
+
+						board-name@d0 {
+							reg = <0xd0 0x6>;
+						};
+
+						board-revision@e0 {
+							reg = <0xe0 0x3>;
+						};
+					};
+				};
+
+				i2c@1 {
+					#address-cells = <0x1>;
+					#size-cells = <0x0>;
+					reg = <0x1>;
+
+					clock-generator@36 {
+						compatible = "silabs,si5341";
+						reg = <0x36>;
+					};
+				};
+
+				i2c@2 {
+					#address-cells = <0x1>;
+					#size-cells = <0x0>;
+					reg = <0x2>;
+
+					clock-generator@5d {
+						#clock-cells = <0x0>;
+						compatible = "silabs,si570";
+						reg = <0x5d>;
+						temperature-stability = <0x32>;
+						factory-fout = <0x11e1a300>;
+						clock-frequency = <0x11e1a300>;
+						clock-output-names = "si570_user";
+					};
+				};
+
+				i2c@3 {
+					#address-cells = <0x1>;
+					#size-cells = <0x0>;
+					reg = <0x3>;
+
+					clock-generator@5d {
+						#clock-cells = <0x0>;
+						compatible = "silabs,si570";
+						reg = <0x5d>;
+						temperature-stability = <0x32>;
+						factory-fout = <0x9502f90>;
+						clock-frequency = <0x8d9ee20>;
+						clock-output-names = "si570_mgt";
+					};
+				};
+
+				i2c@4 {
+					#address-cells = <0x1>;
+					#size-cells = <0x0>;
+					reg = <0x4>;
+
+					clock-generator@69 {
+						compatible = "silabs,si5328";
+						reg = <0x69>;
+					};
+				};
+			};
+
+			i2c-mux@75 {
+				compatible = "nxp,pca9548";
+				#address-cells = <0x1>;
+				#size-cells = <0x0>;
+				reg = <0x75>;
+
+				i2c@0 {
+					#address-cells = <0x1>;
+					#size-cells = <0x0>;
+					reg = <0x0>;
+				};
+
+				i2c@1 {
+					#address-cells = <0x1>;
+					#size-cells = <0x0>;
+					reg = <0x1>;
+				};
+
+				i2c@2 {
+					#address-cells = <0x1>;
+					#size-cells = <0x0>;
+					reg = <0x2>;
+				};
+
+				i2c@3 {
+					#address-cells = <0x1>;
+					#size-cells = <0x0>;
+					reg = <0x3>;
+				};
+
+				i2c@4 {
+					#address-cells = <0x1>;
+					#size-cells = <0x0>;
+					reg = <0x4>;
+				};
+
+				i2c@5 {
+					#address-cells = <0x1>;
+					#size-cells = <0x0>;
+					reg = <0x5>;
+				};
+
+				i2c@6 {
+					#address-cells = <0x1>;
+					#size-cells = <0x0>;
+					reg = <0x6>;
+				};
+
+				i2c@7 {
+					#address-cells = <0x1>;
+					#size-cells = <0x0>;
+					reg = <0x7>;
+				};
+			};
+		};
+
+		memory-controller@ff960000 {
+			compatible = "xlnx,zynqmp-ocmc-1.0";
+			reg = <0x0 0xff960000 0x0 0x1000>;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0xa 0x4>;
+		};
+
+		perf-monitor@ffa00000 {
+			compatible = "xlnx,axi-perf-monitor";
+			reg = <0x0 0xffa00000 0x0 0x10000>;
+			interrupts = <0x0 0x19 0x4>;
+			interrupt-parent = <0x4>;
+			xlnx,enable-profile = <0x0>;
+			xlnx,enable-trace = <0x0>;
+			xlnx,num-monitor-slots = <0x1>;
+			xlnx,enable-event-count = <0x1>;
+			xlnx,enable-event-log = <0x1>;
+			xlnx,have-sampled-metric-cnt = <0x1>;
+			xlnx,num-of-counters = <0x8>;
+			xlnx,metric-count-width = <0x20>;
+			xlnx,metrics-sample-count-width = <0x20>;
+			xlnx,global-count-width = <0x20>;
+			xlnx,metric-count-scale = <0x1>;
+			clocks = <0x3 0x1f>;
+		};
+
+		perf-monitor@fd0b0000 {
+			compatible = "xlnx,axi-perf-monitor";
+			reg = <0x0 0xfd0b0000 0x0 0x10000>;
+			interrupts = <0x0 0x7b 0x4>;
+			interrupt-parent = <0x4>;
+			xlnx,enable-profile = <0x0>;
+			xlnx,enable-trace = <0x0>;
+			xlnx,num-monitor-slots = <0x6>;
+			xlnx,enable-event-count = <0x1>;
+			xlnx,enable-event-log = <0x0>;
+			xlnx,have-sampled-metric-cnt = <0x1>;
+			xlnx,num-of-counters = <0xa>;
+			xlnx,metric-count-width = <0x20>;
+			xlnx,metrics-sample-count-width = <0x20>;
+			xlnx,global-count-width = <0x20>;
+			xlnx,metric-count-scale = <0x1>;
+			clocks = <0x3 0x1c>;
+		};
+
+		perf-monitor@fd490000 {
+			compatible = "xlnx,axi-perf-monitor";
+			reg = <0x0 0xfd490000 0x0 0x10000>;
+			interrupts = <0x0 0x7b 0x4>;
+			interrupt-parent = <0x4>;
+			xlnx,enable-profile = <0x0>;
+			xlnx,enable-trace = <0x0>;
+			xlnx,num-monitor-slots = <0x1>;
+			xlnx,enable-event-count = <0x1>;
+			xlnx,enable-event-log = <0x0>;
+			xlnx,have-sampled-metric-cnt = <0x1>;
+			xlnx,num-of-counters = <0x8>;
+			xlnx,metric-count-width = <0x20>;
+			xlnx,metrics-sample-count-width = <0x20>;
+			xlnx,global-count-width = <0x20>;
+			xlnx,metric-count-scale = <0x1>;
+			clocks = <0x3 0x1c>;
+		};
+
+		perf-monitor@ffa10000 {
+			compatible = "xlnx,axi-perf-monitor";
+			reg = <0x0 0xffa10000 0x0 0x10000>;
+			interrupts = <0x0 0x19 0x4>;
+			interrupt-parent = <0x4>;
+			xlnx,enable-profile = <0x0>;
+			xlnx,enable-trace = <0x0>;
+			xlnx,num-monitor-slots = <0x1>;
+			xlnx,enable-event-count = <0x1>;
+			xlnx,enable-event-log = <0x1>;
+			xlnx,have-sampled-metric-cnt = <0x1>;
+			xlnx,num-of-counters = <0x8>;
+			xlnx,metric-count-width = <0x20>;
+			xlnx,metrics-sample-count-width = <0x20>;
+			xlnx,global-count-width = <0x20>;
+			xlnx,metric-count-scale = <0x1>;
+			clocks = <0x3 0x1f>;
+		};
+
+		pcie@fd0e0000 {
+			compatible = "xlnx,nwl-pcie-2.11";
+			status = "okay";
+			#address-cells = <0x3>;
+			#size-cells = <0x2>;
+			#interrupt-cells = <0x1>;
+			msi-controller;
+			device_type = "pci";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x76 0x4 0x0 0x75 0x4 0x0 0x74 0x4 0x0 0x73 0x4 0x0 0x72 0x4>;
+			interrupt-names = "misc", "dummy", "intx", "msi1", "msi0";
+			msi-parent = <0x17>;
+			reg = <0x0 0xfd0e0000 0x0 0x1000 0x0 0xfd480000 0x0 0x1000 0x80 0x0 0x0 0x1000000>;
+			reg-names = "breg", "pcireg", "cfg";
+			ranges = <0x2000000 0x0 0xe0000000 0x0 0xe0000000 0x0 0x10000000 0x43000000 0x6 0x0 0x6 0x0 0x2 0x0>;
+			interrupt-map-mask = <0x0 0x0 0x0 0x7>;
+			bus-range = <0x0 0xff>;
+			interrupt-map = <0x0 0x0 0x0 0x1 0x18 0x1 0x0 0x0 0x0 0x2 0x18 0x2 0x0 0x0 0x0 0x3 0x18 0x3 0x0 0x0 0x0 0x4 0x18 0x4>;
+			power-domains = <0xc 0x3b>;
+			clocks = <0x3 0x17>;
+			xlnx,bar0-enable = <0x0>;
+			xlnx,bar1-enable = <0x0>;
+			xlnx,bar2-enable = <0x0>;
+			xlnx,bar3-enable = <0x0>;
+			xlnx,bar4-enable = <0x0>;
+			xlnx,bar5-enable = <0x0>;
+			xlnx,pcie-mode = "Root Port";
+			xlnx,tz-nonsecure = <0x0>;
+			phandle = <0x17>;
+
+			legacy-interrupt-controller {
+				interrupt-controller;
+				#address-cells = <0x0>;
+				#interrupt-cells = <0x1>;
+				phandle = <0x18>;
+			};
+		};
+
+		spi@ff0f0000 {
+			u-boot,dm-pre-reloc;
+			compatible = "xlnx,zynqmp-qspi-1.0";
+			status = "okay";
+			clock-names = "ref_clk", "pclk";
+			interrupts = <0x0 0xf 0x4>;
+			interrupt-parent = <0x4>;
+			num-cs = <0x1>;
+			reg = <0x0 0xff0f0000 0x0 0x1000 0x0 0xc0000000 0x0 0x8000000>;
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			#stream-id-cells = <0x1>;
+			iommus = <0xe 0x873>;
+			power-domains = <0xc 0x2d>;
+			clocks = <0x3 0x35 0x3 0x1f>;
+			is-dual = <0x1>;
+			spi-rx-bus-width = <0x4>;
+			spi-tx-bus-width = <0x4>;
+
+			flash@0 {
+				compatible = "m25p80", "jedec,spi-nor";
+				#address-cells = <0x1>;
+				#size-cells = <0x1>;
+				reg = <0x0>;
+				spi-tx-bus-width = <0x1>;
+				spi-rx-bus-width = <0x4>;
+				spi-max-frequency = <0x66ff300>;
+
+				partition@0 {
+					label = "boot";
+					reg = <0x0 0x1e00000>;
+				};
+
+				partition@1 {
+					label = "bootenv";
+					reg = <0x1e00000 0x40000>;
+				};
+
+				partition@2 {
+					label = "kernel";
+					reg = <0x1e40000 0x2400000>;
+				};
+			};
+		};
+
+		rtc@ffa60000 {
+			compatible = "xlnx,zynqmp-rtc";
+			status = "okay";
+			reg = <0x0 0xffa60000 0x0 0x100>;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x1a 0x4 0x0 0x1b 0x4>;
+			interrupt-names = "alarm", "sec";
+			calibration = <0x8000>;
+		};
+
+		zynqmp_phy@fd400000 {
+			compatible = "xlnx,zynqmp-psgtr-v1.1";
+			status = "okay";
+			reg = <0x0 0xfd400000 0x0 0x40000 0x0 0xfd3d0000 0x0 0x1000>;
+			reg-names = "serdes", "siou";
+			nvmem-cells = <0x19>;
+			nvmem-cell-names = "soc_revision";
+			resets = <0x1a 0x10 0x1a 0x3b 0x1a 0x3c 0x1a 0x3d 0x1a 0x3e 0x1a 0x3f 0x1a 0x40 0x1a 0x3 0x1a 0x1d 0x1a 0x1e 0x1a 0x1f 0x1a 0x20>;
+			reset-names = "sata_rst", "usb0_crst", "usb1_crst", "usb0_hibrst", "usb1_hibrst", "usb0_apbrst", "usb1_apbrst", "dp_rst", "gem0_rst", "gem1_rst", "gem2_rst", "gem3_rst";
+
+			lane0 {
+				#phy-cells = <0x4>;
+			};
+
+			lane1 {
+				#phy-cells = <0x4>;
+				phandle = <0x22>;
+			};
+
+			lane2 {
+				#phy-cells = <0x4>;
+				phandle = <0x20>;
+			};
+
+			lane3 {
+				#phy-cells = <0x4>;
+				phandle = <0x1b>;
+			};
+		};
+
+		ahci@fd0c0000 {
+			compatible = "ceva,ahci-1v84";
+			status = "okay";
+			reg = <0x0 0xfd0c0000 0x0 0x2000>;
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x85 0x4>;
+			power-domains = <0xc 0x1c>;
+			#stream-id-cells = <0x4>;
+			clocks = <0x3 0x16>;
+			ceva,p0-cominit-params = <0x18401828>;
+			ceva,p0-comwake-params = <0x614080e>;
+			ceva,p0-burst-params = <0x13084a06>;
+			ceva,p0-retry-params = <0x96a43ffc>;
+			ceva,p1-cominit-params = <0x18401828>;
+			ceva,p1-comwake-params = <0x614080e>;
+			ceva,p1-burst-params = <0x13084a06>;
+			ceva,p1-retry-params = <0x96a43ffc>;
+			phy-names = "sata-phy";
+			phys = <0x1b 0x1 0x1 0x1 0x7735940>;
+			xlnx,tz-nonsecure-sata0 = <0x0>;
+			xlnx,tz-nonsecure-sata1 = <0x0>;
+		};
+
+		mmc@ff160000 {
+			u-boot,dm-pre-reloc;
+			compatible = "xlnx,zynqmp-8.9a", "arasan,sdhci-8.9a";
+			status = "disabled";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x30 0x4>;
+			reg = <0x0 0xff160000 0x0 0x1000>;
+			clock-names = "clk_xin", "clk_ahb";
+			xlnx,device_id = <0x0>;
+			#stream-id-cells = <0x1>;
+			iommus = <0xe 0x870>;
+			power-domains = <0xc 0x27>;
+			nvmem-cells = <0x19>;
+			nvmem-cell-names = "soc_revision";
+			#clock-cells = <0x1>;
+			clock-output-names = "clk_out_sd0", "clk_in_sd0";
+			clocks = <0x3 0x36 0x3 0x1f>;
+		};
+
+		mmc@ff170000 {
+			u-boot,dm-pre-reloc;
+			compatible = "xlnx,zynqmp-8.9a", "arasan,sdhci-8.9a";
+			status = "okay";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x31 0x4>;
+			reg = <0x0 0xff170000 0x0 0x1000>;
+			clock-names = "clk_xin", "clk_ahb";
+			xlnx,device_id = <0x1>;
+			#stream-id-cells = <0x1>;
+			iommus = <0xe 0x871>;
+			power-domains = <0xc 0x28>;
+			nvmem-cells = <0x19>;
+			nvmem-cell-names = "soc_revision";
+			#clock-cells = <0x1>;
+			clock-output-names = "clk_out_sd1", "clk_in_sd1";
+			clocks = <0x3 0x37 0x3 0x1f>;
+			pinctrl-names = "default";
+			pinctrl-0 = <0x1c>;
+			no-1-8-v;
+			clock-frequency = <0xb2cbcae>;
+			xlnx,mio_bank = <0x1>;
+		};
+
+		spi@ff040000 {
+			compatible = "cdns,spi-r1p6";
+			status = "disabled";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x13 0x4>;
+			reg = <0x0 0xff040000 0x0 0x1000>;
+			clock-names = "ref_clk", "pclk";
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			power-domains = <0xc 0x23>;
+			clocks = <0x3 0x3a 0x3 0x1f>;
+		};
+
+		spi@ff050000 {
+			compatible = "cdns,spi-r1p6";
+			status = "disabled";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x14 0x4>;
+			reg = <0x0 0xff050000 0x0 0x1000>;
+			clock-names = "ref_clk", "pclk";
+			#address-cells = <0x1>;
+			#size-cells = <0x0>;
+			power-domains = <0xc 0x24>;
+			clocks = <0x3 0x3b 0x3 0x1f>;
+		};
+
+		timer@ff110000 {
+			compatible = "cdns,ttc";
+			status = "disabled";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x24 0x4 0x0 0x25 0x4 0x0 0x26 0x4>;
+			reg = <0x0 0xff110000 0x0 0x1000>;
+			timer-width = <0x20>;
+			power-domains = <0xc 0x18>;
+			clocks = <0x3 0x1f>;
+		};
+
+		timer@ff120000 {
+			compatible = "cdns,ttc";
+			status = "disabled";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x27 0x4 0x0 0x28 0x4 0x0 0x29 0x4>;
+			reg = <0x0 0xff120000 0x0 0x1000>;
+			timer-width = <0x20>;
+			power-domains = <0xc 0x19>;
+			clocks = <0x3 0x1f>;
+		};
+
+		timer@ff130000 {
+			compatible = "cdns,ttc";
+			status = "disabled";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x2a 0x4 0x0 0x2b 0x4 0x0 0x2c 0x4>;
+			reg = <0x0 0xff130000 0x0 0x1000>;
+			timer-width = <0x20>;
+			power-domains = <0xc 0x1a>;
+			clocks = <0x3 0x1f>;
+		};
+
+		timer@ff140000 {
+			compatible = "cdns,ttc";
+			status = "disabled";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x2d 0x4 0x0 0x2e 0x4 0x0 0x2f 0x4>;
+			reg = <0x0 0xff140000 0x0 0x1000>;
+			timer-width = <0x20>;
+			power-domains = <0xc 0x1b>;
+			clocks = <0x3 0x1f>;
+		};
+
+		serial@ff000000 {
+			u-boot,dm-pre-reloc;
+			compatible = "cdns,uart-r1p12", "xlnx,xuartps";
+			status = "okay";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x15 0x4>;
+			reg = <0x0 0xff000000 0x0 0x1000>;
+			clock-names = "uart_clk", "pclk";
+			power-domains = <0xc 0x21>;
+			clocks = <0x3 0x38 0x3 0x1f>;
+			pinctrl-names = "default";
+			pinctrl-0 = <0x1d>;
+			cts-override;
+			device_type = "serial";
+			port-number = <0x0>;
+		};
+
+		serial@ff010000 {
+			u-boot,dm-pre-reloc;
+			compatible = "cdns,uart-r1p12", "xlnx,xuartps";
+			status = "okay";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x16 0x4>;
+			reg = <0x0 0xff010000 0x0 0x1000>;
+			clock-names = "uart_clk", "pclk";
+			power-domains = <0xc 0x22>;
+			clocks = <0x3 0x39 0x3 0x1f>;
+			pinctrl-names = "default";
+			pinctrl-0 = <0x1e>;
+			cts-override;
+			device_type = "serial";
+			port-number = <0x1>;
+		};
+
+		usb0@ff9d0000 {
+			#address-cells = <0x2>;
+			#size-cells = <0x2>;
+			status = "okay";
+			compatible = "xlnx,zynqmp-dwc3";
+			reg = <0x0 0xff9d0000 0x0 0x100>;
+			clock-names = "bus_clk", "ref_clk";
+			power-domains = <0xc 0x16>;
+			ranges;
+			nvmem-cells = <0x19>;
+			nvmem-cell-names = "soc_revision";
+			clocks = <0x3 0x20 0x3 0x22>;
+			pinctrl-names = "default";
+			pinctrl-0 = <0x1f>;
+			xlnx,tz-nonsecure = <0x1>;
+			xlnx,usb-polarity = <0x0>;
+			xlnx,usb-reset-mode = <0x0>;
+
+			dwc3@fe200000 {
+				compatible = "snps,dwc3";
+				status = "okay";
+				reg = <0x0 0xfe200000 0x0 0x40000>;
+				interrupt-parent = <0x4>;
+				interrupt-names = "dwc_usb3", "otg", "hiber";
+				interrupts = <0x0 0x41 0x4 0x0 0x45 0x4 0x0 0x4b 0x4>;
+				#stream-id-cells = <0x1>;
+				iommus = <0xe 0x860>;
+				snps,quirk-frame-length-adjustment = <0x20>;
+				snps,refclk_fladj;
+				snps,enable_guctl1_resume_quirk;
+				snps,enable_guctl1_ipd_quirk;
+				snps,xhci-stream-quirk;
+				dr_mode = "host";
+				snps,usb3_lpm_capable;
+				phy-names = "usb3-phy";
+				phys = <0x20 0x4 0x0 0x2 0x18cba80>;
+				maximum-speed = "super-speed";
+			};
+		};
+
+		usb1@ff9e0000 {
+			#address-cells = <0x2>;
+			#size-cells = <0x2>;
+			status = "disabled";
+			compatible = "xlnx,zynqmp-dwc3";
+			reg = <0x0 0xff9e0000 0x0 0x100>;
+			clock-names = "bus_clk", "ref_clk";
+			power-domains = <0xc 0x17>;
+			ranges;
+			nvmem-cells = <0x19>;
+			nvmem-cell-names = "soc_revision";
+			clocks = <0x3 0x21 0x3 0x22>;
+
+			dwc3@fe300000 {
+				compatible = "snps,dwc3";
+				status = "disabled";
+				reg = <0x0 0xfe300000 0x0 0x40000>;
+				interrupt-parent = <0x4>;
+				interrupt-names = "dwc_usb3", "otg", "hiber";
+				interrupts = <0x0 0x46 0x4 0x0 0x4a 0x4 0x0 0x4c 0x4>;
+				#stream-id-cells = <0x1>;
+				iommus = <0xe 0x861>;
+				snps,quirk-frame-length-adjustment = <0x20>;
+				snps,refclk_fladj;
+				snps,enable_guctl1_resume_quirk;
+				snps,enable_guctl1_ipd_quirk;
+				snps,xhci-stream-quirk;
+			};
+		};
+
+		watchdog@fd4d0000 {
+			compatible = "cdns,wdt-r1p2";
+			status = "okay";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x71 0x1>;
+			reg = <0x0 0xfd4d0000 0x0 0x1000>;
+			timeout-sec = <0x3c>;
+			reset-on-timeout;
+			clocks = <0x3 0x4b>;
+		};
+
+		watchdog@ff150000 {
+			compatible = "cdns,wdt-r1p2";
+			status = "okay";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x34 0x1>;
+			reg = <0x0 0xff150000 0x0 0x1000>;
+			timeout-sec = <0xa>;
+			clocks = <0x3 0x70>;
+		};
+
+		zynqmp_ipi: zynqmp_ipi{
+			compatible = "xlnx,zynqmp-ipi-mailbox";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x23 0x4>;
+			xlnx,ipi-id = <0x0>;
+			#address-cells = <0x2>;
+			#size-cells = <0x2>;
+			ranges;
+
+			mailbox@ff990400 {
+				reg = <0x0 0xff9905c0 0x0 0x20 0x0 0xff9905e0 0x0 0x20 0x0 0xff990e80 0x0 0x20 0x0 0xff990ea0 0x0 0x20>;
+				reg-names = "local_request_region", "local_response_region", "remote_request_region", "remote_response_region";
+				#mbox-cells = <0x1>;
+				xlnx,ipi-id = <0x4>;
+				phandle = <0x5>;
+			};
+		};
+
+		ams@ffa50000 {
+			compatible = "xlnx,zynqmp-ams";
+			status = "okay";
+			interrupt-parent = <0x4>;
+			interrupts = <0x0 0x38 0x4>;
+			interrupt-names = "ams-irq";
+			reg = <0x0 0xffa50000 0x0 0x800>;
+			reg-names = "ams-base";
+			#address-cells = <0x2>;
+			#size-cells = <0x2>;
+			#io-channel-cells = <0x1>;
+			ranges;
+			clocks = <0x3 0x46>;
+
+			ams_ps@ffa50800 {
+				compatible = "xlnx,zynqmp-ams-ps";
+				status = "okay";
+				reg = <0x0 0xffa50800 0x0 0x400>;
+			};
+
+			ams_pl@ffa50c00 {
+				compatible = "xlnx,zynqmp-ams-pl";
+				status = "okay";
+				reg = <0x0 0xffa50c00 0x0 0x400>;
+			};
+		};
+
+		dma@fd4c0000 {
+			compatible = "xlnx,dpdma";
+			status = "okay";
+			reg = <0x0 0xfd4c0000 0x0 0x1000>;
+			interrupts = <0x0 0x7a 0x4>;
+			interrupt-parent = <0x4>;
+			clock-names = "axi_clk";
+			power-domains = <0xc 0x29>;
+			dma-channels = <0x6>;
+			#dma-cells = <0x1>;
+			clocks = <0x3 0x14>;
+			phandle = <0x23>;
+
+			dma-video0channel {
+				compatible = "xlnx,video0";
+			};
+
+			dma-video1channel {
+				compatible = "xlnx,video1";
+			};
+
+			dma-video2channel {
+				compatible = "xlnx,video2";
+			};
+
+			dma-graphicschannel {
+				compatible = "xlnx,graphics";
+			};
+
+			dma-audio0channel {
+				compatible = "xlnx,audio0";
+			};
+
+			dma-audio1channel {
+				compatible = "xlnx,audio1";
+			};
+		};
+
+		zynqmp-display@fd4a0000 {
+			compatible = "xlnx,zynqmp-dpsub-1.7";
+			status = "okay";
+			reg = <0x0 0xfd4a0000 0x0 0x1000 0x0 0xfd4aa000 0x0 0x1000 0x0 0xfd4ab000 0x0 0x1000 0x0 0xfd4ac000 0x0 0x1000>;
+			reg-names = "dp", "blend", "av_buf", "aud";
+			interrupts = <0x0 0x77 0x4>;
+			interrupt-parent = <0x4>;
+			clock-names = "dp_apb_clk", "dp_aud_clk", "dp_vtc_pixel_clk_in";
+			power-domains = <0xc 0x29>;
+			clocks = <0x21 0x3 0x11 0x3 0x10>;
+			phy-names = "dp-phy0";
+			phys = <0x22 0x6 0x0 0x3 0x19bfcc0>;
+			xlnx,max-lanes = <0x1>;
+
+			vid-layer {
+				dma-names = "vid0", "vid1", "vid2";
+				dmas = <0x23 0x0 0x23 0x1 0x23 0x2>;
+			};
+
+			gfx-layer {
+				dma-names = "gfx0";
+				dmas = <0x23 0x3>;
+			};
+
+			i2c-bus {
+			};
+
+			zynqmp_dp_snd_codec0 {
+				compatible = "xlnx,dp-snd-codec";
+				clock-names = "aud_clk";
+				clocks = <0x3 0x11>;
+				status = "okay";
+				phandle = <0x26>;
+			};
+
+			zynqmp_dp_snd_pcm0 {
+				compatible = "xlnx,dp-snd-pcm";
+				dmas = <0x23 0x4>;
+				dma-names = "tx";
+				status = "okay";
+				phandle = <0x24>;
+			};
+
+			zynqmp_dp_snd_pcm1 {
+				compatible = "xlnx,dp-snd-pcm";
+				dmas = <0x23 0x5>;
+				dma-names = "tx";
+				status = "okay";
+				phandle = <0x25>;
+			};
+
+			zynqmp_dp_snd_card {
+				compatible = "xlnx,dp-snd-card";
+				xlnx,dp-snd-pcm = <0x24 0x25>;
+				xlnx,dp-snd-codec = <0x26>;
+				status = "okay";
+			};
+		};
+	};
+
+	fclk0 {
+		status = "okay";
+		compatible = "xlnx,fclk";
+		clocks = <0x3 0x47>;
+	};
+
+	fclk1 {
+		status = "okay";
+		compatible = "xlnx,fclk";
+		clocks = <0x3 0x48>;
+	};
+
+	fclk2 {
+		status = "okay";
+		compatible = "xlnx,fclk";
+		clocks = <0x3 0x49>;
+	};
+
+	fclk3 {
+		status = "okay";
+		compatible = "xlnx,fclk";
+		clocks = <0x3 0x4a>;
+	};
+
+	pss_ref_clk {
+		u-boot,dm-pre-reloc;
+		compatible = "fixed-clock";
+		#clock-cells = <0x0>;
+		clock-frequency = <0x1fc9350>;
+		phandle = <0x6>;
+	};
+
+	video_clk {
+		u-boot,dm-pre-reloc;
+		compatible = "fixed-clock";
+		#clock-cells = <0x0>;
+		clock-frequency = <0x19bfcc0>;
+		phandle = <0x7>;
+	};
+
+	pss_alt_ref_clk {
+		u-boot,dm-pre-reloc;
+		compatible = "fixed-clock";
+		#clock-cells = <0x0>;
+		clock-frequency = <0x0>;
+		phandle = <0x8>;
+	};
+
+	gt_crx_ref_clk {
+		u-boot,dm-pre-reloc;
+		compatible = "fixed-clock";
+		#clock-cells = <0x0>;
+		clock-frequency = <0x66ff300>;
+		phandle = <0xa>;
+	};
+
+	aux_ref_clk {
+		u-boot,dm-pre-reloc;
+		compatible = "fixed-clock";
+		#clock-cells = <0x0>;
+		clock-frequency = <0x19bfcc0>;
+		phandle = <0x9>;
+	};
+
+	dp_aclk {
+		compatible = "fixed-clock";
+		#clock-cells = <0x0>;
+		clock-frequency = <0x5f5e100>;
+		clock-accuracy = <0x64>;
+		phandle = <0x21>;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		#address-cells = <0x1>;
+		#size-cells = <0x0>;
+		autorepeat;
+
+		sw19 {
+			label = "sw19";
+			gpios = <0x14 0x16 0x0>;
+			linux,code = <0x6c>;
+			wakeup-source;
+			autorepeat;
+		};
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		heartbeat-led {
+			label = "heartbeat";
+			gpios = <0x14 0x17 0x0>;
+			linux,default-trigger = "heartbeat";
+		};
+	};
+
+	chosen {
+		xlnx,eeprom = "/amba/i2c@ff030000/i2c-mux@74/i2c@0/eeprom@54";
+		bootargs = " earlycon console=ttyPS0,115200 clk_ignore_unused root=/dev/ram0 rw";
+		stdout-path = "serial0:115200n8";
+	};
+
+	ina226-u76 {
+		compatible = "iio-hwmon";
+		io-channels = <0x27 0x0 0x27 0x1 0x27 0x2 0x27 0x3>;
+	};
+
+	ina226-u77 {
+		compatible = "iio-hwmon";
+		io-channels = <0x28 0x0 0x28 0x1 0x28 0x2 0x28 0x3>;
+	};
+
+	ina226-u78 {
+		compatible = "iio-hwmon";
+		io-channels = <0x29 0x0 0x29 0x1 0x29 0x2 0x29 0x3>;
+	};
+
+	ina226-u87 {
+		compatible = "iio-hwmon";
+		io-channels = <0x2a 0x0 0x2a 0x1 0x2a 0x2 0x2a 0x3>;
+	};
+
+	ina226-u85 {
+		compatible = "iio-hwmon";
+		io-channels = <0x2b 0x0 0x2b 0x1 0x2b 0x2 0x2b 0x3>;
+	};
+
+	ina226-u86 {
+		compatible = "iio-hwmon";
+		io-channels = <0x2c 0x0 0x2c 0x1 0x2c 0x2 0x2c 0x3>;
+	};
+
+	ina226-u93 {
+		compatible = "iio-hwmon";
+		io-channels = <0x2d 0x0 0x2d 0x1 0x2d 0x2 0x2d 0x3>;
+	};
+
+	ina226-u88 {
+		compatible = "iio-hwmon";
+		io-channels = <0x2e 0x0 0x2e 0x1 0x2e 0x2 0x2e 0x3>;
+	};
+
+	ina226-u15 {
+		compatible = "iio-hwmon";
+		io-channels = <0x2f 0x0 0x2f 0x1 0x2f 0x2 0x2f 0x3>;
+	};
+
+	ina226-u92 {
+		compatible = "iio-hwmon";
+		io-channels = <0x30 0x0 0x30 0x1 0x30 0x2 0x30 0x3>;
+	};
+
+	ina226-u79 {
+		compatible = "iio-hwmon";
+		io-channels = <0x31 0x0 0x31 0x1 0x31 0x2 0x31 0x3>;
+	};
+
+	ina226-u81 {
+		compatible = "iio-hwmon";
+		io-channels = <0x32 0x0 0x32 0x1 0x32 0x2 0x32 0x3>;
+	};
+
+	ina226-u80 {
+		compatible = "iio-hwmon";
+		io-channels = <0x33 0x0 0x33 0x1 0x33 0x2 0x33 0x3>;
+	};
+
+	ina226-u84 {
+		compatible = "iio-hwmon";
+		io-channels = <0x34 0x0 0x34 0x1 0x34 0x2 0x34 0x3>;
+	};
+
+	ina226-u16 {
+		compatible = "iio-hwmon";
+		io-channels = <0x35 0x0 0x35 0x1 0x35 0x2 0x35 0x3>;
+	};
+
+	ina226-u65 {
+		compatible = "iio-hwmon";
+		io-channels = <0x36 0x0 0x36 0x1 0x36 0x2 0x36 0x3>;
+	};
+
+	ina226-u74 {
+		compatible = "iio-hwmon";
+		io-channels = <0x37 0x0 0x37 0x1 0x37 0x2 0x37 0x3>;
+	};
+
+	ina226-u75 {
+		compatible = "iio-hwmon";
+		io-channels = <0x38 0x0 0x38 0x1 0x38 0x2 0x38 0x3>;
+	};
+
+	aliases {
+		ethernet0 = "/amba/ethernet@ff0e0000";
+		i2c0 = "/amba/i2c@ff020000";
+		i2c1 = "/amba/i2c@ff030000";
+		serial0 = "/amba/serial@ff000000";
+		serial1 = "/amba/serial@ff010000";
+		spi0 = "/amba/spi@ff0f0000";
+	};
+
+	memory {
+		device_type = "memory";
+		reg = <0x0 0x0 0x0 0x7ff00000 0x8 0x0 0x0 0x80000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <0x2>;
+		#size-cells = <0x2>;
+		ranges;
+
+		/* For compatibility with default the cpus cluster */
+		memory_r5@0 {
+			compatible = "openamp,domain-memory-v1";
+			reg = <0x0 0x0 0x0 0x8000000>;
+		};
+
+	};
+	domains {
+		#address-cells = <0x2>;
+		#size-cells = <0x2>;
+
+		openamp_r5 {
+			compatible = "openamp,domain-v1";
+			#address-cells = <0x2>;
+			#size-cells = <0x2>;
+			/*
+			 * 1:1 map, it should match the memory regions
+			 * specified under access below.
+			 *
+			 * It is in the form:
+			 * memory = <address size address size ...>
+			 */
+			memory = <0x0 0x0 0x0 0x8000000>;
+			/*
+			 * cpus specifies on which CPUs this domain runs
+			 * on
+			 *
+			 * link to cluster | cpus-mask | execution-mode
+			 *
+			 * execution mode for ARM-R CPUs:
+			 * bit 30: lockstep (lockstep enabled == 1)
+			 * bit 31: secure mode / normal mode (secure mode == 1)
+			 */
+			cpus = <&cpus_r5 0x2 0x80000000>;
+			/*
+			 * Access specifies which resources this domain
+			 * has access to.
+			 *
+			 * Link to resource | flags
+			 *
+			 * The "flags" field is mapping specific
+			 *
+			 * For memory, reserved-memory, and sram:
+			 *   bit 0: 0/1: RO/RW
+			 *
+			 * Other cases: unused 
+			 *
+			 * In this example we are assigning:
+			 * - memory range 0x0-0x8000000 RW
+			 * - tcm RW
+			 * - ethernet card at 0xff0c0000
+			 */
+			access = <&tcm 0x1>, <&ethernet0 0x0>;
+
+			chosen {
+				bootargs = "console=ttyAMA0";
+			};
+		};
+	};
+};

--- a/device-trees/system-device-tree.dts
+++ b/device-trees/system-device-tree.dts
@@ -56,30 +56,19 @@
 			};
 		};
 	};
-	ps_ipi_1: ps_ipi@ff340000 {
-		compatible = "ps-interrupt";
-		#address-cells = <2>;
-		#size-cells = <2>;
-		reg = <0xFF340000 0x1000>;
-	};
-	ps_ipi_2: ps_ipi@ff350000 {
-		compatible = "ps-interrupt";
-		#address-cells = <2>;
-		#size-cells = <2>;
-		reg = <0xFF350000 0x1000>;
-	};
 	ps_ipi_3: ps_ipi@ff360000 {
 		compatible = "ps-interrupt";
 		#address-cells = <2>;
 		#size-cells = <2>;
 		reg = <0xFF360000 0x1000>;
 	};
-	ps_ipi_4: ps_ipi@ff370000 {
+	ps_ipi_1: ps_ipi@ff340000 {
 		compatible = "ps-interrupt";
 		#address-cells = <2>;
 		#size-cells = <2>;
-		reg = <0xFF370000 0x1000>;
+		reg = <0xFF340000 0x1000>;
 	};
+
 	channel0vdev0vring0: channel0vdev0vring0@3ed40000 {
 		no-map;
 		#address-cells = <2>;
@@ -106,34 +95,6 @@
 		#address-cells = <2>;
 		#size-cells = <2>;
 		reg = <0x3ed00000 0x40000>;
-		compatible = "openamp,xlnx,mem-carveout";
-	};
-	channel1vdev0vring0: channel1vdev0vring0@3ef40000 {
-		no-map;
-		#address-cells = <2>;
-		#size-cells = <2>;
-		reg = <0x3ef40000 0x4000>;
-		compatible = "openamp,xlnx,mem-carveout";
-	};
-	channel1vdev0vring1: channel1vdev0vring1@3ef44000 {
-		no-map;
-		#address-cells = <2>;
-		#size-cells = <2>;
-		reg = <0x3ef44000 0x4000>;
-		compatible = "openamp,xlnx,mem-carveout";
-	};
-	channel1vdev0buffer: channel1vdev0buffer@3ef48000 {
-		no-map;
-		#address-cells = <2>;
-		#size-cells = <2>;
-		reg = <0x3ef48000 0x100000>;
-		compatible = "openamp,xlnx,mem-carveout";
-	};
-	channel1_elfload: channel1_elfload@3ef000000 {
-		no-map;
-		#address-cells = <2>;
-		#size-cells = <2>;
-		reg = <0x3ef00000 0x40000>;
 		compatible = "openamp,xlnx,mem-carveout";
 	};
 

--- a/lopper.py
+++ b/lopper.py
@@ -30,6 +30,8 @@ import atexit
 import textwrap
 from collections import UserDict
 from collections import OrderedDict
+import os.path
+from os import path
 
 import libfdt
 from libfdt import Fdt, FdtException, QUIET_NOTFOUND, QUIET_ALL
@@ -520,6 +522,9 @@ class LopperSDT:
 
         try:
             mod_file_abs = mod_file.resolve()
+            if path.exists(os.path.abspath(assist_name)) == False:
+                raise FileNotFoundError
+
         except FileNotFoundError:
             # check the path from which lopper is running, that directory + assists, and paths
             # specified on the command line
@@ -528,7 +533,8 @@ class LopperSDT:
                 mod_file = Path( s + "/" + mod_file.name )
                 try:
                     mod_file_abs = mod_file.resolve()
-                    break
+                    if path.exists(os.path.abspath(mod_file_abs)):
+                        break
                 except FileNotFoundError:
                     mod_file_abs = ""
 

--- a/lops/lop-domain-r5-zynqmp.dts
+++ b/lops/lop-domain-r5-zynqmp.dts
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2019,2020 Xilinx Inc. All rights reserved.
+ *
+ * Author:
+ *       Bruce Ashfield <bruce.ashfield@xilinx.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/dts-v1/;
+
+/ {
+        compatible = "system-device-tree-v1,lop";
+        lops {
+                compatible = "system-device-tree-v1,lop";
+                lop_0_0 {
+                        compatible = "system-device-tree-v1,lop,meta-v1","phandle-desc-v1";
+                        address-map = "#ranges-address-cells phandle #ranges-address-cells #ranges-size-cells";
+                        interrupt-parent = "phandle";
+                        iommus = "phandle field";
+                        interrupt-map = "#interrupt-cells phandle #interrupt-cells";
+                        access = "phandle flags";
+                        cpus = "phandle mask mode";
+                };
+                lop_0 {
+                        compatible = "system-device-tree-v1,lop,assist-v1";
+                        node = "/domains/openamp_r5";
+                        id = "openamp,domain-v1";
+			// if uncommented the noexec property means the lop can be
+			// present but skipped. useful for debug
+			//noexec;
+                };
+                lop_2 {
+                        // node name modify
+                        compatible = "system-device-tree-v1,lop,modify";
+                        //modify = "/cpus_r5::";
+                        modify = "/cpus-cluster@0/::/cpus/";
+                        //noexec;
+                };
+                lop_3 {
+                        compatible = "system-device-tree-v1,lop,modify";
+                        // format is: "path":"property":"replacement"
+                        //    - modify to "nothing", is a remove operation
+                        //    - modify with no property is node operation (rename or remove)
+                        modify = "/cpus/:access:";
+                };
+                lop_4 {
+                        // modify to "nothing", is a remove operation
+                        compatible = "system-device-tree-v1,lop,modify";
+                        modify = "/cpus:no-access:";
+                };
+                lop_7 {
+                        // node add
+                        compatible = "system-device-tree-v1,lop,add";
+                        node_src = "zynqmp-rpu";
+                        node_dest = "/zynqmp-rpu";
+                        zynqmp-rpu {
+                            compatible = "xlnx,zynqmp-r5-remoteproc-1.0","test2ndtype";
+                            #address-cells = <2>;
+                            #size-cells = <2>;
+                            ranges;
+                            core_conf = "__core_conf__";
+                            r5_0: __cpu__ {
+                                  // #address-cells = <2>;
+                                  // #size-cells = <2>;
+                                  // <0xF> indicates that it must be replaced
+                                  #address-cells = <0xF>;
+                                  #size-cells = <0xF>;
+                                  ranges;
+                                  // memory-region = <&rproc_0_reserved>, <&rproc_0_dma>;
+                                  memory-region = <&__memory_access__>;
+                                  pnode-id = <0x7>;
+                                  // mboxes = <&ipi_mailbox_rpu0 0>, <&ipi_mailbox_rpu0 1>;
+                                  mboxes = <&__mailbox_ipi__>;
+                                  // mbox-names = "tx", "rx";
+                                  mbox-names = "__mbox_names__";
+                                  tcm_0_a: tcm_0@0 {
+                                           reg = <0x0 0xFFE00000 0x0 0x10000>;
+                                           pnode-id = <0xf>;
+                                  };
+                                  tcm_0_b: tcm_0@1 {
+                                         reg = <0x0 0xFFE20000 0x0 0x10000>;
+                                         pnode-id = <0x10>;
+                                  };
+                            };
+                        };
+                  };
+                  lop_10 {
+                          // optionally execute a routine in a loaded module. If the routine
+                          // isn't found, this is NOT a failure. Since we don't want to tightly
+                          // couple these transforms and loaded modules
+                          compatible = "system-device-tree-v1,lop,assist-v1";
+                          id = "openamp,xlnx-rpu";
+                          node = "/domains/openamp_r5";
+                          options = "openamp_channel_info.h";
+                  };
+                  lop_13 {
+                         compatible = "system-device-tree-v1,lop,output";
+                         outfile = "openamp-test.dts";
+                         // nodes = "/reserved-memory", "/zynqmp-rpu", "/zynqmp_ipi1", "/chosen/resource_group_1";
+                         // list of nodes to select and output
+                         nodes = "reserved-memory", "zynqmp-rpu", "zynqmp_ipi1";
+                  };
+                  lop_14 {
+                         compatible = "system-device-tree-v1,lop,output";
+                         outfile = "linux.dtb";
+                         // * is "all nodes"
+                         nodes = "*";
+                  };
+                  lop_15 {
+                         compatible = "system-device-tree-v1,lop,output";
+                         outfile = "r5.dts";
+                         // * is "all nodes"
+                         nodes = "ps_ipi_*", "channel*", "cpus*","fpga*", "amba_rpu","tcm","memory_r5@0";
+                  };
+
+                  lop_16 {
+                         compatible = "system-device-tree-v1,lop,modify";
+                         modify = "/amba/.*ethernet.*phy.*:testprop:testvalue";
+                         // noexec;
+                  };
+                  lop_17 {
+                         compatible = "system-device-tree-v1,lop,modify";
+                         //modify = "/amba/:testprop:testvalue";
+                         modify = "/bus@f1000000/.*ethernet.*phy.*:testprop:testvaluenew";
+                         //modify = "/amba.*:testprop:testvalue";
+                         // note: nodes is legacy now. Just put the regex into the modify
+                         // parameter
+                         // nodes = "/amba/.*ethernet.*phy.*";
+                  };
+                  lop_18 {
+                         compatible = "system-device-tree-v1,lop,modify";
+                         modify = "/bus@f1000000:testprop:testvalue";
+                  };
+		  lop_19 {
+			 compatible = "system-device-tree-v1,lop,output";
+			 outfile = "linux-partial.dts";
+			 // * is "all nodes"
+			 nodes = "bus@f1000000.*";
+		  };
+		  lop_21 {
+			 compatible = "system-device-tree-v1,lop,output";
+			 outfile = "linux-special-props.dts";
+			 // nodes (regex), with a property that must be set
+			 nodes = "bus.*:testprop:testvalue";
+		  };
+		  lop_22 {
+			 compatible = "system-device-tree-v1,lop,output";
+			 outfile = "linux-labels.dts";
+			 // select nodes labelled "amba*"
+			 nodes = "amba.*";
+		  };
+
+        };
+};


### PR DESCRIPTION
Add symbols using memory and interrupt specific info for the following
OpenAMP subsystems: VirtIO, RPMsg, Remoteproc.

Adding vector ID and bitmasks for versal IPIs, memory-related offsets and
trivial calculations and some hard-coded values corresponding to default
cases for resource table.

As the IRQ info is complex enough for 2 IPIs trim input systemDT to only have
needed default IPI info for now.

Signed-off-by: Ben Levinsky <ben.levinsky@xilinx.com>