### PR TITLE
lopper: assists: breametallinker: fix race condition in memory node handling

### DIFF
--- a/lopper/assists/baremetallinker_xlnx.py
+++ b/lopper/assists/baremetallinker_xlnx.py
@@ -153,7 +153,7 @@ def get_memranges(tgt_node, sdt, options):
             match = [mem for mem in name_list if mem in compat]
             for i in range(total_nodes):
                 reg, size = scan_reg_size(node, val, i)
-                valid_range = [reg for addr in addr_list if reg == addr or reg > addr]
+                valid_range = [addr for addr in addr_list if reg == addr or addr in range(reg, size-reg)]
                 if valid_range:
                     key = match[0].replace("-", "_")
                     is_valid_noc_ch = 0


### PR DESCRIPTION
In the system device tree, there will be a per CPU cluster address-map
property, As per the system device-tree specification  the start address
in the address-map need not to be mapped with the node start address
(ex: for entire system memory node has 2 GB out of which r5 can be
mapped to only 1GB memory), Existing assist logic is not considering
this use case this patch fixes this issue.

Signed-off-by: Appana Durga Kedareswara rao <appana.durga.rao@xilinx.com>