### PR TITLE
extract-xen: Copy sdt root compatibles into extracted node

### DIFF
--- a/lopper/assists/extract-xen.py
+++ b/lopper/assists/extract-xen.py
@@ -99,6 +99,11 @@ def extract_xen( tgt_node, sdt, options ):
     # rename the containing node from /extracted to /passthrough
     extracted_node.name = "passthrough"
 
+    # copy sdt root compatibles into extracted node
+    root_compat = sdt.tree["/"]["compatible"].value
+    root_compat.append(extracted_node["compatible"].value)
+    extracted_node["compatible"].value = root_compat
+
     # walk the nodes in the tree, and look for the property "extracted,path"
     # and update it to "xen,path" (when conditions are met)
     for n in xen_tree:


### PR DESCRIPTION
Currently extract assist only adds "simple-bus" but we also need to copy
all the other compatibles from the sdt root node. This is because some
drivers may refuse to continue unless they find the root-level board
compatible property.

Signed-off-by: Michal Orzel <michal.orzel@amd.com>