### PR TITLE
lopper: Fix parser errors (NameError)

### DIFF
--- a/lopper.py
+++ b/lopper.py
@@ -33,6 +33,7 @@ from collections import OrderedDict
 
 from lopper_fdt import Lopper
 from lopper_fdt import LopperFmt
+from lopper_tree import LopperNode, LopperTree
 
 import lopper_rest
 


### PR DESCRIPTION
This commit fixes the below parser errors
by importing the proper functions.

1) NameError: name 'LopperTree' is not defined
2) NameError: name 'LopperNode' is not defined

Signed-off-by: Appana Durga Kedareswara rao <appana.durga.rao@xilinx.com>