### PR TITLE
xlnx: add updated CDO for Versal Soc (1 board only)

### DIFF
--- a/assists/cdo.py
+++ b/assists/cdo.py
@@ -26,7 +26,7 @@ import lopper
 from lopper_tree import *
 
 sys.path.append(os.path.dirname(__file__))
-import cdotypes
+from xlnx_versal_power import *
 
 def props():
     return ["id", "file_ext"]
@@ -42,232 +42,144 @@ def is_compat( node, compat_id ):
         return cdo_write
     return ""
 
-# nodetype mapping
-cdo_basenodeid = 0xc4100000
+current_subsystem_id = 0x1c000003
+subsystems = {}
 
-# map a device tree "type" to a cdo nodeid/type list
-cdo_nodetype = {
-                 "root" : [ "0x10", "root" ],
-                 "cpus,cluster" : [ "0x1b", "device" ],
-                 "interrupt-controller.*" : [ "0x1c", "device" ],
-                 "subclock" : [ "0x1e", "clock" ],
-                 ".*clk" : [ "0x1f", "clock-controller" ],
-                 ".*clock" : [ "0x1d", "clock" ]
-               }
+def add_subsystem(domain_node, sdt, output):
 
-def cdo_parent_word( parent_count, width, shift ):
-    # After the node ID, the CMD_PM_ADD* have a word of the following format:
-    #      <Reserved> <Number of Parents> <Width> <Shift>
-    reserved = 0
+  global current_subsystem_id
+  global subsystems
 
-    word_one = "0x{:02d}{:02d}{:02d}{:02d}".format( reserved, parent_count, width, shift )
+  # read cpus property
+  if domain_node.propval("cpus") == [""]:
+    print("ERROR: add_subsystem: ",str(domain_node), "missing cpus property.")
+    return -1
+  else:
+    cpu_node = sdt.tree.pnode(domain_node.propval("cpus")[0])
+    if cpu_node == None:
+      print("add_subsystem: could not find corresponding core node")
+      return -1
 
-    return word_one
+    subsystem_num = current_subsystem_id & 0xF
 
-#
-# generate a nodeid from a compatible string
-#
-# nodeid is of the format: <class:24-31><subclass:16-23>:<type:8-15><index 0:7>
-#
-# TODO: make this smarter and produce nodes with proper nodeid structure
-#
-def cdo_nodeid( nodeoffset, device_tree_type ):
-    try:
-        x = cdo_nodetype[device_tree_type]
-        x = x[0]
-    except:
-        x = hex(0 | nodeoffset)
-        for k in cdo_nodetype.keys():
-            if re.search( k, str(device_tree_type) ):
-                x = cdo_nodetype[k]
-                x = x[0]
+    # if cpus_a72, then APU subsystem
+    if "a72" in cpu_node.name or "r5" in cpu_node.name:
 
-    #
-    # note: the node offset can't be a longterm solution, but we'll use it
-    # for now to make sure we are getting more unique nodeids, eventually this
-    # is where the index goes in the nodeid.
-    #
-    idx = (int(x,16) << 8) | (cdo_basenodeid) | (nodeoffset & 0xff)
-    return idx
+      print("# subsystem_"+str(subsystem_num), file=output)
+      print("pm_add_subsystem "+ hex(current_subsystem_id), file=output)
+      subsystems[cpu_node.name] = current_subsystem_id
+      current_subsystem_id += 1
+    else:
+      print("ERROR: add_subsystem: cpu  not supported ",str(cpu_node))
+      return -1
 
-# map a compatible string to a cdo type
-def cdo_type( device_tree_type ):
-    try:
-        x = cdo_nodetype[device_tree_type]
-        x = x[1]
-    except:
-        x = "unknown_type"
-        for k in cdo_nodetype.keys():
-            if re.search( k, str(device_tree_type) ):
-                x = cdo_nodetype[k]
-                x = x[1]
-    return x
+  # cpu_node can be used later, as some
+  # subsystems will have hard-coded requirements
+  return cpu_node
 
-def cdo_write( node, lt, options ):
+
+def cdo_write_command(sub_num, sub_id, dev_str, dev_val, flag1, flag2, output):
+  print("# subsystem_"+str(sub_num)+" "+dev_str,file=output)
+  print("pm_add_requirement "+hex(sub_id)+" "+dev_val+" "+hex(flag1)+" "+hex(flag2),file=output)
+
+# add requirements that link devices to subsystems
+def add_requirement_for_devices(domain_node, cpu_node, sdt, output):
+  subsystem_id = subsystems[cpu_node.name]
+  subsystem_num = subsystem_id & 0xF
+
+  if "a72" in cpu_node.name:
+    cdo_write_command(subsystem_num, subsystem_id,"dev_l2_bank_0",hex(existing_devices["dev_l2_bank_0"]),0x4, 0xfffff, output)
+    cdo_write_command(subsystem_num, subsystem_id,"dev_ams_root",hex(existing_devices["dev_ams_root"]),0x4, 0xfffff, output)
+
+  # here parse the subsystem for device requirements
+  device_list = domain_node.propval("xilinx,subsystem-config")
+  num_params = domain_node.propval("#xilinx,config-cells")[0]
+
+  root_node = domain_node.tree['/']
+
+  for index,device_phandle in enumerate(device_list):
+    if index % 3 != 0:
+      continue
+    device_node = root_node.tree.pnode(device_phandle)
+    if device_node == None:
+      print("ERROR: add_requirement_for_devices: invalid phandle: ",str(device_phandle), index, device_node)
+      return -1
+
+    # there are multiple cases to handle
+    if "cpu" in device_node.name:
+      if "a72" in device_node.abs_path:
+        key = "dev_acpu_" + device_node.name[len(device_node.name)-1]
+      elif "r5" in  device_node.abs_path:
+        key = "dev_rpu0_"
+        if (domain_node.propval("cpus")[1] & 0x1) == 1:
+          # if cpus second arg has rightmost bit on, then this is either lockstep or r5-0
+          key += "0"
+        else:
+          key += "1"
+      else:
+        print("add_requirement_for_devices: cores: TODO not covered: ",str(device_node))
+        return -1
+    elif device_node.propval("power-domains") != [""]:
+      cdo_write_command(subsystem_num, subsystem_id, 
+                        xilinx_versal_device_names[device_node.propval("power-domains")[1]],
+                        hex(device_node.propval("power-domains")[1]),
+                        device_list[index+1],device_list[index+2],output)
+      continue
+    elif "mailbox" in device_node.name:
+      key = mailbox_devices[device_node.name]
+    elif "memory" in device_node.name or "tcm" in device_node.name :
+      if 0xfffc0000 == device_node.propval("reg")[1]:
+        for key in ocm_bank_names:
+          cdo_write_command(subsystem_num, subsystem_id, key, hex(existing_devices[key]),
+                            device_list[index+1],device_list[index+2],output)
+
+      elif device_node.propval("reg")[1] in memory_range_to_dev_name.keys():
+        key = memory_range_to_dev_name[device_node.propval("reg")[1]]
+      else:
+        print("add_requirement_for_devices: TODO: memory: ",str(device_node),hex(device_node.propval("reg")[1]))
+        return -1
+    else:
+      print("add_requirement_for_devices: not covered: ",str(device_node))
+      return -1
+    cdo_write_command(subsystem_num, subsystem_id, key, hex(existing_devices[key]),
+                      device_list[index+1],device_list[index+2],output)
+
+
+  return 0
+
+def cdo_write( domain_node, sdt, options ):
     try:
         verbose = options['verbose']
     except:
         verbose = 0
 
