### PR TITLE
xlnx: xppu/xmpu: add permitted apertures for boot protections

### DIFF
--- a/assists/xlnx/protections.py
+++ b/assists/xlnx/protections.py
@@ -955,12 +955,29 @@ def setup_mem_ftb_entry(subsystem):  # Subsystem() object
             if dom_or_ss_name not in prot_map.ss_or_dom:
                 # print("Skipping dom/ss:", dom_or_ss_name, "for", pm_name)
                 continue
+
             # print("[DBG++++]", prot_map.ss_or_dom[dom_or_ss_name])
             for bus_mid_name, smid in prot_map.ss_or_dom[dom_or_ss_name][1]:
                 if priority not in bus_mids:
                     bus_mids[priority] = []
+
                 bus_mids[priority].append(
                     ftb.MidEntry(smid, 0x3FF, name=bus_mid_name))
+
+            # TODO: Remove hardcoding in future (this should come from domains.yaml)
+            # Allow firmware masters needed for each region
+            bus_mids[priority].append(
+                ftb.MidEntry(xppu.MIDL["PMC_DMA0"][0],
+                             xppu.MIDL["PMC_DMA0"][1],
+                             name="PMC_DMA0"))
+            bus_mids[priority].append(
+                ftb.MidEntry(xppu.MIDL["PMC_DMA1"][0],
+                             xppu.MIDL["PMC_DMA1"][1],
+                             name="PMC_DMA1"))
+            # Needed for booting from OCM
+            bus_mids[priority].append(
+                ftb.MidEntry(0x268, 0x3FF, name="APU-NonCPU"))
+
 
         if debug > 0:
             print(


### PR DESCRIPTION
Due to a few platform specific dependencies at boot, there is a need to open up few protected regions for specific masters. Without this, the boot will not work on the platform. These protected regions are referred to as "RegNodes" (or Register Nodes).

Currently, there is no S-DT/YAML specification available to express protections for RegNodes. Due to this, the output CDO directly needs to be patched with hardcoded entries so the boot will function. These will be removed in later when the gaps in the specification are resolved.

Signed-off-by: Izhar Shaikh <izhar.ameer.shaikh@xilinx.com>