### PR TITLE
assists: baremetal*: Handle /bits/ value as properly

### DIFF
--- a/assists/baremetal_xparameters_xlnx.py
+++ b/assists/baremetal_xparameters_xlnx.py
@@ -212,6 +212,8 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
                             except KeyError:
                                 prop_val = [0]
 
+                            if ('/bits/' in prop_val):
+                                prop_val = [int(prop_val[-1][3:-1], base=16)]
                             prop = prop.replace("-", "_")
                             prop = prop.replace("xlnx,", "")
                             if len(prop_val) > 1:

--- a/assists/baremetalconfig_xlnx.py
+++ b/assists/baremetalconfig_xlnx.py
@@ -566,6 +566,9 @@ def xlnx_generate_bm_config(tgt_node, sdt, options):
                 except KeyError:
                     prop_val = [0]
 
+                if ('/bits/' in prop_val):
+                    prop_val = [int(prop_val[-1][3:-1], base=16)]
+
                 if len(prop_val) > 1:
                     plat.buf('\n\t\t{')
                     for k,item in enumerate(prop_val):


### PR DESCRIPTION
When the device-tree node property contains the value in
/bits/ format, Standalone driver expects the property value
which is represented in the last nibble.

This commit updates the logic for the same.

Signed-off-by: Appana Durga Kedareswara rao <appana.durga.rao@xilinx.com>