-    outfile = options['outfile']
+    print( " node being processing: ", str(domain_node) )
+    if (len(options["args"]) > 0):
+      outfile = options["args"][0]
+      print("set cdo outfile to ",outfile)
+    else:
+      print("cdo header file name not provided.")
+      return -1
 
     # todo: we could have a force flag and not overwrite this if it exists
     if outfile != sys.stdout:
         output = open( outfile, "w")
+    else:
+      print("stdout provided as outfile")
 
     if verbose > 1:
         print( "[INFO]: cdo write: {}".format(outfile) )
 
-    # we are going to tag the tree with some attributes, so make a copy
-    cdo_tree = lt # LopperTree( sdt.FDT, True )
-
     print( "# Lopper CDO export", file=output )
+    print( "version 2.0", file=output )
 
-    # ref-count clock nodes. this will be used below when putting out the CDO
-    # clocks and subclocks
-    cdo_tree.ref( 0 )
-    for n in cdo_tree:
-        node_type = n.type
-        if node_type:
-            cdo_t = cdo_type( node_type[0] )
-
-        if re.match( "^clock-controller$", cdo_t ):
-            sub_clocks = n["clock-names"].value
-            # TODO: we have to make sure these don't get output again
-            for c in sub_clocks:
-                cn = cdo_tree["/.*" + c]
-                if cn:
-                    cn.ref = 1
-
-    # for depth, nodeoffset, nodename in node_list:
-    for n in cdo_tree:
-        if not n.name:
-            nodename = "root"
-            node_type= "root"
-        else:
-            nodename = n.name
-            # get the compatible string of the node, that's our "type", which we'll
-            # map to the CDO class, subclass and type fields.
-            node_type = n.type
-
-        #
-        # we need to track the node IDs at depth > 1
-        #
-        #   depth 1: the parent is the root node
-        #   depth 2: the parent is whatever the most recent node 1 was
-        #   depth 3: the parent is whatever the most recent node 2 was
-        #   ... etc
-        #
-        if not node_type:
-            # we need to be at depth 2 or more, or we are just going to find the root node
-            # .. and that type isn't all that useful
-            if n.parent and n.parent.parent:
-                print( "# [DBG]+: trying to infer type from parent node)", file=output )
-                # try and infer the type from the parents type
-                ptype = n.parent.parent.type
-                if ptype:
-                    print("# parent type: %s" % ptype, file=output )
-                    node_type = ptype
-
-        nodeid = cdo_nodeid( n.number, str(node_type) )
-        # track the nodeid in the current node so we can reference it in its child nodes
-        n.cdo_nodeid = nodeid
-        n.cdo_type = node_type
-        n.cdo_nodename = nodename
-
-        if node_type:
-            print( "# node start: [%s]:%s depth: %s offset: %s type: %s (%s)" %
-                   (hex(nodeid), nodename, n.depth, hex(n.number), str(node_type), type(node_type) ) , file=output)
-
-            cdo_t = cdo_type( node_type )
-
-            print( "# node cdo mapping: %s" % cdo_t, file=output )
-
-            #
-            # TODO: these will be in routines eventually .. but for now, its a
-            # giant set of if statements
-            #
-
-            reserved = 0
-            parent_count = 1
-            width = 0
-            shift = 0
-
-            if re.match( "root", cdo_t ):
-                pm_add_word_one = cdo_parent_word( parent_count, width, shift )
-                # note: since we are the root node, "parent" is 0x0, which has already been
-                #       initialized in the parent tracker
-                print( "# root node", file=output )
-                print( "pm_add_node {0} {1} {2}".format( hex(nodeid), pm_add_word_one, hex(0)), file=output )
-
-            elif re.match( "device", cdo_t ):
-                # if we see a cluster, add a power domain/island
-                pm_add_word_one = cdo_parent_word( parent_count, width, shift )
-
-                print( "# device add: pm_add_node <nodeid> <res parent width shift> <parent>", file=output )
-                print( "# cpu cluster, depth: {0}".format(n.depth), file=output)
-                print( "pm_add_node {0} {1} {2}".format( hex(nodeid), pm_add_word_one, hex(n.parent.cdo_nodeid)), file=output )
-
-            elif re.match( "domain", cdo_t ):
-                # note: we could also put the skipping in the gather routine, so this can be
-                #       a simple iteration
-                print( "# skipping domain node: %s" % nodename, file=output )
-            elif re.match( "^clock$", cdo_t ):
-                ref_count = n.ref
-                if ref_count < 0:
-                    # there are no other references to this clock, so we put it out as
-                    # a standalone node
-
-                    # these aren't correct for a clock add, but we leave this call as a reminder
-                    pm_add_word_one = cdo_parent_word( parent_count, width, shift )
-
-                    print( "# clock add: pm_add_node <nodeid> <control reg addr> <flags> <power domain ID> ..", file=output)
-                    print( "bb pm_add_node {0} <control reg addr> <flags> <power domain ID> ".format( hex(nodeid)), file=output )
-
-            elif re.match( "^clock-controller$", cdo_t ):
-                # we actually now need to iterate and issue parent adds for any
-                # clocks that are in the "clock-names"
-
-                # print the parent clock controller, and then we check for sub clocks
-                print( "# clock controller: pm_add_node <nodeid> <control reg addr> <flags> <power domain ID> ..", file=output )
-                # TODO: maybe unify this with the clock add (unreferenced) above, i.e.
-                #       move them into a function ...
-
-                # these aren't correct for a clock add, but we leave this call as a reminder
-                pm_add_word_one = cdo_parent_word( parent_count, width, shift )
-                print( "pm_add_node {0} <control reg addr> <flags> <power domain ID> ".format( hex(nodeid)), file=output )
-
-                # sub_clocks = Lopper.property_get( fdt, nodeoffset, "clock-names" )
-                sub_clocks = n["clock-names"].value
-                for c in sub_clocks:
-                    cn = cdo_tree["/.*" + c]
-                    if cn:
-                        # we put out a pm_add for each subclock
-                        sub_node_type = "subclock"
-                        sub_nodeid = cdo_nodeid( cn.number, sub_node_type )
-
-                        sub_clocktype = cn.type[0]
-                        sub_clock_mask = 0x0
-                        if re.match( "fixed", sub_clocktype ):
-                            sub_clock_mask = 0x1
-                        else:
-                            sub_clock_mask = 0x2
-
-                        # these aren't correct for a clock add, but we leave this call as a reminder
-                        pm_add_word_one = cdo_parent_word( parent_count, width, shift )
-                        print( "# clock subnode: pm_add_node <parent clock id> <clock type> <control reg addr> <reserved> <flags>", file=output )
-                        print( "pm_add_node {0} {1} 0x0 0x0 0x0".format( hex(nodeid), hex(sub_clock_mask)), file=output )
-            else:
-                pm_add_word_one = cdo_parent_word( parent_count, width, shift )
-                print( "# unknown type, depth: {0}".format(n.depth), file=output)
-                print( "pm_add_node {0} <flags> {1}".format( hex(nodeid), hex(n.parent.cdo_nodeid)), file=output )
-
-            print( "# node end: [%s]:%s" % (hex(nodeid), nodename), file=output )
-        else:
-            # TODO: what do to about these ? For now, we just log them
-            print( "# INFO: skipping node with no type: %s (depth %s)" % (nodename,n.depth), file=output)
-            print( "#       parent was: %s" % n.parent, file=output )
-
+    # given root domain node do the following:
+    # add subsystem
+    for n in domain_node.subnodes():
+      if n.propval('xilinx,subsystem-config') != ['']:
+        cpu_node = add_subsystem(n, sdt, output)
+        add_requirement_for_devices(n, cpu_node, sdt, output)
+        # TODO permissions requirements
 
     return True
 

