### PR TITLE
spec: remove resource-groups

### DIFF
--- a/specification/domains-yaml.md
+++ b/specification/domains-yaml.md
@@ -11,8 +11,7 @@ representation of System Device Tree domains (/domains).
 Hierarchy
 ---------
 
-Resource groups nodes are not under /domains but under
-/resource\_groups; domains are under /domains.
+Domains are under /domains.
 
 All domains, even nested domains, are specified under a "domain" key.
 
@@ -32,7 +31,7 @@ Example:
 ~~~
   access:
       - dev: serial0
-        flags: dev_ns_req
+        flags: {read-only: true}
 ~~~
 
 
@@ -40,9 +39,8 @@ Memory and Sram
 ---------------
 
 The memory and sram properties to specify the memory and sram
-allocations to a domain (or shared under a resource\_group) are
-specified in YAML using start and size key: value pairs to increase
-readability.
+allocations to a domain are specified in YAML using start and size key:
+value pairs to increase readability.
 
 Example:
 
@@ -50,7 +48,7 @@ Example:
   sram:
       - start: 0xfffc0000
         size: 0x1000
-        flags: sharedmem
+        flags: {read-only: true}
 ~~~
 
 
@@ -85,25 +83,19 @@ Flags
 In YAML the following simplifications are used for access, memory, and
 sram flags definitions and usage:
 
-- To define flags, instead of two separate flags and flags-names
-  properties, use key: value pairs under a top "flags" key.
+- To define flags  use key: value pairs
 
 - When defining flags values, give individual flags setting a name
   rather than just a number, e.g. use read-only instead of (1<<2). The
   name and corresponding numeric values should be specified in lopper.
 
-- Instead of \*-flags-names, use a "flags" key: value pair.
+- no \*-flags-cells
 
 ~~~
 
-  flags:
-    rodev:
-      requested: true
-      read-only: true
-
   access:
       - dev: can0
-        flags: rodev
+        flags: {requested: true, read-only: true}
 
 ~~~
 
@@ -141,13 +133,6 @@ Full Example
 ------------
 
 ~~~
-resource_groups:
-    resource_group1:
-        sram:
-            - start: 0xfffc0000
-              size: 0x1000
-              flags: sharedmem
-
 domains:
     xen:
         compatible: openamp,domain-v1
@@ -163,13 +148,11 @@ domains:
             - start: 0x500000
               size: 0x7fb00000
 
-        flags:
-            dev_ns_req: { xen-flag-example1: true }
-            sharedmem: { read-only: true }
-
         access:
             - dev: serial0
-              flags: dev_ns_req
+              flags: { xen-flag-example1: true }
+            - dev: mmc0
+              flags: { xen-flag-example1: true }
 
         domains:
             linux1:
@@ -186,9 +169,10 @@ domains:
                     - size: 1G
                 access:
                     - dev: mmc0
-                      flags: dev_ns_req
-                include:
-                    - resource_group1
+                sram:
+                    - start: 0xfffc0000
+                      size: 0x1000
+                      flags: { read-only: true }
                 firewallconf:
                     domain: bm1
                     block: 0x12
@@ -207,7 +191,6 @@ domains:
                     - size: 512M
                 access:
                     - dev: ethernet0
-                      flags: dev_ns_req
                 firewallconf:
                     domain: linux1
                     block: always
@@ -238,6 +221,8 @@ domains:
             - size: 1M
         access:
             - dev: serial1
-        include:
-            - resource_group1
+        sram:
+            - start: 0xfffc0000
+              size: 0x1000
+              flags: { read-only: true }
 ~~~

