### PR TITLE
lops: lop-domain-linux-a53: Select all the memory nodes

### DIFF
--- a/lops/lop-domain-linux-a53.dts
+++ b/lops/lop-domain-linux-a53.dts
@@ -39,6 +39,7 @@
                       select_1;
                       select_2 = "/cpus/.*:compatible:.*arm,cortex-a53.*";
                       select_3 = "/.*:status:.*okay.*";
+                      select_4 = "/.*:device_type:.*memory.*";
                 };
                 lop_5 {
                         // modify to "nothing", is a remove operation


### PR DESCRIPTION
Inorder to delete the axi bram memory node, we need
to select all the memory nodes in a given system device-tree,

Commit dac94bbf8302 missed this logic,
This commit updates the same.

Signed-off-by: Appana Durga Kedareswara rao <appana.durga.rao@xilinx.com>