--- a/assists/xlnx_versal_power.py
+++ b/assists/xlnx_versal_power.py
@@ -1,0 +1,91 @@
+# TODO ensure mapping is consistent and for correct for each core
+mailbox_devices = {
+  "mailbox@ff330000":"dev_ipi_0",
+  "mailbox@ff340000":"dev_ipi_1",
+  "mailbox@ff350000":"dev_ipi_2",
+  "mailbox@ff360000":"dev_ipi_3",
+  "mailbox@ff370000":"dev_ipi_4",
+  "mailbox@ff380000":"dev_ipi_5",
+  "mailbox@ff3a0000":"dev_ipi_6",
+}
+
+memory_range_to_dev_name = {
+ 0xffe00000:"dev_tcm_0_a",
+ 0xffe20000:"dev_tcm_0_a",
+ 0xffe90000:"dev_tcm_1_a",
+ 0xffeb0000:"dev_tcm_1_b",
+ 0x0:"dev_ddr_0",
+}
+
+ocm_bank_names = [
+  "dev_ocm_bank_0",
+  "dev_ocm_bank_1",
+  "dev_ocm_bank_2",
+  "dev_ocm_bank_3"
+]
+
+existing_devices = {
+  "dev_rpu0_0":0x18110005 ,
+  "dev_rpu0_1":0x18110006 ,
+  "dev_ddr_0":0x18320010 ,
+  "dev_ocm_bank_0":0x18314007 ,
+  "dev_ocm_bank_1":0x18314008 ,
+  "dev_ocm_bank_2":0x18314009 ,
+  "dev_ocm_bank_3":0x1831400a ,
+  "dev_tcm_0_a":0x1831800b ,
+  "dev_tcm_0_b":0x1831800c ,
+  "dev_tcm_1_a":0x1831800d ,
+  "dev_tcm_1_b":0x1831800e ,
+
+  "dev_acpu_0": 0x1810c003,
+  "dev_acpu_1" : 0x1810c004 ,
+  "dev_ipi_0":0x1822403d ,
+  "dev_ipi_1":0x1822403e ,
+  "dev_ipi_2":0x1822403f ,
+  "dev_ipi_3":0x18224040 ,
+  "dev_ipi_4":0x18224041 ,
+  "dev_ipi_5":0x18224042 ,
+  "dev_ipi_6":0x18224043 ,
+  "dev_l2_bank_0": 0x1831c00f,
+  "dev_ams_root": 0x18224055,
+}
+
+# map xilpm IDs to strings
+device_lookup = { 0x1831c00f : "dev_l2_bank_0" ,
+  0x18224055 : "dev_ams_root"
+}
+
+xilinx_versal_device_names = {
+	0x18224018	:   "PM_DEV_USB_0"		,
+	0x18224019	:   "PM_DEV_GEM_0"		,
+	0x1822401a	:   "PM_DEV_GEM_1"		,
+	0x1822401b	:   "PM_DEV_SPI_0"		,
+	0x1822401c	:   "PM_DEV_SPI_1"		,
+	0x1822401d	:   "PM_DEV_I2C_0"		,
+	0x1822401e	:   "PM_DEV_I2C_1"		,
+	0x1822401f	:   "PM_DEV_CAN_FD_0"	,
+	0x18224020	:   "PM_DEV_CAN_FD_1"	,
+	0x18224021	:   "PM_DEV_UART_0"	,	
+	0x18224022	:   "PM_DEV_UART_1"	,	
+	0x18224023	:   "PM_DEV_GPIO"		,
+	0x18224024	:   "PM_DEV_TTC_0"		,
+	0x18224025	:   "PM_DEV_TTC_1"		,
+	0x18224026	:   "PM_DEV_TTC_2"		,
+	0x18224027	:   "PM_DEV_TTC_3"		,
+	0x18224029	:   "PM_DEV_SWDT_FPD"	,
+	0x1822402a	:   "PM_DEV_OSPI"		,
+	0x1822402b	:   "PM_DEV_QSPI"		,
+	0x1822402c	:	"PM_DEV_GPIO_PMC"		,
+	0x1822402e	:   "PM_DEV_SDIO_0"	,		
+	0x1822402f	:   "PM_DEV_SDIO_1"	,		
+	0x18224034	:   "PM_DEV_RTC"	,	
+	0x18224035	:   "PM_DEV_ADMA_0"	,		
+	0x18224036	:   "PM_DEV_ADMA_1"	,		
+	0x18224037	:   "PM_DEV_ADMA_2"	,		
+	0x18224038	:   "PM_DEV_ADMA_3"	,		
+	0x18224039	:   "PM_DEV_ADMA_4"	,		
+	0x1822403a	:   "PM_DEV_ADMA_5"	,		
+	0x1822403b	:   "PM_DEV_ADMA_6"	,		
+	0x1822403c	:   "PM_DEV_ADMA_7"	,		
+	0x18224072	:   "PM_DEV_AI"	
+}

--- a/lops/lop-load.dts
+++ b/lops/lop-load.dts
@@ -19,7 +19,6 @@
                         compatible = "system-device-tree-v1,lop,load";
                         load = "assists/openamp.py";
                 };
-		/*
                 lop_1 {
                         compatible = "system-device-tree-v1,lop,load";
                         load = "assists/cdo.py";
@@ -32,7 +31,6 @@
                         // the id that this module is compatible with
                         id = "xlnx,output,cdo";
                 };
-		*/
                 lop_2 {
                         compatible = "system-device-tree-v1,lop,load";
                         load = "assists/openamp-xlnx.py";

--- a/lops/lop-versal-cdo-hook.dts
+++ b/lops/lop-versal-cdo-hook.dts
@@ -1,0 +1,14 @@
+/dts-v1/;
+/ {
+	compatible = "system-device-tree-v1,lop";
+	lops {
+
+		lop_3_3 {
+			compatible = "system-device-tree-v1,lop,assist-v1";
+			node = "/domains";
+			id = "xlnx,output,cdo";
+			options = "subsystem.cdo";
+		};
+	};
+
+};

--- a/lops/lop-versal-vck190_apu_sub-xilpm_subsystem.dts
+++ b/lops/lop-versal-vck190_apu_sub-xilpm_subsystem.dts
@@ -17,10 +17,25 @@
 			};
 		};
 