--- a/specification/os,types.md
+++ b/specification/os,types.md
@@ -1,0 +1,92 @@
+os,types
+========
+
+Execution domains can have an optional "os,type" property to capture one
+or more operating systems that may run on the domain. The field may be
+used by automated tooling for activities, such as verifying that the
+domain is capable of running the operating system, configuring a build
+system to produce the proper operating system, configure a storage
+mechanism to include the specified operating system, or other purposes.
+
+The value of "os,type" is a string defined in the format:
+
+	OS_TYPE[,TYPE_ID[,TYPE_ID_VERSION]]
+
+OS\_TYPE is mandatory and explains what the type of the operating system
+will be. The values for this are defined as follows. In order to add
+additional types, the specification should be updated.
+
+	OS_TYPE:
+	   baremetal
+	   linux
+	   freertos
+	   zyphyr
+	   custom
+	   x-<vendor>[-os]
+
+*baremetal* refers to a direct application that executes on the system
+with no conventional operating system. Examples of this may include
+first stage boot loader, second stage boot loader, u-boot,
+arm-trusted-firmware, etc.
+
+*linux* refers to a Linux based operating system. Examples of this may
+include Yocto Project derived, Red Hat, Ubuntu, etc.
+
+*freertos* refers to FreeRTOS real-time operating system.
+
+*zyphyr* refers to Zephyr operating system.
+
+*custom* refers to a user specific operating system. Custom is to be
+used only by the group providing the custom implementation. Each usage
+of custom will be different.
+
+*x-\<vendor\>[-os]* refers to an extension of a non-registered vendor
+specific operating system.  The 'x' refers to extension, which is
+attempts to avoid namespace collisions by convention. At a minimum the
+name space must be x-\<vendor\>, such as x-xilinx.  However, the vendor
+name may not be a specific enough namespace to avoid collision, so an
+optional "-os" is allowed as well.  The \<vendor\> controls the
+namespace of "os" values, if they are used.  For instance Wind River
+VxWorks could be specified using: x-windriver-vxworks.
+
+It is recommended that a vendor register their operating system in the
+official named list, only using the extension format until it is
+official.
+
+The *TYPE_ID* is specific to each OS\_TYPE, but is not currently
+formalized. The purpose of this is to further clarify details on the
+OS\_TYPE if desired. For instance, to specify Ubuntu Linux, use:
+linux,ubuntu
+
+As *TYPE_ID* is not yet formalized it is open for different usages by
+different parties. It's recommended that groups work together to define
+common values where appropriate.
+
+The *TYPE_ID_VERSION* is an optional parameter that is allowed, only if
+the TYPE\_ID is used, and it's purpose is to specify the version of the
+TYPE\_ID.  In the prior example of "linux,ubuntu", it may be specified
+"linux,ubuntu,18.04".
+
+As with *TYPE_ID*, this may be open to namespace collisions, and is
+again recommended that groups work together to define common values
+where appropriate.
+
+
+Examples:
+
+	os,type = "linux"
+	
+	os,type = "linux,ubuntu,18.04"
+	
+	os.type = "linux,ubuntu,18.04.01"
+	
+	os,type = "linux,yocto"
+	
+	os,type = "linux,yocto,gatesgarth"
+	
+	os.type = "baremetal"
+	
+	os.type = "baremetal,fsbl"
+	
+	os.type = "baremetal,newlib,3.3.0"
+

--- a/specification/remoteproc.md
+++ b/specification/remoteproc.md
@@ -1,8 +1,5 @@
 # OpenAMP RemoteProc
 
-This extension is still a DRAFT.
-
-
 OpenAMP RemoteProc is a framework for remote processor communication and
 lifecycle management between Linux and other OSes.
 
@@ -22,7 +19,7 @@ similar plugins to generate their RemoteProc device tree nodes.
 At the System Device Tree level, no special nodes or properties are
 needed to represent RemoteProc information. Typically, the main cluster
 and the remote cluster are separate domains. Any shared resources are
-represented as a resource-group, as usual with system device tree.
+repeated under all domains that can access them.
 
 Special vendor-specific properties can be represented using the access
 list flag fields, as usual with system device tree.
@@ -34,127 +31,194 @@ list flag fields, as usual with system device tree.
 This is a System Device Tree example that can be used as input for
 lopper to generate RemoteProc nodes for Linux.
 
-The things to note are:
+~~
 
-- resource\_group@0 to share resources
-- the 0x13 access flags for ipi\_mailbox\_rpu0, the specific
-  meaning is expressed in a comment below
-- the sharedmem flag, which is defined as 0x1 for openamp_a53, which
-  means master, and as 0x0 for openamp_r5, which means slave.
-
+Example in YAML:
 
 ~~~
-	psu_r5_0_atcm_global: psu_tcm_global@ffe00000 {
-		xlnx,s-axi-highaddr = <0xFFE0FFFF>;
-		compatible = "xlnx,psu-tcm-global";
-		status = "okay";
-		reg = <0x0 0xffe00000 0x0 0x10000>;
-		firewall-0 = <&lpd_xppu>;
-		xlnx,s-axi-baseaddr = <0xFFE00000>;
-	};
-	psu_r5_0_btcm_global: psu_tcm_global@ffe20000 {
-		xlnx,s-axi-highaddr = <0xFFE2FFFF>;
-		compatible = "xlnx,psu-tcm-global";
-		status = "okay";
-		reg = <0x0 0xffe20000 0x0 0x10000>;
-		firewall-0 = <&lpd_xppu>;
-		xlnx,s-axi-baseaddr = <0xFFE20000>;
-	};
+definitions:
+    OpenAMP:
 
