### PR TITLE
xlate-yaml and readme fixes

### DIFF
--- a/README
+++ b/README
@@ -24,7 +24,7 @@ processing and manipulating device trees. These tools must be installed and
 on the PATH.
 
 Note: (python cpp) pcpp is optional (available on PyPi), and if not available cpp
-      will be used for preprossing input files. If comments are to be maintained
+      will be used for pre-processing input files. If comments are to be maintained
       through the processing flow, pcpp must be used since it has functionality to
       not strip them during processing.
 
@@ -79,11 +79,11 @@ This flag indicates that lopper should perform pre-processing and output phandle
 mapping to restore both comments, labels and symbolic phandles to the final
 output.
 
-Note: By default Lopper puts preprocessed files (.pp) into the same directory as
+Note: By default Lopper puts pre-processed files (.pp) into the same directory as
 the system device tree. This is required, since in some cases when the .pp files
 and device tree are not in the same directory, dtc cannot resolve labels from
 include files, and will error. That being said, if the -O option is used to
-specify an output directory, the preprocessed file will be placed there. If we
+specify an output directory, the pre-processed file will be placed there. If we
 get into a mode where the system device tree's directory is not writeable, or
 the -O option is breaking symbol resolution, then we'll have to either copy
 everything to the output directory, or look into why dtc can't handle the split

--- a/README-architecture.txt
+++ b/README-architecture.txt
@@ -18,7 +18,7 @@ format of the files, and libraries to manipulate the tree can change in the
 future without the inputs and outputs differing.
 
 Currently, Lopper operates on dtb files. It does not parse or otherwise
-manipulate source dts files (except for preprocessing). Lopper uses libfdt for
+manipulate source dts files (except for pre-processing). Lopper uses libfdt for
 operations on these files, and uses the standard dtc tools to prepare the files
 for manipulation.
 
@@ -33,7 +33,7 @@ The flow of lopper processing is broken into the following broad categories:
   - input file normalization with standard tools
 
     Lopper processes input files by invoking a standard pipeline of processing
-    on dts files using standard tools. pcpp (or cpp) is used for preprocessing and
+    on dts files using standard tools. pcpp (or cpp) is used for pre-processing and
     expansion, and dtc is used to compile dts inputs into dtbs. Lopper is
     somewhat tolerant of incomplete dts inputs, and will use forced dtc
     compilation to ensure that dtbs are generated (with the assumption that the
@@ -44,7 +44,7 @@ The flow of lopper processing is broken into the following broad categories:
 
     Note that lopper operations file can be passed directly as dtb files, and
     applied to the tree, but the system device tree and other device tree
-    fragments must be source (so they can be preprocessed and concatenated
+    fragments must be source (so they can be pre-processed and concatenated
     as needed).
 
   - operation runqueue execution
@@ -131,7 +131,7 @@ output formats, but operate on the LopperTree/Lopper data structures. It is this
 separation that allows Lopper to abstract both the tree and convert between the
 various formats.
 
-To aid decoding and intepretation of properties carried in a LopperTree, if a
+To aid decoding and interpretation of properties carried in a LopperTree, if a
 node has been created from yaml, the LopperNode field '_source' is set to "yaml"
 (otherwise it is "dts").
 
@@ -283,7 +283,7 @@ The following types of lops are currently valid:
                         compatible = "system-device-tree-v1,lop,modify";
                         # finds the target phandle (modify_val), which can either be in
                         # this tree, or the system device tree, and looks up the property
-                        # following '#', that value is used as the replement. If no property
+                        # following '#', that value is used as the replacement. If no property
                         # is provided, then the value is changed to the phandle target.
                         modify = "/memory@800000000:reg:&modify_val#reg";
                         modify_val {

--- a/assists/subsystem.py
+++ b/assists/subsystem.py
@@ -103,7 +103,7 @@ def firewall_expand( tree, subnode, verbose = 0 ):
 
         # the first item is "block" (0) and the second is the priority (default 0), so
         # we use <0 0>
-        firewall_prop = LopperProp( "firewallconfig-default", -1, subnode.parent, [ 0, 0 ] )
+        firewall_prop = LopperProp( "firewallconf-default", -1, subnode.parent, [ 0, 0 ] )
         subnode.parent + firewall_prop
         # delete our node, it has been converted to a property
         subnode.tree - subnode

--- a/lops/lop-xlate-yaml.dts
+++ b/lops/lop-xlate-yaml.dts
@@ -43,8 +43,12 @@
                               compatible = "system-device-tree-v1,lop,code-v1";
                               inherit = "subsystem";
                               code = "
-                                    for n in __selected__:
-                                        n['compatible'] = [ 'xilinx,subsystem-v1', 'openamp,domain-v1' ]
+                                    for i, d in enumerate(__selected__):
+                                        d['compatible'] = [ 'xilinx,subsystem-v1', 'openamp,domain-v1' ]
+                                        name = d.name
+                                        # flip the name and label
+                                        d.label = name
+                                        d.name = 'subsystem@{}'.format(i)
                         ";
                       };
                 };


### PR DESCRIPTION
This PR mainly has some pre-requisite changes required for protection plugin and a couple minor fixes for typos and readme.

Summary:
 - fixes for typos in xlate-yaml and readme
 - xlate-yaml: fix generation of subsystem node names and labels