### PR TITLE
assists: baremetal*: Bug fixes

### DIFF
--- a/assists/baremetal_xparameters_xlnx.py
+++ b/assists/baremetal_xparameters_xlnx.py
@@ -35,7 +35,7 @@ def is_compat( node, compat_string_to_test ):
     return ""
 
 def get_label(sdt, symbol_node, node):
-    prop_dict = Lopper.node_properties_as_dict(sdt.FDT, symbol_node.abs_path, False)
+    prop_dict = symbol_node.__props__
     match = [label for label,node_abs in prop_dict.items() if re.match(node_abs[0], node.abs_path) and len(node_abs[0]) == len(node.abs_path)]
     if match:
         return match[0]
@@ -233,7 +233,6 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
     # Generate Defines for Generic Nodes
     node_list = get_mapped_nodes(sdt, node_list, options)
     for node in node_list:
-        prop_dict = Lopper.node_properties_as_dict(sdt.FDT, node.abs_path)
         label_name = get_label(sdt, symbol_node, node)
         label_name = label_name.upper()
         try:

--- a/assists/baremetalconfig_xlnx.py
+++ b/assists/baremetalconfig_xlnx.py
@@ -281,8 +281,8 @@ def is_compat(node, compat_string_to_test):
 
 def get_stdin(sdt, chosen_node, node_list):
     prop_val = chosen_node['stdout-path'].value
-    serial_node = sdt.FDT.get_alias(prop_val[0].split(':')[0])
-    match = [x for x in node_list if re.search(x.name, serial_node)]
+    serial_node = sdt.tree.alias_node(prop_val[0].split(':')[0])
+    match = [x for x in node_list if re.search(x.name, serial_node.name)]
     return match[0]
 
 def get_mapped_nodes(sdt, node_list, options):

--- a/assists/baremetallinker_xlnx.py
+++ b/assists/baremetallinker_xlnx.py
@@ -182,7 +182,7 @@ def xlnx_generate_bm_linker(tgt_node, sdt, options):
     ## To inline with existing tools point default ddr for linker to lower DDR
     lower_ddrs = ["axi_noc_0", "psu_ddr_0", "ps7_ddr_0"]
     has_ddr = [x for x in mem_ranges.keys() for ddr in lower_ddrs if re.search(ddr, x)]
-    if has_ddr:
+    if has_ddr and not memtest_config:
         default_ddr = has_ddr[0]
 
     with open(cmake_file, 'a') as fd:

--- a/lops/lop-domain-a72.dts
+++ b/lops/lop-domain-a72.dts
@@ -40,11 +40,6 @@
                         compatible = "system-device-tree-v1,lop,modify";
                         modify = "/memory@fffc0000::";
                 };
-                lop_7 {
-                        // modify to "nothing", is a remove operation
-                        compatible = "system-device-tree-v1,lop,modify";
-                        modify = "/tcm_bus::";
-                };
                 lop_9 {
 			compatible = "system-device-tree-v1,lop,code-v1";
 			code = "

--- a/lops/lop-domain-linux-a53.dts
+++ b/lops/lop-domain-linux-a53.dts
@@ -16,17 +16,17 @@
                 lop_0 {
                         // node name modify
                         compatible = "system-device-tree-v1,lop,modify";
-                        modify = "/cpus_a53/::/cpus/";
+                        modify = "/cpus-a53@0/::/cpus/";
                 };
                 lop_1 {
                         // modify to "nothing", is a remove operation
                         compatible = "system-device-tree-v1,lop,modify";
-                        modify = "/cpus_r5::";
+                        modify = "/cpus-r5@1::";
                 };
                 lop_2 {
                         // modify to "nothing", is a remove operation
                         compatible = "system-device-tree-v1,lop,modify";
-                        modify = "/cpus_microblaze::";
+                        modify = "/cpus_microblaze@1::";
                 };
                 lop_3 {
                         // modify to "nothing", is a remove operation


### PR DESCRIPTION
This pull request does the below
1) Fix sdt.FDT checks in baremetal assist files 
2) Fix race condition in baremetal linker assist for memory test
3) Update A72 domain lops file as per latest system device-tree generated by the device-tree-generator tool 
4) Update A53 linux domain lops file as per latest system device-tree generated by the device-tree-generator tool 