-	zynqmp_ipi@0 {
-		 compatible = "xlnx,zynqmp-ipi-mailbox";
-		 interrupt-parent = <&gic>;
-		 interrupts = <0 29 4>;
-		 xlnx,ipi-id = <7>;
-		 #address-cells = <1>;
-		 #size-cells = <1>;
-		 ranges;
+        openamp-channel-0-access-srams: &openamp-channel0-access-srams # used for access in each domain
+            - dev: psu_r5_0_atcm_global
+            - dev: psu_r5_0_btcm_global
 
-		 /* APU<->RPU0 IPI mailbox controller */
-		 ipi_mailbox_rpu0: mailbox@ff90000 {
-			reg = <0xff990600 0x20>,
-			      <0xff990620 0x20>,
-			      <0xff9900c0 0x20>,
-			      <0xff9900e0 0x20>;
-			reg-names = "local_request_region",
-				    "local_response_region",
-				    "remote_request_region",
-				    "remote_response_region";
-			#mbox-cells = <1>;
-			xlnx,ipi-id = <1>;
-		 };
-	};
+        openamp-channel-1-access-srams: &openamp-channel1-access-srams # used for access in each domain
+            - dev: psu_r5_1_atcm_global
+            - dev: psu_r5_1_btcm_global
 
-	domains {
-		#address-cells = <0x2>;
-		#size-cells = <0x2>;
+        rproc1: &rproc_reserved1
+            compatible: xilinx,openamp-ipc-1.0
+            no-map: 1
+            reg:
+                - start: 0x3ed00000
+                  size: 0x40000
 
-		resource_group: resource_group@0 {
-			compatible = "openamp,remoteproc-v1", "openamp,group-v1";
-			memory = <0x0 0x3ed40000 0x0 0x4000
-				  0x0 0x3ed44000 0x0 0x4000
-				  0x0 0x3ed48000 0x0 0x100000
-				  0x0 0x3ed00000 0x0 0x40000
-			memory-flags-names = "sharedmem";
-			sram = <&psu_r5_0_btcm_global>, <&psu_r5_0_atcm_global>;
-			sram-flags-names = "sharedmem";
-		};
+        rproc0: &rproc_reserved0
+            compatible: xilinx,openamp-ipc-1.0
+            no-map: 1
+            reg:
+                - start: 0x3ed00000
+                  size: 0x40000
 
-		openamp_a53 {
-			compatible = "openamp,domain-v1";
-			#address-cells = <0x2>;
-			#size-cells = <0x2>;
+        rpu1vdev0vring: &rpu1vdev0vring0
+            compatible: xilinx,openamp-ipc-1.0
+            no-map: 1
+            reg:
+                - start: 0x3ed40000
+                  size: 0x4000
 
-			id = <0x3>;
-			memory = <0x0 0x80000000 0x0 0x78000000
-				  0x8 0x0 0x0 0x80000000>;
-			cpus = <&cpus_a53 0xf 0x2>;
+        rpu1vdev0vring1: &rpu1vdev0vring1
+            compatible: xilinx,openamp-ipc-1.0
+            no-map: 1
+            reg:
+                - start: 0x3ed44000
+                  size: 0x4000
 
-			/*
-			 * Flags field, mapping specific
-			 *
-			 * memory and reserved-memory:
-			 *   bit 0: 0/1: RO/RW
-			 *
-			 * xlnx,zynqmp-ipi-mailbox:
-			 *   4 bits for each IPI channel to pass special flags
-			 *   0-3   bits: channel 0
-			 *   4-7   bits: channel 1
-			 *   8-11  bits: channel 2
-			 *   12-15 bits: channel 3
-			 * each 4 bits:
-			 *   bit 0: enable/disable (enable==1)
-			 *   bit 1: TX/RX (TX==1)
-			 *   bit 2-3: unused
-			 *
-			 * Other cases: unused 
-			 *
-			 */
-			#flags-cells = <1>;
-			flags = <0x13 0x1>;
-			flags-names = "rpu0", "sharedmem";
-			access = <&ipi_mailbox_rpu0>;
-			access-flags-names = "rpu0";
+        rpu1vdev0buffer: &rpu1vdev0buffer
+            compatible: xilinx,openamp-ipc-1.0
+            no-map: 1
+            reg:
+                - start: 0x3ed48000
+                  size: 0x100000
 
-			include = <&resource_group>;
-		};
+        rproc_reserved1: &rproc_reserved11
+            compatible: xilinx,openamp-ipc-1.0
+            no-map: 1
+            reg:
+                - start: 0x3ed00000
+                  size: 0x40000
 
-		openamp_r5 {
-			compatible = "openamp,domain-v1";
-			#address-cells = <0x2>;
-			#size-cells = <0x2>;
+        rpu0vdev0vring: &rpu0vdev0vring0
+            compatible: xilinx,openamp-ipc-1.0
+            no-map: 1
+            reg:
+                - start: 0x3ed40000
+                  size: 0x4000
 
-			id = <0x4>;
-			memory = <0x0 0x0 0x0 0x20000000>;
-			cpus = <&cpus_r5 0x2 0x80000000>;
+        rpu0vdev0vring1: &rpu0vdev0vring1
+            compatible: xilinx,openamp-ipc-1.0
+            no-map: 1
+            reg:
+                - start: 0x3ed44000
+                  size: 0x4000
 
-			#flags-cells = <1>;
-			flags = <0x0>;
-			flags-names = "sharedmem";
+        rpu0vdev0buffer: &rpu0vdev0buffer
+            compatible: xilinx,openamp-ipc-1.0
+            no-map: 1
+            reg:
+                - start: 0x3ed48000
+                  size: 0x100000
 
-			include = <&resource_group>;
-		};
-	};
+
+domains:
+    openamp_a72_0_cluster: # host in channel from a72-0 to r5-1 over channel 0
+        compatible: openamp,domain-v1
+        cpus:
+            - cluster: cpus_a72
+              cpumask: 0x1
+              mode:
+                 secure: false
+                 el: 0x1
+        access:
+            # if we want to have a list merge, it should be in a list
+            - dev: ipi0  # used for Open AMP RPMsg IPC
+            - <<+: [ *openamp-channel0-access-srams, *openamp-channel1-access-srams ]
+            - <<+: *openamp-channel1-access-srams # TCM banks used for elf load
+
+        reserved-memory:
+            ranges: true
+            # if we want an object / node merge, it should be like this (a map)
+            - <<+: [*rpu0vdev0vring0, *rpu0vdev0vring1, *rpu0vdev0buffer, *rproc_reserved0 ]
+            - <<+: [*rpu1vdev0vring0, *rpu1vdev0vring1, *rpu1vdev0buffer, *rproc_reserved1 ]
+
+        domain-to-domain:
+            compatible: openamp,domain-to-domain-v1
+
+            remoteproc0:
+                compatible: openamp,remoteproc-v1
+                remote: openamp_r5_0_cluster
+                elfload:
+                     - rproc_reserved0
+                     - openamp-channel-0-access-srams
+
+            remoteproc1:
+                compatible: openamp,remoteproc-v1
+                remote: openamp_r5_1_cluster
+                elfload:
+                     - rproc_reserved1
+                     - openamp-channel-1-access-srams
+
+            rpmsg0:
+                compatible: openamp,rpmsg-v1
+                openamp-xlnx-native: true # use native OpenAMP implementation
+                remote:  openamp_r5_0_cluster
+                mbox: ipi0
+                carveouts:
+                   - rpu0vdev0buffer
+                   - rpu0vdev0vring0
+                   - rpu0vdev0vring1
+
+
+            rpmsg1:
+                compatible: openamp,rpmsg-v1
+                openamp-xlnx-native: true # use native OpenAMP implementation
+                remote:  openamp_r5_1_cluster
+                mbox: ipi0
+                carveouts:
+                   - rpu1vdev0buffer
+                   - rpu1vdev0vring0
+                   - rpu1vdev0vring1
+
+    openamp_r5_0_cluster:
+        compatible: openamp,domain-v1
+        cpus:
+            - cluster: cpus_r5
+              cpumask: 0x1
+              mode:
+              secure: true
+        access:
+            - dev: ipi2
+            - <<+: *openamp-channel0-access-srams # TCM banks used for firmware memory
+        reserved-memory:
+            ranges: true
+            <<+: [ *rpu0vdev0vring0, *rpu0vdev0vring0, *rpu0vdev0buffer, *rproc_reserved0 ]
+        domain-to-domain:
+             compatible: openamp,domain-to-domain-v1
+             rpmsg0:
+                 compatible: openamp,rpmsg-v1
+                 host: openamp_a72_0_cluster
+                 mbox: ipi2
+                 carveouts:
+                    - rpu0vdev0buffer
+                    - rpu0vdev0vring0
+                    - rpu0vdev0vring1
+
+    openamp_r5_1_cluster:
+        compatible: openamp,domain-v1
+        cpus:
+            - cluster: cpus_r5
+              cpumask: 0x2
+              mode:
+              secure: true
+        access:
+            - dev: ipi3
+            - <<+: *openamp-channel1-access-srams # TCM banks used for firmware memory
+        reserved-memory:
+            ranges: true
+            <<+: [ *rpu1vdev0vring0, *rpu1vdev0vring0, *rpu1vdev0buffer, *rproc_reserved1 ]
+        domain-to-domain:
+             compatible: openamp,domain-to-domain-v1
+             relation0:
+                 compatible: openamp,rpmsg-v1
+                 host: openamp_a72_0_cluster
+                 mbox: ipi3
+                 carveouts:
+                    - rpu1vdev0buffer
+                    - rpu1vdev0vring0
+                    - rpu1vdev0vring1
+
+
 ~~~
 
 
