### PR TITLE
Update openamp yaml stubs

### DIFF
--- a/lopper/assists/openamp_xlnx.py
+++ b/lopper/assists/openamp_xlnx.py
@@ -38,6 +38,17 @@ def is_compat( node, compat_string_to_test ):
         return xlnx_openamp_rpu
     return ""
 
+
+def xlnx_openamp_rpmsg_expand(tree, subnode, verbose = 0 ):
+    # Xilinx-specific YAML expansion of RPMsg description.
+    return True
+
+
+def xlnx_openamp_remoteproc_expand(tree, subnode, verbose = 0 ):
+    # Xilinx-specific YAML expansion of Remoteproc description.
+    return True
+
+
 def update_mbox_cntr_intr_parent(sdt):
   # find phandle of a72 gic for mailbox controller
   a72_gic_node = sdt.tree["/amba_apu/interrupt-controller@f9000000"]

--- a/lopper/assists/subsystem.py
+++ b/lopper/assists/subsystem.py
@@ -684,6 +684,18 @@ def flags_expand(tree, tgt_node, verbose = 0 ):
 
     return True
 
+def domain_to_domain_expand(tree, tgt_node, verbose = 0 ):
+
+    if 'openamp,domain-to-domain-v1' not in tgt_node.propval("compatible"):
+        return False
+
+    # loop through subnodes that describe various relations between domains
+    for n in tgt_node.subnodes():
+        if n.depth == tgt_node.depth + 1:
+            if verbose:
+                print("domain_to_domain_expand: ", tgt_node, n)
+
+    return True
 
 def subsystem_expand( tgt_node, sdt, verbose = 0 ):
     if verbose:

--- a/lopper/assists/subsystem.py
+++ b/lopper/assists/subsystem.py
@@ -33,6 +33,11 @@ import lopper
 import json
 import humanfriendly
 
+sys.path.append(os.path.dirname(__file__))
+from openamp import is_openamp_d_to_d
+from openamp import openamp_d_to_d_expand
+
+
 def is_compat( node, compat_string_to_test ):
     if re.search( "module,subsystem", compat_string_to_test):
         return subsystem
@@ -694,6 +699,8 @@ def domain_to_domain_expand(tree, tgt_node, verbose = 0 ):
         if n.depth == tgt_node.depth + 1:
             if verbose:
                 print("domain_to_domain_expand: ", tgt_node, n)
+            if is_openamp_d_to_d(tree, tgt_node, verbose):
+                openamp_d_to_d_expand(tree, tgt_node, verbose)
 
     return True
 

--- a/lopper/lops/lop-load.dts
+++ b/lopper/lops/lop-load.dts
@@ -19,21 +19,9 @@
                         compatible = "system-device-tree-v1,lop,load";
                         load = "assists/openamp.py";
                 };
-                lop_1 {
-                        compatible = "system-device-tree-v1,lop,load";
-                        load = "assists/cdo.py";
-                        // props describes the extra properties of this assist,
-                        // so they can be loaded and stored with the module
-                        props = "id", "file_ext";
-                        // the extension of the output file that this is
-                        // compatible with.
-                        file_ext = ".cdo";
-                        // the id that this module is compatible with
-                        id = "xlnx,output,cdo";
-                };
                 lop_2 {
                         compatible = "system-device-tree-v1,lop,load";
-                        load = "assists/openamp-xlnx.py";
+                        load = "assists/openamp_xlnx.py";
                 };
                 lop_3 {
                         compatible = "system-device-tree-v1,lop,load";

--- a/lopper/lops/lop-xlate-yaml.dts
+++ b/lopper/lops/lop-xlate-yaml.dts
@@ -222,6 +222,10 @@
                                         for child_n in n.subnodes():
                                             if child_n.abs_path.endswith('/flags') and child_n.depth == n.depth + 1:
                                                 subsystem.flags_expand( tree, n)
+
+                                        for child_n in n.subnodes():
+                                            if child_n.abs_path.endswith('/domain-to-domain'):
+                                                subsystem.domain_to_domain_expand( tree, n)
                         ";
                       };
                 };


### PR DESCRIPTION
add stubs for OpenAMP YAML expansion as follows
- subsystem: add YAML handler for the domain-to-domain YAML property
- openamp generic: add landing function to determine if RPMsg or Remoteproc relation and which vendor
- openamp xilinx: stub for handling specific to Xilinx
- rename openamp-xlnx to openamp_xlnx for includes
- remove CDO from being loaded as it currently is based off deprecated Lopper code