### PR TITLE
lops: lop-domain-a72: do not prune TCM nodes

### DIFF
--- a/lops/lop-domain-a72.dts
+++ b/lops/lop-domain-a72.dts
@@ -55,17 +55,5 @@
                         ";
 
                 };
-                lop_10 {
-                        compatible = "system-device-tree-v1,lop,modify";
-                        modify = "/amba/psv_r5_tcm@0000::";
-                };
-                lop_11 {
-                        compatible = "system-device-tree-v1,lop,modify";
-                        modify = "/amba/psv_r5_tcm@20000::";
-                };
-                lop_12 {
-                        compatible = "system-device-tree-v1,lop,modify";
-                        modify = "/amba/psv_r5_tcm@00000::";
-                };
         };
 };


### PR DESCRIPTION
as the TCM nodes have changed in generated SDT do not prune now deprecated nodes

Signed-off-by: Ben Levinsky <ben.levinsky@xilinx.com>