@@ -164,11 +228,11 @@ The corresponding Device Tree for Linux generated by lopper is the
 following. (It is compliant to the latest RemoteProc Xilinx bindings
 upstream.)
 
-- the reserved-memory regions are generated from the regions under resource\_group@0 in system device tree
+- the reserved-memory regions are copied from the reserved-memory subnode of a domain.
 - r5ss@f9a00000:
     - xlnx,cluster-mode comes from the cpus property of the RPU domain
-    - memory-region and sram properties come from resource\_group@0
-	- mboxes and mbox-names come from the access property and the 0x13 flag
+    - memory-region and sram properties come from the shared regions
+    - mboxes and mbox-names come from the access property and the 0x13 flag
 
 ~~~
 	reserved-memory {
@@ -196,6 +260,27 @@ upstream.)
 			no-map;
 			reg = <0x3ed00000 0x40000>;
 		};
+
+		rpu1vdev0vring0: rpu1vdev0vring0@3ef40000 {
+			compatible = "xilinx,openamp-ipc-1.0";
+			no-map;
+			reg = <0x3ef40000 0x4000>;
+		};
+		rpu1vdev0vring1: rpu1vdev0vring1@3ef44000 {
+			compatible = "xilinx,openamp-ipc-1.0";
+			no-map;
+			reg = <0x3ef44000 0x4000>;
+		};
+		rpu1vdev0buffer: rpu1vdev0buffer@3ef48000 {
+			compatible = "xilinx,openamp-ipc-1.0";
+			no-map;
+			reg = <0x3ef48000 0x100000>;
+		};
+		rproc_1_reserved: rproc@3ef000000 {
+			compatible = "xilinx,openamp-ipc-1.0";
+			no-map;
+			reg = <0x3ef00000 0x40000>;
+		};
 	};
 
 	r5ss@f9a00000 {
@@ -208,17 +293,28 @@ upstream.)
 
 		r5f_0 {
 			compatible = "xilinx,r5f";
-			memory-region = <&elf_load0>,
-							 <&rpu0vdev0vring0>,
-							 <&rpu0vdev0vring1>,
-							 <&rpu0vdev0buffer>;
+			memory-region = <&rproc_0_reserved0>,
+					<&rpu0vdev0vring0>,
+					<&rpu0vdev0vring1>,
+					<&rpu0vdev0buffer>;
 			sram = <&psu_r5_0_atcm_global>, <&psu_r5_0_btcm_global>;
 			mboxes = <&ipi_mailbox_rpu0 0x0 &ipi_mailbox_rpu0 0x1>;
 			mbox-names = "tx", "rx";
 			power-domain = <0x7>;
 		};
