### PR TITLE
assists: baremetal_gentestapp_xlnx: Fix race condition in files_list generation

### DIFF
--- a/assists/baremetal_gentestapp_xlnx.py
+++ b/assists/baremetal_gentestapp_xlnx.py
@@ -129,7 +129,7 @@ def xlnx_generate_testapp(tgt_node, sdt, options):
                                             except KeyError:
                                                 has_hwdep = 0
 
-                                            if not os.path.isfile(destination) and not has_hwdep:
+                                            if not has_hwdep:
                                                 shutil.copyfile(filename, destination)
                                                 file_fd.write(destination)
                                                 file_fd.write("\n")
@@ -138,7 +138,6 @@ def xlnx_generate_testapp(tgt_node, sdt, options):
                                                     content.insert(0, "#define TESTAPP_GEN\n")
                                                     fd.seek(0, 0)
                                                     fd.writelines(content)
-                                            if not has_hwdep:
                                                 dec.append(testapp_schema[app]['declaration'])
                                         testapp_data.update({label_name:dec})
                                         testapp_name.update({label_name:drvname})
@@ -176,6 +175,11 @@ def xlnx_generate_testapp(tgt_node, sdt, options):
     plat.buf('\treturn 0;\n')
     plat.buf('}')
     os.chdir(tmpdir)
+    # Remove duplicate lines
+    with open('file_list.txt', 'r') as f:
+        unique_lines = set(f.readlines())
+    with open('file_list.txt', 'w') as f:
+        f.writelines(unique_lines)
     plat.out(''.join(plat.get_buf()))
 
     return True

--- a/assists/baremetallinker_xlnx.py
+++ b/assists/baremetallinker_xlnx.py
@@ -53,6 +53,8 @@ def get_memranges(tgt_node, sdt, options):
         except:
            pass
 
+    versal_noc_ch_ranges =  {"DDR_CH_1": "0x50000000000", "DDR_CH_2": "0x60000000000", "DDR_CH_3": "0x70000000000"}
+
     # Yocto Machine to CPU compat mapping
     match_cpunodes = get_cpu_node(sdt, options)
    
@@ -101,9 +103,19 @@ def get_memranges(tgt_node, sdt, options):
                 valid_range = [addr for addr in addr_list if reg == addr or addr > reg]
                 if valid_range:
                     key = match[0].replace("-", "_")
-                    linker_secname = key + str("_") + str(xlnx_memipname[key])
+                    is_valid_noc_ch = 0
+                    if "axi_noc" in key:
+                        for ch_name, ran in sorted(versal_noc_ch_ranges.items(), reverse=True):
+                            if ran <= hex(valid_range[0]):
+                                is_valid_noc_ch = ch_name
+                                break
+
+                    if is_valid_noc_ch:
+                        linker_secname = key + str("_") + is_valid_noc_ch
+                    else:
+                        linker_secname = key + str("_") + str(xlnx_memipname[key])
+                        xlnx_memipname[key] += 1
                     mem_ranges.update({linker_secname: [valid_range[0], size]})
-                    xlnx_memipname[key] += 1
         except KeyError:
             pass
 


### PR DESCRIPTION
While generating the peripheral test meta-data existing logic
is not properly updating the driver example names in the file_list
text file, When running the assist file multiple times.

This commit fixes the above-mentioned issue.

Signed-off-by: Appana Durga Kedareswara rao <appana.durga.rao@xilinx.com>