### PR TITLE
lops: lop-domain-linux-a53: Disable SMMU node

### DIFF
--- a/lops/lop-domain-linux-a53.dts
+++ b/lops/lop-domain-linux-a53.dts
@@ -80,5 +80,10 @@
                               tree.delete(node1)
                       ";
                 };
+                lop_7 {
+                        compatible = "system-device-tree-v1,lop,modify";
+                        // Disable SMMU Node
+                        modify = "/smmu@fd800000:status:disabled";
+                };
         };
 };


### PR DESCRIPTION
To Inline with the existing flow disable the smmu node
for zynqmp linux domain use case.

Signed-off-by: Appana Durga Kedareswara rao <appana.durga.rao@xilinx.com>