-	};
 
+		r5f_1 {
+			compatible = "xilinx,r5f";
+			memory-region = <&rproc_1_reserved1>,
+					<&rpu1vdev0vring0>,
+					<&rpu1vdev0vring1>,
+					<&rpu1vdev0buffer>;
+			sram = <&psu_r5_1_atcm_global>, <&psu_r5_1_btcm_global>;
+			mboxes = <&ipi_mailbox_rpu1 0x0 &ipi_mailbox_rpu1 0x1>;
+			mbox-names = "tx", "rx";
+			power-domain = <0x8>;
+		};
+	};
 	psu_r5_0_atcm_global: psu_tcm_global@ffe00000 {
 		compatible = "xlnx,psu-tcm-global";
 		status = "okay";
@@ -228,6 +324,17 @@ upstream.)
 		compatible = "xlnx,psu-tcm-global";
 		status = "okay";
 		reg = <0x0 0xffe20000 0x0 0x10000>;
+	};
+
+	psu_r5_1_atcm_global: psu_tcm_global@ffe90000 {
+		compatible = "xlnx,psu-tcm-global";
+		status = "okay";
+		reg = <0x0 0xffe90000 0x0 0x10000>;
+	};
+	psu_r5_1_btcm_global: psu_tcm_global@ffeb0000 {
+		compatible = "xlnx,psu-tcm-global";
+		status = "okay";
+		reg = <0x0 0xffeb0000 0x0 0x10000>;
 	};
 
 	zynqmp_ipi@0 {
@@ -252,5 +359,20 @@ upstream.)
 			#mbox-cells = <1>;
 			xlnx,ipi-id = <1>;
 		 };