+		lop_2_2_1 {
+			compatible = "system-device-tree-v1,lop,code-v1";
+			code = "
+			root_node = node.tree['/']
+			apu_domain_node = node.tree['/domains/apu_domain']
+			new_phandle = root_node.tree.phandle_gen()
+			newprop = LopperProp(name='phandle',value=new_phandle)
+			apu_domain_node.phandle = new_phandle
+			apu_domain_node + newprop
+			apu_domain_node.sync( root_node.tree.fdt )
+			";
+		};
+
+
 		lop_2_3_1 {
 			compatible = "system-device-tree-v1,lop,code-v1";
 			code = "
 			requirements = {
+
 			'/amba/pmcqspi@f1030000':[0x4,0xfffff],
 			'/amba_pl/ai_engine@40000000':[0x4,0xfffff],
 			'/amba/serial@ff000000':[0x5,0x38],

--- a/lops/lop-versal-vck190_apu_sub-xilpm_subsystem.dts
+++ b/lops/lop-versal-vck190_apu_sub-xilpm_subsystem.dts
@@ -1,0 +1,113 @@
+/dts-v1/;
+/ {
+	compatible = "system-device-tree-v1,lop";
+	lops {
+
+		lop_2_2 {
+			compatible = "system-device-tree-v1,lop,add";
+			node_src = "apu_domain";
+			node_dest = "/domains/apu_domain";
+			apu_domain {
+				compatible = "openamp,domain-v1";
+				xilinx,subsystem = <0x1>;
+				#xilinx,config-cells = <2>;
+				
+				/* cdo add subsystem for apu is inferred as cpus_a72 is in cpu field */
+				cpus = <&cpus_a72 0x3 0x80000003>;
+			};
+		};
+
+		lop_2_3_1 {
+			compatible = "system-device-tree-v1,lop,code-v1";
+			code = "
+			requirements = {
+			'/amba/pmcqspi@f1030000':[0x4,0xfffff],
+			'/amba_pl/ai_engine@40000000':[0x4,0xfffff],
+			'/amba/serial@ff000000':[0x5,0x38],
+			'/amba/serial@ff010000':[0x7,0x38],
+			'/amba/mailbox@ff330000':[0x8104,0xfffff],
+			'/amba/mailbox@ff340000':[0x4,0xfffff],
+			'/amba/mailbox@ff350000':[0x4,0xfffff],
+			'/amba/mailbox@ff360000':[0x4,0xfffff],
+			'/amba/mailbox@ff370000':[0x4,0xfffff],
+			'/amba/mailbox@ff380000':[0x4,0xfffff],
+			'/amba/mailbox@ff3a0000':[0x4,0xfffff],
+			'/memory@fffc0000':[0x8304,0xfffff],
+			'/amba/psv_tcm_global@ffe00000':[0x4,0xfffff],
+			'/amba/psv_tcm_global@ffe20000':[0x4,0xfffff],
+			'/amba/psv_tcm_global@ffe90000':[0x4,0xfffff],
+			'/amba/psv_tcm_global@ffeb0000':[0x4,0xfffff],
+
+			'/cpus_a72/cpu@0':[0x8104,0xfffff],
+			'/cpus_a72/cpu@1':[0x8104,0xfffff],
+
+			'/amba/ethernet@ff0c0000':[0x8706,0x38],
+			'/amba/ethernet@ff0d0000':[0x8706,0x38],
+			'/amba/sdhci@f1040000':[0x7,0x38],
+			'/amba/sdhci@f1050000':[0x7,0xfffff],
+
+			'/amba/can@ff060000':[0x4,0xfffff],
+			'/amba/can@ff070000':[0x4,0xfffff],
+			'/amba/i2c@ff020000':[0x4,0xfffff],
+			'/amba/i2c@ff030000':[0x4,0xfffff],
+			'/amba/dma@ffaf0000':[0x4,0xfffff],
+			'/amba/dma@ffae0000':[0x4,0xfffff],
+			'/amba/dma@ffad0000':[0x4,0xfffff],
+			'/amba/dma@ffac0000':[0x4,0xfffff],
+			'/amba/dma@ffab0000':[0x4,0xfffff],
+			'/amba/dma@ffaa0000':[0x4,0xfffff],
+			'/amba/dma@ffa90000':[0x4,0xfffff],
+			'/amba/dma@ffa80000':[0x4,0xfffff],
+			'/memory@800000000':[0x7,0x38],
+			'/amba/rtc@f12a0000':[0x4,0xfffff],
+			'/amba/timer@ff0e0000':[0x4,0xfffff],
+			'/amba/usb@ff9d0000':[0x7,0x38],
+			'/amba/watchdog@fd4d0000':[0x7,0x38],
+			'/amba/gpio@ff0b0000':[0x4,0xfffff],
+			'/amba/gpio@f1020000':[0x4,0xfffff],
+			'/amba/spi@ff040000':[0x4,0xfffff],
+			'/amba/spi@ff050000':[0x4,0xfffff],
+			}
+
+			device_list = []
+
+			# set device list for apu domain
+			apu_domain_node = node.tree['/domains/apu_domain']
+		
+			# for each device in nodes_to_update:
+			# find node in tree with name
+			# generate phandle for that node
+			# add to prop the following: 'phandle nodes_to_update[info]'
+			for n in requirements.keys():
+				target_node = apu_domain_node.tree[n]
+				device_list.append(target_node.propval('phandle'))
+				device_list.append(requirements[n][0])
+				device_list.append(requirements[n][1])
+
+			device_list_prop = LopperProp(name='xilinx,subsystem-config',value=device_list)
+
+			apu_domain_node + device_list_prop
+			apu_domain_node.sync( apu_domain_node.tree.fdt )
+			";
+		};
+
+		lop_2_3_2 {
+			compatible = "system-device-tree-v1,lop,code-v1";
+			code = "
+			cpus_a72_node = node.tree['/cpus_a72']
+			new_phandle = cpus_a72_node.tree.phandle_gen()
+			newprop = LopperProp(name='phandle',value=new_phandle)
+			cpus_a72_node.phandle = new_phandle
+			cpus_a72_node + newprop
+			cpus_a72_node.sync( cpus_a72_node.tree.fdt )
+
+			# set cpus to reference the new phandle
+			apu_domain_node = node.tree['/domains/apu_domain']
+			apu_domain_node_cpus = apu_domain_node.propval('cpus')
+			apu_domain_node_cpus[0] = new_phandle
+			apu_domain_node['cpus'].value = apu_domain_node_cpus
+			";
+                };
+	};
+
+};

--- a/lops/lop-versal-vck190_domains-xilpm_subsystem.dts
+++ b/lops/lop-versal-vck190_domains-xilpm_subsystem.dts
@@ -1,0 +1,89 @@
+/dts-v1/;
+/ {
+	compatible = "system-device-tree-v1,lop";
+	lops {
+
+
+		lop_2_1 {
+			compatible = "system-device-tree-v1,lop,add";
+			node_src = "domains";
+			node_dest = "/domains";
+			domains {
+				 #address-cells = <0x2>;
+				 #size-cells = <0x2>;
+			};
+		};
+
+		lop_2_3_0 {
+			compatible = "system-device-tree-v1,lop,code-v1";
+			code = "
+			devices = [
+			'/amba/pmcqspi@f1030000',
+			'/amba_pl/ai_engine@40000000',
+			'/amba/serial@ff000000', 
+			'/amba/serial@ff010000' ,
+			'/amba/mailbox@ff330000',
+			'/amba/mailbox@ff340000',
+			'/amba/mailbox@ff350000',
+			'/amba/mailbox@ff360000',
+			'/amba/mailbox@ff370000',
+			'/amba/mailbox@ff380000',
+			'/amba/mailbox@ff3a0000',
+			'/memory@fffc0000',
+			'/amba/psv_tcm_global@ffe00000',
+			'/amba/psv_tcm_global@ffe20000',
+			'/amba/psv_tcm_global@ffe90000',
+			'/amba/psv_tcm_global@ffeb0000',
+
+			'/cpus_a72/cpu@0',
+			'/cpus_a72/cpu@1',
+
+			'/amba/ethernet@ff0c0000',
+			'/amba/ethernet@ff0d0000',
+			'/amba/sdhci@f1040000'  , 
+			'/amba/sdhci@f1050000'   ,
+
+			'/amba/can@ff060000'     ,
+			'/amba/can@ff070000'     ,
+			'/amba/i2c@ff020000'     ,
+			'/amba/i2c@ff030000'     ,
+			'/amba/dma@ffaf0000',
+			'/amba/dma@ffae0000',
+			'/amba/dma@ffad0000',
+			'/amba/dma@ffac0000',
+			'/amba/dma@ffab0000',
+			'/amba/dma@ffaa0000',
+			'/amba/dma@ffa90000',
+			'/amba/dma@ffa80000',
+			'/memory@800000000' ,
+			'/amba/rtc@f12a0000',
+			'/amba/timer@ff0e0000',
+			'/amba/usb@ff9d0000'  ,
+			'/amba/watchdog@fd4d0000',
+			'/amba/gpio@ff0b0000',
+			'/amba/gpio@f1020000',
+			'/amba/spi@ff040000',
+			'/amba/spi@ff050000',
+			'/cpus_r5/cpu@4',
+			'/cpus_r5/cpu@5',
+			'/amba/timer@ff0f0000',
+			'/amba/timer@ff100000',
+			]
+
+			# for each device in nodes_to_update:
+			# find node in tree with name
+			# generate phandle for that node
+			root_node = node.tree['/']
+			for n in devices:
+				target_node = root_node.tree[n]
+				new_phandle = root_node.tree.phandle_gen()
+				newprop = LopperProp(name='phandle',value=new_phandle)
+				target_node.phandle = new_phandle
+				target_node + newprop
+				target_node.sync(root_node.tree.fdt)
+			";
+		};
+
+	};
+
+};

--- a/lops/lop-versal-vck190_ls-xilpm_subsystem.dts
+++ b/lops/lop-versal-vck190_ls-xilpm_subsystem.dts
@@ -3,6 +3,7 @@
 	compatible = "system-device-tree-v1,lop";
 	lops {
 
+
 		lop_2_2_1 {
 			compatible = "system-device-tree-v1,lop,add";
 			node_src = "rpu0_domain";
@@ -12,21 +13,8 @@
 				xilinx,subsystem = <0x1>;
 				#xilinx,config-cells = <2>;
 			
-				/* subsystem for split r5-0 */
-				cpus = <&cpus_r5 0x1 0x80000000>;
-			};
-		};
-		lop_2_2_2 {
-			compatible = "system-device-tree-v1,lop,add";
-			node_src = "rpu1_domain";
-			node_dest = "/domains/rpu1_domain";
-			rpu1_domain {
-				compatible = "openamp,domain-v1";
-				xilinx,subsystem = <0x1>;
-				#xilinx,config-cells = <2>;
-			
-				/* subsystem for split r5-1 */
-				cpus = <&cpus_r5 0x2 0x80000000>;
+				/* subsystem for lockstep r5 */
+				cpus = <&cpus_r5 0x3 0x80000000>;
 			};
 		};
 
@@ -44,11 +32,14 @@
 			'/amba/mailbox@ff370000':[0x4,0xfffff],
 			'/amba/mailbox@ff380000':[0x4,0xfffff],
 			'/amba/mailbox@ff3a0000':[0x4,0xfffff],
-			'/amba/timer@ff0f0000':[0x7,0x1],
-			'/amba/serial@ff010000':[ 0x8707, 0x2],
-			'/amba/watchdog@fd4d0000':[ 0x7, 0x2],
+			'/amba/timer@ff100000':[0x7,0x1],
+			'/amba/serial@ff010000':[ 0x8707, 0x6],
+			'/amba/watchdog@fd4d0000':[ 0x7, 0x6],
 			'/amba/psv_tcm_global@ffe00000':[0x8304,0xfffff],
 			'/amba/psv_tcm_global@ffe20000':[0x8304,0xfffff],
+			'/amba/psv_tcm_global@ffe90000':[0x8304,0xfffff],
+			'/amba/psv_tcm_global@ffeb0000':[0x8304,0xfffff],
+
 			'/amba/rtc@f12a0000':[ 0x4, 0xfffff],
 			'/cpus_r5/cpu@4':[ 0x8104, 0xfffff],
 			}
@@ -74,49 +65,6 @@
 			rpu0_domain_node.sync( rpu0_domain_node.tree.fdt )
 			";
 		};
