### PR TITLE
lops: lop-domain-a72: prune certain TCM nodes for Versal Linux boot

### DIFF
--- a/lops/lop-domain-a72.dts
+++ b/lops/lop-domain-a72.dts
@@ -84,6 +84,11 @@
                         for i in n.subnodes():
                             if i.propval('compatible') == ['xlnx,axi-dma-mm2s-channel'] or i.propval('compatible') == ['xlnx,axi-dma-s2mm-channel']:
                                 tree.delete(i)
+                        n = node.tree['/amba']
+                        for i in n.subnodes():
+                            if i.propval('compatible') == ['xlnx,psv-r5-tcm'] or 'xlnx,psv-r5-tcm' in i.propval('compatible'):
+                                tree.delete(i)
+
 			";
 		};
 


### PR DESCRIPTION
Currently for Versal Linux boot there is issue with multiple nodes of the same
name being created for boot and this causes small kernel crash.

Remove these nodes to fix this issue

Signed-off-by: Ben Levinsky <ben.levinsky@xilinx.com>