### PR TITLE
openamp: add stub for OpenAMP Domain processing landing function

### DIFF
--- a/lopper/assists/openamp.py
+++ b/lopper/assists/openamp.py
@@ -29,10 +29,13 @@ import lopper
 sys.path.append(os.path.dirname(__file__))
 from openamp_xlnx import xlnx_openamp_rpmsg_expand
 from openamp_xlnx import xlnx_openamp_remoteproc_expand
+from openamp_xlnx import xlnx_openamp_parse
 
 def is_compat( node, compat_string_to_test ):
     if re.search( "openamp,domain-v1", compat_string_to_test):
         return process_domain
+    if re.search( "openamp,domain-processing", compat_string_to_test):
+        return openamp_parse
     return ""
 
 # tests for a bit that is set, going fro 31 -> 0 from MSB to LSB
@@ -171,6 +174,20 @@ def openamp_process_cpus( sdt, domain_node, verbose = 0 ):
                 sdt.tree.delete( s )
             except Exception as e:
                 print( "[WARNING]: %s" % e )
+
+
+def openamp_parse(root_node, tree, verbose = 0 ):
+    try:
+        verbose = options['verbose']
+    except:
+        verbose = 0
+
+    for i in root_node["compatible"].value:
+        if "xlnx" in i:
+            return xlnx_openamp_parse(tree, verbose)
+
+    return False
+
 
 # all the logic for applying a openamp domain to a device tree.
 # this is a really long routine that will be broken up as more examples

--- a/lopper/assists/openamp_xlnx.py
+++ b/lopper/assists/openamp_xlnx.py
@@ -32,12 +32,49 @@ sys.path.append(os.path.dirname(__file__))
 from openamp_xlnx_common import *
 
 RPU_PATH = "/rpu@ff9a0000"
+REMOTEPROC_D_TO_D = "openamp,remoteproc-v1"
+RPMSG_D_TO_D = "openamp,rpmsg-v1"
+
 
 def is_compat( node, compat_string_to_test ):
     if re.search( "openamp,xlnx-rpu", compat_string_to_test):
         return xlnx_openamp_rpu
     return ""
 
+
+def xlnx_rpmsg_parse(tree, node, openamp_channel_info, verbose = 0 ):
+    # Xilinx OpenAMP subroutine to collect RPMsg information from RPMsg
+    # relation
+    return True
+
+
+def xlnx_remoteproc_parse(tree, node, openamp_channel_info, verbose = 0 ):
+    # Xilinx OpenAMP subroutine to collect RPMsg information from Remoteproc
+    # relation
+    return True
+
+
+def xlnx_openamp_parse(sdt, verbose = 0 ):
+    # Xilinx OpenAMP subroutine to parse OpenAMP Channel
+    # information and generate Device Tree information.
+    tree = sdt.tree
+    ret = False
+    openamp_channel_info = {}
+
+    for n in tree["/domains"].subnodes():
+            node_compat = n.props("compatible")
+            if node_compat != []:
+                node_compat = node_compat[0].value
+
+                if node_compat == REMOTEPROC_D_TO_D:
+                    ret = xlnx_remoteproc_parse(tree, n, openamp_channel_info, verbose)
+                elif node_compat == RPMSG_D_TO_D:
+                    ret = xlnx_rpmsg_parse(tree, n, openamp_channel_info, verbose)
+
+                if ret == False:
+                    return ret
+
+    return ret
 
 def xlnx_openamp_rpmsg_expand(tree, subnode, verbose = 0 ):
     # Xilinx-specific YAML expansion of RPMsg description.

--- a/lopper/lops/lop-openamp-versal.dts
+++ b/lopper/lops/lop-openamp-versal.dts
@@ -25,7 +25,7 @@
 		lop_5_1 {
 			compatible = "system-device-tree-v1,lop,assist-v1";
 			node = "/";
-			id = "openamp,xlnx-rpu";
+			id = "openamp,domain-processing";
 
 		};
 	};


### PR DESCRIPTION
Stub to catch processing of OpenAMP Domains is now present.

Additionally, route stub for Xilinx OpenAMP Domains.

Signed-off-by: Ben Levinsky <ben.levinsky@xilinx.com>