-		lop_2_3_3_1 {
-			compatible = "system-device-tree-v1,lop,code-v1";
-			code = "
-			requirements = {
-			'/amba/pmcqspi@f1030000':[0x4,0xfffff],
-			'/amba/serial@ff000000':[0x5,0x38],
-			'/amba/mailbox@ff330000':[0x4,0xfffff],
-			'/amba/mailbox@ff340000':[0x4,0xfffff],
-			'/amba/mailbox@ff350000':[0x8104,0xfffff],
-			'/amba/mailbox@ff360000':[0x4,0xfffff],
-			'/amba/mailbox@ff370000':[0x4,0xfffff],
-			'/amba/mailbox@ff380000':[0x4,0xfffff],
-			'/amba/mailbox@ff3a0000':[0x4,0xfffff],
-			'/amba/timer@ff100000':[0x7,0x1],
-			'/amba/serial@ff010000':[ 0x8707, 0x4],
-			'/amba/watchdog@fd4d0000':[ 0x7, 0x4],
-			'/amba/psv_tcm_global@ffe90000':[0x8304,0xfffff],
-			'/amba/psv_tcm_global@ffeb0000':[0x8304,0xfffff],
-			'/amba/rtc@f12a0000':[ 0x4, 0xfffff],
-			'/cpus_r5/cpu@5':[ 0x8104, 0xfffff],
-			}
-
-			device_list = []
-
-			# set device list for apu domain
-			rpu1_domain_node = node.tree['/domains/rpu1_domain']
-		
-			# for each device in nodes_to_update:
-			# find node in tree with name
-			# generate phandle for that node
-			# add to prop the following: 'phandle nodes_to_update[info]'
-			for n in requirements.keys():
-				target_node = rpu1_domain_node.tree[n]
-				device_list.append(target_node.phandle)
-				device_list.append(requirements[n][0])
-				device_list.append(requirements[n][1])
-
-			device_list_prop = LopperProp(name='xilinx,subsystem-config',value=device_list)
-
-			rpu1_domain_node + device_list_prop
-			rpu1_domain_node.sync( rpu1_domain_node.tree.fdt )
-			";
-		};
 
 		lop_2_3_4 {
 			compatible = "system-device-tree-v1,lop,code-v1";
@@ -134,11 +82,6 @@
 			rpu0_domain_node_cpus[0] = new_phandle
 			rpu0_domain_node['cpus'].value = rpu0_domain_node_cpus
 
-			# set cpus to reference the new phandle
-			rpu1_domain_node = node.tree['/domains/rpu1_domain']
-			rpu1_domain_node_cpus = rpu1_domain_node.propval('cpus')
-			rpu1_domain_node_cpus[0] = new_phandle
-			rpu1_domain_node['cpus'].value = rpu1_domain_node_cpus
 			";
                 };
 	};

