### PR TITLE
Add support for board topology cdo generation

### DIFF
--- a/assists/cdo.py
+++ b/assists/cdo.py
@@ -27,6 +27,7 @@ from lopper_tree import *
 
 sys.path.append(os.path.dirname(__file__))
 from xlnx_versal_power import *
+from cdo_topology import *
 
 def props():
     return ["id", "file_ext"]
@@ -261,7 +262,10 @@ def cdo_write( domain_node, sdt, options ):
         verbose = 0
 
     if (len(options["args"]) > 0):
-      outfile = options["args"][0]
+      if re.match(options["args"][0], "regulator"):
+        outfile = options["args"][1]
+      else:
+        outfile = options["args"][0]
     else:
       print("cdo header file name not provided.")
       return -1
@@ -282,17 +286,20 @@ def cdo_write( domain_node, sdt, options ):
     # add subsystem
     domain_nodes = []
     cpu_nodes = []
-    for n in domain_node.subnodes():
-      if n.propval('access') != ['']:
-        cpu_node = add_subsystem(n, sdt, output)
-        if cpu_node == -1:
-          print("invalid cpu node for add_subsystem")
-          return False
-        elif cpu_node == 0:
-          continue
+    if re.match(options["args"][0], "regulator"):
+        gen_board_topology( domain_node, sdt, output )
+    else:
+        for n in domain_node.subnodes():
+            if n.propval('access') != ['']:
+                cpu_node = add_subsystem(n, sdt, output)
+                if cpu_node == -1:
+                    print("invalid cpu node for add_subsystem")
+                    return False
+                elif cpu_node == 0:
+                    continue
 
-        cpu_nodes.append(cpu_node)
-        domain_nodes.append(n)
+                cpu_nodes.append(cpu_node)
+                domain_nodes.append(n)
     for i in range(len(domain_nodes)):
       add_requirements(domain_nodes[i], cpu_nodes[i], sdt, output)
 

