### PR TITLE
assists: baremetal*: Remove references to sdt.FDT handling

### DIFF
--- a/assists/baremetal_xparameters_xlnx.py
+++ b/assists/baremetal_xparameters_xlnx.py
@@ -144,7 +144,7 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
                             canondef_dict.update({prop:node[prop].value[0]})
                         elif prop == "interrupts":
                             try:
-                                intr = get_interrupt_prop(sdt.FDT, node, node[prop].value)
+                                intr = get_interrupt_prop(sdt, node, node[prop].value)
                                 plat.buf('\n#define XPAR_%s_%s %s' % (label_name, prop.upper(), intr[0]))
                                 canondef_dict.update({prop:intr[0]})
                             except KeyError:

--- a/assists/bmcmake_metadata_xlnx.py
+++ b/assists/bmcmake_metadata_xlnx.py
@@ -145,10 +145,7 @@ def getmatch_nodes(sdt, node_list, yamlfile, options):
     return driver_nodes
 
 def getxlnx_phytype(sdt, value):
-    child_node = sdt.FDT.node_offset_by_phandle(value[0])
-    name = sdt.FDT.get_name(child_node)
-    root_sub_nodes = sdt.tree['/'].subnodes()
-    child_node = [node for node in root_sub_nodes if re.search(name, node.name)]
+    child_node = [node for node in sdt.tree['/'].subnodes() if node.phandle == value[0]]
     phy_type = child_node[0]['xlnx,phy-type'].value[0]
     return hex(phy_type)
 
@@ -212,7 +209,7 @@ def generate_hwtocmake_medata(sdt, node_list, src_path, repo_path, options):
                            topology_data.append(val)
                            topology_data.append(lwiptype_index)
                     elif prop == "interrupts":
-                       val = get_interrupt_prop(sdt.FDT, node, node[prop].value)
+                       val = get_interrupt_prop(sdt, node, node[prop].value)
                        val = val[0]
                     elif prop == "axistream-connected":
                        val = hex(get_phandle_regprop(sdt, prop, node[prop].value))


### PR DESCRIPTION
Inorder to support PDT (parsed device-tree) SDT.FDT calls
shouldn't be used in the assist files.

This commit updates the assist for the same.

@zeddii : After this commit still we are using sdt.FDT calls at two places in baremetal assists,
1) sdt.FDT.get_alias (Couldn't able to find equivalent API in lopper tree)
2) Lopper.node_properties_as_dict(sdt.FDT) (This can be resolved need to look into lopper front end..)