--- a/lops/lop-versal-vck190_ls-xilpm_subsystem.dts
+++ b/lops/lop-versal-vck190_ls-xilpm_subsystem.dts
@@ -17,6 +17,18 @@
 				cpus = <&cpus_r5 0x3 0x80000000>;
 			};
 		};
+		lop_2_2_2 {
+			compatible = "system-device-tree-v1,lop,code-v1";
+			code = "
+			root_node = node.tree['/']
+			rpu0_domain_node = node.tree['/domains/rpu0_domain']
+			new_phandle = root_node.tree.phandle_gen()
+			newprop = LopperProp(name='phandle',value=new_phandle)
+			rpu0_domain_node.phandle = new_phandle
+			rpu0_domain_node + newprop
+			rpu0_domain_node.sync( root_node.tree.fdt )
+			";
+		};
 
 		lop_2_3_3 {
 			compatible = "system-device-tree-v1,lop,code-v1";
@@ -46,7 +58,7 @@
 
 			device_list = []
 
-			# set device list for apu domain
+			# set device list for rpu0 domain
 			rpu0_domain_node = node.tree['/domains/rpu0_domain']
 		
 			# for each device in nodes_to_update:

--- a/lops/lop-versal-vck190_split-xilpm_subsystem.dts
+++ b/lops/lop-versal-vck190_split-xilpm_subsystem.dts
@@ -1,0 +1,336 @@
+/dts-v1/;
+/ {
+	compatible = "system-device-tree-v1,lop";
+	lops {
+
+
+		lop_2_1 {
+			compatible = "system-device-tree-v1,lop,add";
+			node_src = "domains";
+			node_dest = "/domains";
+			domains {
+				 #address-cells = <0x2>;
+				 #size-cells = <0x2>;
+			};
+		};
+		lop_2_2 {
+			compatible = "system-device-tree-v1,lop,add";
+			node_src = "apu_domain";
+			node_dest = "/domains/apu_domain";
+			apu_domain {
+				compatible = "openamp,domain-v1";
+				xilinx,subsystem = <0x1>;
+				#xilinx,config-cells = <2>;
+				
+				/* cdo add subsystem for apu is inferred as cpus_a72 is in cpu field */
+				cpus = <&cpus_a72 0x3 0x80000003>;
+			};
+		};
+		lop_2_2_1 {
+			compatible = "system-device-tree-v1,lop,add";
+			node_src = "rpu0_domain";
+			node_dest = "/domains/rpu0_domain";
+			rpu0_domain {
+				compatible = "openamp,domain-v1";
+				xilinx,subsystem = <0x1>;
+				#xilinx,config-cells = <2>;
+			
+				/* subsystem for split r5-0 */
+				cpus = <&cpus_r5 0x1 0x80000000>;
+			};
+		};
+		lop_2_2_2 {
+			compatible = "system-device-tree-v1,lop,add";
+			node_src = "rpu1_domain";
+			node_dest = "/domains/rpu1_domain";
+			rpu1_domain {
+				compatible = "openamp,domain-v1";
+				xilinx,subsystem = <0x1>;
+				#xilinx,config-cells = <2>;
+			
+				/* subsystem for split r5-1 */
+				cpus = <&cpus_r5 0x2 0x80000000>;
+			};
+		};
+
+		lop_2_3_0 {
+			compatible = "system-device-tree-v1,lop,code-v1";
+			code = "
+			devices = [
+			'/amba/pmcqspi@f1030000',
+			'/amba_pl/ai_engine@40000000',
+			'/amba/serial@ff000000', 
+			'/amba/serial@ff010000' ,
+			'/amba/mailbox@ff330000',
+			'/amba/mailbox@ff340000',
+			'/amba/mailbox@ff350000',
+			'/amba/mailbox@ff360000',
+			'/amba/mailbox@ff370000',
+			'/amba/mailbox@ff380000',
+			'/amba/mailbox@ff3a0000',
+			'/memory@fffc0000',
+			'/amba/psv_tcm_global@ffe00000',
+			'/amba/psv_tcm_global@ffe20000',
+			'/amba/psv_tcm_global@ffe90000',
+			'/amba/psv_tcm_global@ffeb0000',
+
+			'/cpus_a72/cpu@0',
+			'/cpus_a72/cpu@1',
+
+			'/amba/ethernet@ff0c0000',
+			'/amba/ethernet@ff0d0000',
+			'/amba/sdhci@f1040000'  , 
+			'/amba/sdhci@f1050000'   ,
+
+			'/amba/can@ff060000'     ,
+			'/amba/can@ff070000'     ,
+			'/amba/i2c@ff020000'     ,
+			'/amba/i2c@ff030000'     ,
+			'/amba/dma@ffaf0000',
+			'/amba/dma@ffae0000',
+			'/amba/dma@ffad0000',
+			'/amba/dma@ffac0000',
+			'/amba/dma@ffab0000',
+			'/amba/dma@ffaa0000',
+			'/amba/dma@ffa90000',
+			'/amba/dma@ffa80000',
+			'/memory@800000000' ,
+			'/amba/rtc@f12a0000',
+			'/amba/timer@ff0e0000',
+			'/amba/usb@ff9d0000'  ,
+			'/amba/watchdog@fd4d0000',
+			'/amba/gpio@ff0b0000',
+			'/amba/gpio@f1020000',
+			'/amba/spi@ff040000',
+			'/amba/spi@ff050000',
+			'/cpus_r5/cpu@4',
+			'/cpus_r5/cpu@5',
+			'/amba/timer@ff0f0000',
+			'/amba/timer@ff100000',
+			]
+
+			# for each device in nodes_to_update:
+			# find node in tree with name
+			# generate phandle for that node
+			root_node = node.tree['/']
+			for n in devices:
+				target_node = root_node.tree[n]
+				new_phandle = root_node.tree.phandle_gen()
+				newprop = LopperProp(name='phandle',value=new_phandle)
+				target_node.phandle = new_phandle
+				target_node + newprop
+				target_node.sync(root_node.tree.fdt)
+			";
+		};
+
+		lop_2_3_1 {
+			compatible = "system-device-tree-v1,lop,code-v1";
+			code = "
+			requirements = {
+			'/amba/pmcqspi@f1030000':[0x4,0xfffff],
+			'/amba_pl/ai_engine@40000000':[0x4,0xfffff],
+			'/amba/serial@ff000000':[0x5,0x38],
+			'/amba/serial@ff010000':[0x7,0x38],
+			'/amba/mailbox@ff330000':[0x8104,0xfffff],
+			'/amba/mailbox@ff340000':[0x4,0xfffff],
+			'/amba/mailbox@ff350000':[0x4,0xfffff],
+			'/amba/mailbox@ff360000':[0x4,0xfffff],
+			'/amba/mailbox@ff370000':[0x4,0xfffff],
+			'/amba/mailbox@ff380000':[0x4,0xfffff],
+			'/amba/mailbox@ff3a0000':[0x4,0xfffff],
+			'/memory@fffc0000':[0x8304,0xfffff],
+			'/amba/psv_tcm_global@ffe00000':[0x4,0xfffff],
+			'/amba/psv_tcm_global@ffe20000':[0x4,0xfffff],
+			'/amba/psv_tcm_global@ffe90000':[0x4,0xfffff],
+			'/amba/psv_tcm_global@ffeb0000':[0x4,0xfffff],
+
+			'/cpus_a72/cpu@0':[0x8104,0xfffff],
+			'/cpus_a72/cpu@1':[0x8104,0xfffff],
+
+			'/amba/ethernet@ff0c0000':[0x8706,0x38],
+			'/amba/ethernet@ff0d0000':[0x8706,0x38],
+			'/amba/sdhci@f1040000':[0x7,0x38],
+			'/amba/sdhci@f1050000':[0x7,0xfffff],
+
+			'/amba/can@ff060000':[0x4,0xfffff],
+			'/amba/can@ff070000':[0x4,0xfffff],
+			'/amba/i2c@ff020000':[0x4,0xfffff],
+			'/amba/i2c@ff030000':[0x4,0xfffff],
+			'/amba/dma@ffaf0000':[0x4,0xfffff],
+			'/amba/dma@ffae0000':[0x4,0xfffff],
+			'/amba/dma@ffad0000':[0x4,0xfffff],
+			'/amba/dma@ffac0000':[0x4,0xfffff],
+			'/amba/dma@ffab0000':[0x4,0xfffff],
+			'/amba/dma@ffaa0000':[0x4,0xfffff],
+			'/amba/dma@ffa90000':[0x4,0xfffff],
+			'/amba/dma@ffa80000':[0x4,0xfffff],
+			'/memory@800000000':[0x7,0x38],
+			'/amba/rtc@f12a0000':[0x4,0xfffff],
+			'/amba/timer@ff0e0000':[0x4,0xfffff],
+			'/amba/usb@ff9d0000':[0x7,0x38],
+			'/amba/watchdog@fd4d0000':[0x7,0x38],
+			'/amba/gpio@ff0b0000':[0x4,0xfffff],
+			'/amba/gpio@f1020000':[0x4,0xfffff],
+			'/amba/spi@ff040000':[0x4,0xfffff],
+			'/amba/spi@ff050000':[0x4,0xfffff],
+			}
+
+			device_list = []
+
+			# set device list for apu domain
+			apu_domain_node = node.tree['/domains/apu_domain']
+		
+			# for each device in nodes_to_update:
+			# find node in tree with name
+			# generate phandle for that node
+			# add to prop the following: 'phandle nodes_to_update[info]'
+			for n in requirements.keys():
+				target_node = apu_domain_node.tree[n]
+				device_list.append(target_node.propval('phandle'))
+				device_list.append(requirements[n][0])
+				device_list.append(requirements[n][1])
+
+			device_list_prop = LopperProp(name='xilinx,subsystem-config',value=device_list)
+
+			apu_domain_node + device_list_prop
+			apu_domain_node.sync( apu_domain_node.tree.fdt )
+			";
+		};
+
+		lop_2_3_2 {
+			compatible = "system-device-tree-v1,lop,code-v1";
+			code = "
+			cpus_a72_node = node.tree['/cpus_a72']
+			new_phandle = cpus_a72_node.tree.phandle_gen()
+			newprop = LopperProp(name='phandle',value=new_phandle)
+			cpus_a72_node.phandle = new_phandle
+			cpus_a72_node + newprop
+			cpus_a72_node.sync( cpus_a72_node.tree.fdt )
+
+			# set cpus to reference the new phandle
+			apu_domain_node = node.tree['/domains/apu_domain']
+			apu_domain_node_cpus = apu_domain_node.propval('cpus')
+			apu_domain_node_cpus[0] = new_phandle
+			apu_domain_node['cpus'].value = apu_domain_node_cpus
+			";
+                };
+		lop_2_3_3 {
+			compatible = "system-device-tree-v1,lop,code-v1";
+			code = "
+			requirements = {
+			'/amba/pmcqspi@f1030000':[0x4,0xfffff],
+			'/amba/serial@ff000000':[0x5,0x38],
+			'/amba/serial@ff010000':[0x7,0x38],
+			'/amba/mailbox@ff330000':[0x4,0xfffff],
+			'/amba/mailbox@ff340000':[0x8104,0xfffff],
+			'/amba/mailbox@ff350000':[0x4,0xfffff],
+			'/amba/mailbox@ff360000':[0x4,0xfffff],
+			'/amba/mailbox@ff370000':[0x4,0xfffff],
+			'/amba/mailbox@ff380000':[0x4,0xfffff],
+			'/amba/mailbox@ff3a0000':[0x4,0xfffff],
+			'/amba/timer@ff0f0000':[0x7,0x1],
+			'/amba/serial@ff010000':[ 0x8707, 0x2],
+			'/amba/watchdog@fd4d0000':[ 0x7, 0x2],
+			'/amba/psv_tcm_global@ffe00000':[0x8304,0xfffff],
+			'/amba/psv_tcm_global@ffe20000':[0x8304,0xfffff],
+			'/amba/rtc@f12a0000':[ 0x4, 0xfffff],
+			'/cpus_r5/cpu@4':[ 0x8104, 0xfffff],
+			}
+
+			device_list = []
+
+			# set device list for apu domain
+			rpu0_domain_node = node.tree['/domains/rpu0_domain']
+		
+			# for each device in nodes_to_update:
+			# find node in tree with name
+			# generate phandle for that node
+			# add to prop the following: 'phandle nodes_to_update[info]'
+			for n in requirements.keys():
+				target_node = rpu0_domain_node.tree[n]
+				device_list.append(target_node.phandle)
+				device_list.append(requirements[n][0])
+				device_list.append(requirements[n][1])
+
+			device_list_prop = LopperProp(name='xilinx,subsystem-config',value=device_list)
+
+			rpu0_domain_node + device_list_prop
+			rpu0_domain_node.sync( rpu0_domain_node.tree.fdt )
+			";
+		};
+		lop_2_3_3_1 {
+			compatible = "system-device-tree-v1,lop,code-v1";
+			code = "
+			requirements = {
+			'/amba/pmcqspi@f1030000':[0x4,0xfffff],
+			'/amba/serial@ff000000':[0x5,0x38],
+			'/amba/mailbox@ff330000':[0x4,0xfffff],
+			'/amba/mailbox@ff340000':[0x4,0xfffff],
+			'/amba/mailbox@ff350000':[0x8104,0xfffff],
+			'/amba/mailbox@ff360000':[0x4,0xfffff],
+			'/amba/mailbox@ff370000':[0x4,0xfffff],
+			'/amba/mailbox@ff380000':[0x4,0xfffff],
+			'/amba/mailbox@ff3a0000':[0x4,0xfffff],
+			'/amba/timer@ff100000':[0x7,0x1],
+			'/amba/serial@ff010000':[ 0x8707, 0x4],
+			'/amba/watchdog@fd4d0000':[ 0x7, 0x4],
+			'/amba/psv_tcm_global@ffe90000':[0x8304,0xfffff],
+			'/amba/psv_tcm_global@ffeb0000':[0x8304,0xfffff],
+			'/amba/rtc@f12a0000':[ 0x4, 0xfffff],
+			'/cpus_r5/cpu@5':[ 0x8104, 0xfffff],
+			}
+
+			device_list = []
+
+			# set device list for apu domain
+			rpu1_domain_node = node.tree['/domains/rpu1_domain']
+		
+			# for each device in nodes_to_update:
+			# find node in tree with name
+			# generate phandle for that node
+			# add to prop the following: 'phandle nodes_to_update[info]'
+			for n in requirements.keys():
+				target_node = rpu1_domain_node.tree[n]
+				device_list.append(target_node.phandle)
+				device_list.append(requirements[n][0])
+				device_list.append(requirements[n][1])
+
+			device_list_prop = LopperProp(name='xilinx,subsystem-config',value=device_list)
+
+			rpu1_domain_node + device_list_prop
+			rpu1_domain_node.sync( rpu1_domain_node.tree.fdt )
+			";
+		};
+
+		lop_2_3_4 {
+			compatible = "system-device-tree-v1,lop,code-v1";
+			code = "
+			cpus_r5_node = node.tree['/cpus_r5']
+			new_phandle = cpus_r5_node.tree.phandle_gen()
+			newprop = LopperProp(name='phandle',value=new_phandle)
+			cpus_r5_node.phandle = new_phandle
+			cpus_r5_node + newprop
+			cpus_r5_node.sync( cpus_r5_node.tree.fdt )
+
+			# set cpus to reference the new phandle
+			rpu0_domain_node = node.tree['/domains/rpu0_domain']
+			rpu0_domain_node_cpus = rpu0_domain_node.propval('cpus')
+			rpu0_domain_node_cpus[0] = new_phandle
+			rpu0_domain_node['cpus'].value = rpu0_domain_node_cpus
+
+			# set cpus to reference the new phandle
+			rpu1_domain_node = node.tree['/domains/rpu1_domain']
+			rpu1_domain_node_cpus = rpu1_domain_node.propval('cpus')
+			rpu1_domain_node_cpus[0] = new_phandle
+			rpu1_domain_node['cpus'].value = rpu1_domain_node_cpus
+			";
+                };
+		lop_3_3 {
+			compatible = "system-device-tree-v1,lop,assist-v1";
+			node = "/domains";
+			id = "xlnx,output,cdo";
+			options = "subsystem.cdo";
+		};
+	};
+
+};

--- a/lops/lop-versal-vck190_split-xilpm_subsystem.dts
+++ b/lops/lop-versal-vck190_split-xilpm_subsystem.dts
@@ -29,6 +29,26 @@
 				cpus = <&cpus_r5 0x2 0x80000000>;
 			};
 		};