+	
+		 /* APU<->RPU1 IPI mailbox controller */
+		 ipi_mailbox_rpu1: mailbox@ff90000 {
+			reg = <0xff990800 0x20>,
+			      <0xff990820 0x20>,
+			      <0xff990ec0 0x20>,
+			      <0xff990ee0 0x20>;
+			reg-names = "local_request_region",
+				    "local_response_region",
+				    "remote_request_region",
+				    "remote_response_region";
+			#mbox-cells = <1>;
+			xlnx,ipi-id = <2>;
+		 };
+		
 	};
 ~~~

--- a/specification/specification.md
+++ b/specification/specification.md
@@ -217,6 +217,42 @@ range for each execution domain. Software configurations are explained
 below.
 
 
+Secure Addresses
+================
+
+It is possible for a single device to be accessible at different
+addresses whether the transaction is marked as secure or non-secure.
+
+The normal world address range of the device is specified used "reg" as
+usual. If the device comes with a different address range for secure
+world accesses then it can be specified using "secure-reg":
+
+
+		timer@ff110000 {
+			compatible = "cdns,ttc";
+			status = "okay";
+
+			reg = <0x0 0xff110000 0x0 0x1000>;
+			secure-reg = <0x1 0xff110000 0x00 0x1000>;
+		};
+
+
+CPU clusters specify the secure address map with "secure-address-map",
+for instance:
+
+
+	/* additional R5 cluster */
+	cpus_r5: cpus-cluster@0 {
+		compatible = "cpus,cluster";
+
+		/* specifies address mappings */
+		address-map = <0x0 0xf9000000 &amba_rpu 0x0 0xf9000000 0x0 0x10000>;
+
+		/* specifies secure world address mappings */
+		secure-address-map = <0x1 0xf9000000 &amba_rpu 0x1 0xf9000000 0x0 0x10000>;
+	};
+
+
 Execution Domains
 =================
 
@@ -231,21 +267,17 @@ software architect.
 
 Execution domains are expressed by a new node "openamp,domain"
 compatible. Being a configuration rather than a description, their
-natural place is under /chosen or under a similar new top-level node. In
-this example, I used /domains:
+natural place is under a new top-level node /domains:
 
 
 	domains {
 		openamp_r5 {
 			compatible = "openamp,domain-v1";
 			cpus = <&cpus_r5 0x2 0x80000000>;
-			#flags-cells = <1>;
-			flags = <0x0 0x1 0x0>;
-			flags-names = "dev_rw", "dev_ro", "mem_rw";
+			#memory-flags-cells = <0>;
 			memory = <0x0 0x0 0x0 0x8000000>;
-			memory-flags-names = "mem_rw";
-			access = <&can@ff060000 &ethernet@ff0c0000>;
-			access-flags-names = "dev_rw", "dev_ro";
+			#access-flags-cells = <1>;
+			access = <&can@ff060000 0x3 &ethernet@ff0c0000 0x7>;
 			id = <0x1>;
 		};
 	};
@@ -253,23 +285,15 @@ this example, I used /domains:
 
 An openamp,domain node contains information about:
 - cpus: physical cpus on which the software is running on
-- #flags-cells (optional): number of cells to specify flags for each
-  flag group in the flags property, the flags are used to specify
-  accessibility properties
-- flags (optional): a list of flags groups, each flag group has
-  #flags-cells number of cells
-- flags-names (optional): a list of strings giving names to flag groups,
-  one name for each flag group
+- #access-flags-cells (optional): how many cells to specify special access for each
+  device, if absent the default is zero
 - access: any devices configured to be only accessible by a domain
-- access-flags-names: a list of flag group names, one for each device.
-  The names correspond to the flags groups names specified under
-  flags-names.
+- #memory-flags-cells (optional): how many cells to specify special
+  access flags for each memory range, if absent the default is zero
 - memory: memory assigned to the domain
