### PR TITLE
Revert "lops: lop-domain-a72: in code block only remove bram. ipis ma…

### DIFF
--- a/lops/lop-domain-a72.dts
+++ b/lops/lop-domain-a72.dts
@@ -59,15 +59,35 @@
                 lop_8 {
                       compatible = "system-device-tree-v1,lop,code-v1";
                       code = "
-                        # delete bram
-                          for node1 in node.subnodes():
-                              prop_val = node1.propval('compatible')
-                              if prop_val != ['']:
-                                  for compat_str in prop_val:
-                                      if 'xlnx,axi-bram-ctrl' in compat_str:
-                                          print('removing node ',node1)
-                                          tree.delete(node1)
-                        ";
+                          node_list = []
+                          address_map = node.parent['address-map'].value
+                          na = node.parent['#ranges-address-cells'].value[0]
+                          ns = node.parent['#ranges-size-cells'].value[0]
+                          cells = na + ns
+                          phandles = []
+                          tmp = na
+                          while tmp < len(address_map):
+                              phandles.append(address_map[tmp])
+                              tmp = tmp + cells + na + 1
+                          phandles = list(dict.fromkeys(phandles))
+                          for s in tree.__selected__:
+                              if not re.search('cpu.*', s.abs_path):
+                                  node_list.append(s)
+                          # Delete the unmapped nodes for a72
+                          invalid_nodes = []
+                          for node1 in node_list:
+                              match = 0
+                              for handle in phandles:
+                                  if handle == node1.phandle:
+                                      if not re.search('xlnx,zynqmp-ipi-mailbox', node1['compatible'].value[0]):
+                                          match += 1
+                              if match == 0:
+                                  invalid_nodes.append(node1)
+                              if re.search('xlnx,axi-bram-ctrl', node1['compatible'].value[0]):
+                                  invalid_nodes.append(node1)
+                          for node1 in invalid_nodes:
+                              tree.delete(node1)
+                      ";
                 };
         };
 };


### PR DESCRIPTION
…y be used"

This reverts commit 0e7d43a3ba9dc4ba3377c6434c629b1e909ac123.
Reverting this as Linux boot is hanging due to IPI nodes.
This patch is actually removes the IPI nodes that are not used by
Linux.

Signed-off-by: Naga Sureshkumar Relli <naga.sureshkumar.relli@xilinx.com>