### PR TITLE
lops: lop-domain-linux-a53: lops: Remove unneeded bram memory node

### DIFF
--- a/lops/lop-domain-linux-a53.dts
+++ b/lops/lop-domain-linux-a53.dts
@@ -73,6 +73,8 @@
                                           match += 1
                               if match == 0:
                                   invalid_nodes.append(node1)
+                              if re.search('xlnx,axi-bram-ctrl', node1['compatible'].value[0]):
+                                  invalid_nodes.append(node1)
                           for node1 in invalid_nodes:
                               tree.delete(node1)
                       ";


### PR DESCRIPTION
For Linux domain only ddr memory node is valid,
This commit removes the unneeded bram memory nodes from
the system device-tree.

Signed-off-by: Appana Durga Kedareswara rao <appana.durga.rao@xilinx.com>