+		lop_2_2_3 {
+			compatible = "system-device-tree-v1,lop,code-v1";
+			code = "
+			root_node = node.tree['/']
+
+			rpu0_domain_node = node.tree['/domains/rpu0_domain']
+			new_phandle = root_node.tree.phandle_gen()
+			newprop = LopperProp(name='phandle',value=new_phandle)
+			rpu0_domain_node.phandle = new_phandle
+			rpu0_domain_node + newprop
+			rpu0_domain_node.sync( root_node.tree.fdt )
+
+			rpu1_domain_node = node.tree['/domains/rpu1_domain']
+			new_phandle = root_node.tree.phandle_gen()
+			newprop = LopperProp(name='phandle',value=new_phandle)
+			rpu1_domain_node.phandle = new_phandle
+			rpu1_domain_node + newprop
+			rpu1_domain_node.sync( root_node.tree.fdt )
+			";
+		};
 
 		lop_2_3_3 {
 			compatible = "system-device-tree-v1,lop,code-v1";

--- a/lops/lop-versal-vck190_sub_perms.dts
+++ b/lops/lop-versal-vck190_sub_perms.dts
@@ -1,0 +1,62 @@
+/dts-v1/;
+/ {
+	compatible = "system-device-tree-v1,lop";
+	lops {
+		/* for each domain, enable perms to the other domains */
+		lop_2_2_3 {
+			compatible = "system-device-tree-v1,lop,code-v1";
+			code = "
+			root_node = node.tree['/']
+			prop_name = 'xilinx,subsystem-config'
+
+			rpu0_domain_node = node.tree['/domains/rpu0_domain']
+			apu_domain_node = node.tree['/domains/apu_domain']
+
+			rpu0_prop = rpu0_domain_node[prop_name]
+			rpu0_reqs = rpu0_prop.value
+			rpu0_domain_node - rpu0_prop
+
+			apu_prop = apu_domain_node[prop_name]
+			apu_reqs = apu_prop.value
+			apu_domain_node - apu_prop
+
+
+			# split config for rpu
+			#rpu1_domain_node = node.tree['/domains/rpu1_domain']
+			#rpu1_prop = rpu1_domain_node[prop_name]
+			#rpu1_reqs = rpu1_prop.value
+			#rpu1_domain_node - rpu1_prop
+
+			#rpu0_reqs.append(rpu1_domain_node.phandle)
+			#rpu0_reqs.append(0x7) # non secure only
+			#rpu0_reqs.append(0x0) # expect third arg in lopper plugin
+			#rpu1_reqs.append(rpu0_domain_node.phandle)
+			#rpu1_reqs.append(0x7) # non secure only
+			#rpu1_reqs.append(0x0) # expect third arg in lopper plugin
+			#rpu1_reqs.append(apu_domain_node.phandle)
+			#rpu1_reqs.append(0x7) # non secure only
+			#rpu1_reqs.append(0x0) # expect third arg in lopper plugin
+
+			#rpu1_domain_node + LopperProp(prop_name, value = rpu1_reqs)
+			#rpu1_domain_node.sync( root_node.tree.fdt )
+
+
+			# apu to rpu0
+			rpu0_reqs.append(apu_domain_node.phandle)
+			rpu0_reqs.append(0x7) # non secure only
+			rpu0_reqs.append(0x0) # expect third arg in lopper plugin
+			apu_reqs.append(rpu0_domain_node.phandle)
+			apu_reqs.append(0x7) # non secure only
+			apu_reqs.append(0x0) # expect third arg in lopper plugin
+
+			apu_domain_node + LopperProp(prop_name, value = apu_reqs)
+			rpu0_domain_node + LopperProp(prop_name, value = rpu0_reqs)
+
+			rpu0_domain_node.sync( root_node.tree.fdt )
+			apu_domain_node.sync( root_node.tree.fdt )
+
+			";
+		};
+	};
+
+};


### PR DESCRIPTION
this patch does the following:
- re-enable cdo assist (presently xilinx versal support only)
- add lop file that:
  1. adds relevant domains
  2. for each domain, there are xilinx platform mgmt related nodes.
    a. associate these with the aforementioned domains
    b. for each node (device), ensure there is phandle for this node
       so it can be related to later
  3. in each domain, link each device to its specific xilinx platform mgmt
     flags
- retrofit cdo assist as follows:
  1. add lookup tables to hold xilinx-specific info
  2. parse domains, devices and the flags relating the devices to their domains
     and reflect this in output CDO

Signed-off-by: Ben Levinsky <ben.levinsky@xilinx.com>