### PR TITLE
lopper: assists: bmcmake_metadata_xlnx: Fix race condition in the assist file

### DIFF
--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -107,6 +107,7 @@ def generate_drvcmake_metadata(sdt, node_list, src_dir, options):
                     try:
                         valid_ex = node[prop[0]].value
                     except KeyError:
+                        match_list.append(False)
                         valid_ex = 0
 
             if valid_ex or not False in match_list:


### PR DESCRIPTION
When the driver required propery is missing in the device-tree node
match_list should be initialized to false, currently it is empty
this commit fixes this issue.

Signed-off-by: Appana Durga Kedareswara rao <appana.durga.rao@xilinx.com>