-- memory-flags-names (optional): names of the flags group for each
-  memory region
+- #sram-flags-cells (optional): how many cells to specify special
+  access flags for each memory range, if absent the default is zero
 - sram (optional): sram regions assigned to the domain
-- sram-flags-names (optional): names of the flags group for each sram
-  region
 - id: a 32bit integer that identifies a domain
 
 cpus is in the format: link-to-cluster cpu-mask execution-level
@@ -285,36 +309,32 @@ For Cortex-A53/A72 CPUs, execution-level is:
 - bit 31: secure (1) / non-secure (0)
 - bits 0-1: EL0 (0x0), EL1 (0x1), or EL2 (0x2)
 
+The execution level is the most privileged level that the domain can
+make use of. If the execution level is secure, then "secure-reg"
+addresses (when specified) are used when the domain accesses device
+memory mapped regions.
 
 access is list of links to devices. The links are to devices that are
 configured to be only accessible by an execution domain, using bus
-firewalls or similar technologies. For each link to a device, a
-corresponding flags group name is specified with the access-flags-names
-property. They are specified in order, the first name corresponds to the
-first device in the access list. access-flags-names strings correspond
-to the strings under flags-names, which in turn corresponds to flags
-groups under flags. In other words, for each string in
-access-flags-names, there is a set of flags under flags.
-access-flags-names is optional, if it is missing no flags are specified
-for any of the devices.
+firewalls or similar technologies. Each link to a device can be followed
+by one or more cells that defined access flags. The number of cells is
+defined by #access-flags-cells and can be zero of no flags are to be
+specified.
 
-memory is a sequence of start, size tuples. #address-cells and
+memory is a sequence of start, size, flags tuples. #address-cells and
 #size-cells express how many cells are used to specify start and size
-respectively. For each range there might be a flags group name specified
-with the memory-flags-names property. memory-flags-names strings
-correspond to the strings under flags-names, which in turn corresponds
-to flags groups under flags. memory-flags-names is optional, if it is
-missing no flags are specified for any of the memory ranges.
+respectively. #memory-flags-cells specifies how many cells are used to
+specify access flags and can be zero.
 
-sram, like memory, is a sequence of start, size tuples. However, the
-sram ranges should be subsets or matching mmio-sram ranges.
-sram-flags-names strings correspond to the strings under flags-names,
-which in turn corresponds to flags groups under flags.  sram-flags-names
-is optional, if it is missing no flags are specified for any of the sram
-ranges.
+sram, like memory, is a sequence of start, size, flags tuples. However,
+the sram ranges should be subsets or matching mmio-sram ranges.
+#sram-flags-cells specifies how many cells are used to specify access
+flags and can be zero.
 
-Access flags are domain specific.
-
+Access flags are domain specific and have default values defined in
+the System Device Tree specification for each domain type. Different
+domains types have different compatible strings, in addition to
+"openamp,domain".
 
 The memory range assigned to an execution domain is expressed by the
 memory property. It needs to be a subset of the physical memory in the
@@ -356,7 +376,7 @@ clusters from /cpus. We can do that with /reserved-memory:
 		};
 	};
 
-The purpose of memory_r5@0 is to let the default execution domain know
+The purpose of memory\_r5@0 is to let the default execution domain know
 that it shouldn't use the 0x0-0x8000000 memory range because it is
 reserved for use by other domains.
 
@@ -373,3 +393,35 @@ place for the default execution domain. As an example:
 	/domains/openamp_r5/chosen -> configuration for the domain "openamp_r5"
 	/domains/openamp_r5/reserved-memory -> reserved memory for "openamp_r5"
 
+Execution domains can have an optional "os,type" property, see
+os,types.md.
+
+
+Implicit flags
+==============
+
+It is possible to specify default flags values at the domain level using
+thei following properties:
+
+- #access-implicit-default-cells
+- access-implicit-default
+
+- #memory-implicit-default-cells
+- memory-implicit-default
+
+- #sram-implicit-default-cells
+- sram-implicit-default
+
+Each property specifies the default value for the access, memory and
+sram flags for their domain. The number of cells to use is provided by
+the #access-implicit-default-cells, #memory-implicit-default-cells, and
+#sram-implicit-default-cells properties.
+
+Example:
+
+~~~
+	#access-implicit-default-cells = <1>;
+	access-implicit-default = <0xff00ff>;
+	#access-flags-cells = <0x0>;
+	access = <&mmc0>;
+~~