--- a/assists/cdo_topology.py
+++ b/assists/cdo_topology.py
@@ -1,0 +1,180 @@
+#/*
+# * Copyright (c) 2019,2020 Xilinx Inc. All rights reserved.
+# *
+# * Author:
+# *       Bruce Ashfield <bruce.ashfield@xilinx.com>
+# *       Naga Sureshkumar Relli <naga.sureshkumar.relli@xilinx.com>
+# *
+# * SPDX-License-Identifier: BSD-3-Clause
+# */
+
+import struct
+import sys
+import types
+import unittest
+import os
+import getopt
+import re
+import subprocess
+import shutil
+from pathlib import Path
+from pathlib import PurePath
+from io import StringIO
+import contextlib
+import importlib
+from lopper import Lopper
+import lopper
+from lopper_tree import *
+
+sys.path.append(os.path.dirname(__file__))
+from xlnx_versal_power import *
+from topology_headr import *
+
+def gen_board_topology( node, lt, output ):
+    global regulator_count
+    try:
+        verbose = options['verbose']
+    except:
+        verbose = 0
+
+    root_node = lt.tree[node]
+    cdo_tree = root_node.subnodes()
+    board_list = ["vck190"]
+    root_compat = lt.tree['/']['compatible'].value
+    board_name = [b for b in board_list for board in root_compat if b in board]
+    if not board_name:
+        print( "[ERROR]: No supported board provided: %s" % root_compat[0] )
+        sys.exit(1)
+
+    board = board_name[0]
+    regulator_arr = []
+    # This loop iterates twice, one for regulator cdo data and another for rail cdo data
+    mux_addr = None
+    regulator_count = 0
+    mux_count = 0
+    for n in cdo_tree:
+        if not n.name:
+            nodename = "root"
+            node_type= "root"
+        else:
+            nodename = n.name
+            # get the compatible string of the node, that's our "type", which we'll
+            # map to the CDO class, subclass and type fields.
+            node_type = n.type
+            tmp = n.name.split("@")
+            length = len(tmp)
+            if length > 1:
+                # get the mux_address, mux node starts with "i2c-mux"
+                if re.match( "i2c-mux", tmp[0]):
+                    mux_name = n.name
+                    mux_type = n.type[0]
+                    mux_addr = tmp[1]
+                    mux_count += 1
+
+        if node_type:
+            cdo_t = cdo_type( node_type )
+            # if cdo_t is not regulator, we will check for regulator-name property
+            # in the node, as per regulator.txt and gpio-regulator.txt node can have
+            # regulator-name property also.
+            # This is to check whether the node is regulator or not
+            try:
+                regulator_name = n['regulator-name'].value
+            except:
+                regulator_name = ""
+
+            reserved = 0
+            parent_count = 1
+            width = 0
+            shift = 0
+            if re.match( "regulator", cdo_t) or regulator_name != "":
+               bus_type = is_pmbus( node_type )
+               if bus_type == 1:
+                   ctrl_mthd = CTRL_MTHD_PMBUS
+               else:
+                   #TODO gpio control method
+                   ctrl_mthd = CTRL_MTHD_GPIO
+
+               parent = str(n.parent)
+               res = parent.rsplit('@', 1) #/amba/i2c@ff020000/i2c-mux@74/i2c@0, get the i2c channel address which is @0
+               # This is valid only for i2c regulators, where the it is under i2c node
+               # for GPIO regulators, it is just under /
+               try:
+                   mux_channel = int(res[1]) + 1
+               except:
+                   mux_channel = ""
+
+               mux_bytes = get_mux_bytes(mux_type) #Number of i2c bytes to configure the mux channel
+
+               # reg property is not valid for GPIO regulators
+               try:
+                   i2c_addr = n['reg'].value
+               except:
+                   i2c_addr = ""
+
+               # Get the lable name from the node
+               try:
+                   label = n['label'].value
+               except:
+                   label = ""
+
+               # label and regulator_name properties will be empty for PMBUS regulators
+               # and regulator_name will be present for GPIO regulators
+               # With this check, we say that it is Main regulator and generates regulator data
+               if (label == "" and regulator_name == "") or regulator_name != "":
+                   regulator_arr.append(n.name)
+                   regulator_count += 1
+
+               if (label == "" and regulator_name == "") or regulator_name != "":
+                   if ctrl_mthd == CTRL_MTHD_PMBUS:
+                       print("#Regulator: " + str(n.name) + " Mux: " + str(mux_name), file=output)
+                       print("#             <i2c address of Regulator:" + hex(i2c_addr[0]) + "> <Numberof Muxes: " + str(mux_count) + "> <Controlling Method(PMBus(0x1)/GPIO(0x2): " + str(ctrl_mthd) + ">", file=output)
+                       print("#             <NodeId of i2c controller:" + hex(PM_DEV_I2C_PM) + ">",  file=output)
+                       print("#             <Mux Channel:" + hex(mux_channel) + "> <i2c bytes:" + hex(mux_bytes) + "> <mux i2c address:" + str(mux_addr) + ">", file=output )
+                       print( "pm_add_node {0} {1}{2}{3} {4} {5}{6}{7}".format( f"0x442c00{regulator_count}", hex( i2c_addr[0] ), "%02x" % mux_count, "%02x" % ctrl_mthd, hex( PM_DEV_I2C_PM ), "0x%02x"  % mux_channel , "%02x" % mux_bytes, mux_addr), file=output )
+                   else:
+                       #GPIO control method
+                       #TODO Will be updated once we have support in code base
+                       print("#GPIO Regulator: " + str(n.name) , file=output)
+
+               else:
+                   node_id = rail_nodeid(label, board)
+                   if re.match(str(node_id), "0"):
+                           continue
+
+                   try:
+                       regulator_parent = n['parent-regulator'].value
+                   except:
+                       print("[ERROR]: No parent-regulator property found for %s" % label[0])
+                       sys.exit(1)
+
+                   reg_par = lt.FDT.node_offset_by_phandle(regulator_parent[0])
+                   ind = lt.FDT.get_name(reg_par)
+                   array_idx = regulator_arr.index(ind) + 1
+
+                   pgood = is_pgood( node_type )
+
+                   page_nr = n['page-number'].value #Rail line
+                   page_nr = int(page_nr[0])
+
+                   #0x442c00: XPM_NODECLASS_POWER
+                   #          XPM_NODESUBCL_POWER_REGULATOR
+                   #          XPM_NODETYPE_POWER_REGULATOR
+                   #          XPM_NODEIDX_POWER_REGULATOR_0
+                   parent_reg_id = f"0x442c00{array_idx}"
+
+                   print("#Rail: " + str(label[0]) + " and Parent: " + str(ind), file=output)
+                   print("#           <Pgood(0x2)/PMBus(0x1): " + hex( pgood ) + "> <Parent Regulator Id: " + str(parent_reg_id) + "> <Modes supported: " + hex(MODES_SUPPORTED) + ">", file=output)
+                   print("#           <RailOFF data:          <i2c_cmnds:" + hex( MODE_OFF_I2C_CMNDS ) + "> <mode_rail_off: " + hex(MODE_OFF_COMMAND) + ">", file=output)
+                   print("#                                   <cmnd_bytes:" + hex( NUMOF_I2C_CMND_BYTES ) + "> <Page number: " + hex(page_nr) + "> <Page command: " + hex(PAGE_COMMAND) + "> <cmnd_byts: " + hex(NUMOF_I2C_CMND_BYTES) + ">", file=output)
+                   print("#                                   <Operation_OFF:" + hex( ON_OFF_OPERATION_COMMAND ) + "> <cmnd_bytes: " + hex(NUMOF_I2C_CMND_BYTES) + "> <Payload: " + hex(ON_OFF_CONFIG_DATA_BYTE) + "> <ON_OFF_cmd: " + hex(ON_OFF_CONFIG_COMMAND) + "> <Operation_off" +hex( OPERATION_OFF_COMMAND ) + ">", file=output)
+                   print("#           <RailON data:           <i2c_cmnds:" + hex( MODE_ON_I2C_CMNDS ) + "> <mode_rail_off: " + str(MODE_ON_COMMAND) + ">", file=output)
+                   print("#                                   <cmnd_bytes:" + hex( NUMOF_I2C_CMND_BYTES ) + "> <Page number: " + hex(page_nr) + "> <Page command: " + hex(PAGE_COMMAND) + "> <cmnd_bytes: " + hex(NUMOF_I2C_CMND_BYTES) + ">", file=output)
+                   print("#                                   <Operation_OFF:" + hex( ON_OFF_OPERATION_COMMAND ) + "> <cmnd_bytes: " + hex(NUMOF_I2C_CMND_BYTES) + "> <Payload: " + hex(ON_OFF_CONFIG_DATA_BYTE) + "> <ON_OFF_cmd: " + hex(ON_OFF_CONFIG_COMMAND) + "> <Operation_off:" +hex( OPERATION_ON_COMMAND ) + ">", file=output)
+
+                   print( "pm_add_node {0} {1} {2} {3} {4}{5} {6}{7}{8}{9} {10}{11}{12}{13} {14} {15}{16} {17}{18}{19}{20} {21}{22}{23}{24} {25}".format( node_id, hex( pgood ), parent_reg_id , hex( MODES_SUPPORTED), hex( MODE_OFF_I2C_CMNDS), "%02x" % MODE_OFF_COMMAND, "0x%02x" % NUMOF_I2C_CMND_BYTES, "%02x" % int(page_nr), "%02x" % PAGE_COMMAND, "%02x" % NUMOF_I2C_CMND_BYTES, "0x%02x"  % ON_OFF_OPERATION_COMMAND , "%02x" % NUMOF_I2C_CMND_BYTES, "%02x" % ON_OFF_CONFIG_DATA_BYTE, "%02x" % ON_OFF_CONFIG_COMMAND, hex( OPERATION_OFF_COMMAND ), "0x%02x" % MODE_ON_I2C_CMNDS, "%02x" % MODE_ON_COMMAND, "0x%02x" % NUMOF_I2C_CMND_BYTES, "%02x" % int(page_nr), "%02x" % PAGE_COMMAND, "%02x" % NUMOF_I2C_CMND_BYTES, "0x%02x" % ON_OFF_OPERATION_COMMAND, "%02x" % NUMOF_I2C_CMND_BYTES, "%02x" % ON_OFF_CONFIG_DATA_BYTE, "%02x" % ON_OFF_CONFIG_COMMAND, "0x%02x" % OPERATION_ON_COMMAND), file=output )
+
+        else:
+            # TODO: we don't handle other than regulators
+            continue
+
+    return True

