### PR TITLE
lopper: lops: lop-domain-linux-a53: Remove duplicate psu_r5_tcm_ram_global node

### DIFF
--- a/lopper/lops/lop-domain-linux-a53.dts
+++ b/lopper/lops/lop-domain-linux-a53.dts
@@ -80,5 +80,11 @@
                         // Disable SMMU Node
                         modify = "/smmu@fd800000:status:disabled";
                 };
+
+                lop_9 {
+                        // Delete the duplicate tcm_ram node
+                        compatible = "system-device-tree-v1,lop,modify";
+                        modify = "/amba/psu_r5_tcm_ram@ffe00000::";
+                };
         };
 };


### PR DESCRIPTION

In ZynqMP system device-tree tcm_ram mapped into global
tcm ram node and individual atcm and btcm global nodes,
this commit deletes the duplicate psu_r5_tcm_ram_global
from the linux device-tree.

Signed-off-by: Appana Durga Kedareswara rao <appana.durga.kedareswara.rao@amd.com>