--- a/specification/system-device-tree.dts
+++ b/specification/system-device-tree.dts
@@ -743,65 +743,73 @@
 	domains {
 		#address-cells = <0x2>;
 		#size-cells = <0x2>;
-		
-		resource_group_1: resource_group_1 {
-			compatible = "openamp,group-v1";
 
-			access = <&ethernet0, &serial0>;
+		subsystem1: domain@1 {
+			compatible = "xilinx,subsystem-v1", "openamp,domain-v1";
 
-            /* 1: block */
-			firewallconfig-default = <1 0>;
-		};
-	
-		resource_group_2: resource_group_2 {
-			compatible = "openamp,group-v1";
-
-			memory = <0x0 0x500000 0x0 0x1000>;
-		};
-
-		xen: domain@2 {
-			compatible = "openamp,domain-v1";
-
-			cpus = <&cpus_a72 0x3 0x00000002>;
+			/*
+			 * When the domain is a xilinx,subsystem, then the specified
+			 * CPU level is expected to be the highest possible in the
+			 * cluster.
+			 *
+			 * bit 0-3: EL
+			 * bit 31: secure/non-secure
+			 */
+			cpus = <&cpus_a72 0x3 0x80000003>;
 			memory = <0x0 0x500000 0x0 0x7fb00000>;
-			id = <0xffff>;
 
-			linux1: domain@3 {
+			#access-flags-cells = <1>;
+			access = <&mmc0 0x1>;
+			id = <0x3>;
+
+			/* 2: block-desirable */
+			firewallconfig-default = <2 8>;
+
+			xen: domain@2 {
 				compatible = "openamp,domain-v1";
 
-				cpus = <&cpus_a72 0x3 0x00000001>;
-				memory = <0x0 0x501000 0x0 0x3faff000>;
-				id = <0x0>;
-
+				cpus = <&cpus_a72 0x3 0x00000002>;
+				memory = <0x0 0x500000 0x0 0x7fb00000>;
+				id = <0xffff>;
+				#access-flags-cells = <0>;
 				access = <&mmc0>;
-				include = <&resource_group_2>;
-			};
 
-			linux2: domain@4 {
-				compatible = "openamp,domain-v1";
+				linux1: domain@3 {
+					compatible = "openamp,domain-v1";
 
-				cpus = <&cpus_a72 0x3 0x00000001>;
-				memory = <0x0 0x40000000 0x0 0x40000000>;
-				id = <0x1>;
+					cpus = <&cpus_a72 0x3 0x00000001>;
+					memory = <0x0 0x501000 0x0 0x3faff000
+							  0x0 0x500000 0x0 0x1000>;
+					id = <0x0>;
 
-				include = <&resource_group_1, &resource_group_2>;
-				/* 1: block */
-				firewallconfig = <&linux1 1 0>;
+					#access-flags-cells = <0>;
+					access = <&mmc0>;
+				};
+
+				linux2: domain@4 {
+					compatible = "openamp,domain-v1";
+
+					cpus = <&cpus_a72 0x3 0x00000001>;
+					memory = <0x0 0x40000000 0x0 0x40000000
+							  0x0 0x500000 0x0 0x1000>;
+					id = <0x1>;
+
+					access = <&ethernet0 &serial0>;
+					/* 1: block */
+					firewallconfig = <&linux1 1 0>;
+				};
 			};
 		};
 
-		domain@5 {
-			compatible = "openamp,domain-v1";
+		subsystem2: domain@5 {
+			compatible = "xilinx,subsystem-v1", "openamp,domain-v1";
 
 			cpus = <&cpus_r5 0x3 0x80000001 &microblaze0 0x1 0x00000000>;
 			memory = <0x0 0x100000 0x0 0x400000>;
 			id = <0x4>;
 
-			flags = <0x0>;
-			flags-names = "dev";
-			access = <&can0>;
-			access-flags-names = "dev";
-			include = <&resource_group_1>;
+			#access-flags-cells = <0x1>;
+			access = <&can0 0x0 &ethernet0 0x0 &serial0 0x0>;
 			/* 1: block */
 			firewallconfig-default = <1 0>;
 		};


### PR DESCRIPTION
Remove resource-groups, not shared resources are simply repeated.
Simplify access flags, they are just specified at each level
independently.

Update remoteproc binding.

Introduce implicit default access flags.

Introduce secure-reg and secure-address-map.

Introduce os,type.

Signed-off-by: Stefano Stabellini <stefano.stabellini@xilinx.com>