--- a/assists/topology_headr.py
+++ b/assists/topology_headr.py
@@ -1,0 +1,134 @@
+#/*
+# * Copyright (c) 2019,2020 Xilinx Inc. All rights reserved.
+# *
+# * Author:
+# *       Bruce Ashfield <bruce.ashfield@xilinx.com>
+# *       Naga Sureshkumar Relli <naga.sureshkumar.relli@xilinx.com>
+# *
+# * SPDX-License-Identifier: BSD-3-Clause
+# */
+
+from pathlib import Path
+from pathlib import PurePath
+import lopper
+from lopper_tree import *
+
+sys.path.append(os.path.dirname(__file__))
+import cdotypes
+
+#Power Nodes
+PM_DEV_I2C_PM = 0x1822402d
+PM_POWER_VCCINT_PMC = 0x4328029
+PM_POWER_VCCAUX_PMC = 0x432802a
+PM_POWER_VCCINT_PSLP = 0x432802b
+PM_POWER_VCCINT_PSFP = 0x432802c
+PM_POWER_VCCINT_SOC = 0x432802d
+PM_POWER_VCCINT_RAM = 0x432802e
+PM_POWER_VCCAUX = 0x432802f
+PM_POWER_VCCINT_PL = 0x4328030
+
+#Power Rail modes supported(ON or OFF)
+MODES_SUPPORTED = 0x2
+MODE_OFF_COMMAND = 0x0
+MODE_ON_COMMAND = 0x1
+MODE_OFF_I2C_CMNDS = 0x3
+MODE_ON_I2C_CMNDS = 0x3
+
+#PMBUS commands
+PAGE_COMMAND = 0x0
+ON_OFF_CONFIG_COMMAND = 0x2
+ON_OFF_OPERATION_COMMAND = 0x1
+OPERATION_OFF_COMMAND = 0x0
+OPERATION_ON_COMMAND = 0x80
+
+#Number of I2C command bytes
+NUMOF_I2C_CMND_BYTES = 0x2
+
+#Data to pass for ON_OFF_CONFIG Command
+ON_OFF_CONFIG_DATA_BYTE = 0x1a
+
+#Regulator control method
+CTRL_MTHD_PMBUS = 0x1
+CTRL_MTHD_GPIO = 0x2
+
+# map a device tree "type" to a cdo nodeid/type list
+cdo_nodetype = {
+                 "ti,ina226" : "regulator",
+                 "infineon,irps5401" : "regulator",
+                 "infineon,ir38164" : "regulator"
+               }
+
+# These are the regulator devices which supports pgood option
+pgood_devices = { "TPS65400" }
+
+#These are the PMBUS supported regulators
+pmbus_regulators = {"infineon,irps5401",
+                     "infineon,ir38164"}
+
+#Global regulator count, which is used to generate regulator index
+regulator_count = 0
+
+#Number Mux bytes
+mux_bytes = {"nxp,pca9548": 1}
+
+# vck190 power rail macros as mentioned in xpm_node.h
+# {board: {rail: id}
+rail_to_nodeid = { 'vck190':
+                            {'vcc-pslp': '0x432802b',
+                             'vcc-psfp': '0x432802c',
+                             'vccaux': '0x432802f',
+                             'vcc-ram': '0x432802e',
+                             'vcc-soc': '0x432802d',
+                             'vccint': '0x4328030',
+                             'vcc-pmc': '0x4328029',
+                             'vccaux-pmc': '0x432802a'}
+                  }
+
+def get_mux_bytes( mux_type ):
+    for key in mux_bytes:
+       if re.match(key, mux_type):
+           return mux_bytes[key]
+
+    # If no supported Mux found, the default to 1 bytes
+    return 1
+
+def is_pmbus( node_type ):
+    bus_type = 0
+    for type in pmbus_regulators:
+        if re.match(type, node_type[0]):
+            return 1
+
+    return bus_type
+
+def rail_nodeid( label, board):
+    value = 0x0
+    for p_id, p_info in rail_to_nodeid.items():
+        if re.match(p_id, board):
+            for key in p_info:
+                val = label[0].split("-",1)[-1]
+                if val in key:
+                    value = p_info[key]
+                    return value
+
+    return value
+
+def is_pgood(node_type):
+    for type in pgood_devices:
+        if re.match(type, node_type[0]):
+            pgood = 2
+        else:
+            pgood = 1
+
+    return pgood
+
+# map a compatible string to a cdo type
+def cdo_type( device_tree_type ):
+    try:
+        x = cdo_nodetype[device_tree_type]
+    except:
+        x = "unknown_type"
+        for k in cdo_nodetype.keys():
+            if re.search( k, str(device_tree_type) ):
+                x = cdo_nodetype[k]
+
+    return x

--- a/lops/lop-versal-regulator-cdo.dts
+++ b/lops/lop-versal-regulator-cdo.dts
@@ -1,0 +1,14 @@
+/dts-v1/;
+/ {
+	compatible = "system-device-tree-v1,lop";
+	lops {
+
+		lop_3_3 {
+			compatible = "system-device-tree-v1,lop,assist-v1";
+			node = "/";
+			id = "xlnx,output,cdo";
+			options = "regulator topology_board.cdo";
+		};
+	};
+
+};


### PR DESCRIPTION
This patch adds board topology cdo generation support to configure the
regulator rails.
We created a new lop file lop-versal-regulator-cdo.dts which contains
options argument as "regulator topology_board.cdo".
Here the options[0] which is regulator is to differentiate which cdo
the user is asking about and
the options[1] which is topology_board.cdo is the cdo file name.

The input to the lopper is system device tree which contains i2c
regulators information which will be parsed by cdo_topology.py.

The topology_headr.py contains all PM command and other macros required
to generated CDO data.

Signed-off-by: Naga Sureshkumar Relli <naga.sureshkumar.relli@xilinx.com>