### PR TITLE
fdt: Fix for the condition when an include file is defined inside a node

### DIFF
--- a/lopper/fdt.py
+++ b/lopper/fdt.py
@@ -1745,6 +1745,7 @@ class LopperFDT(lopper.base.lopper_base):
                     file_boundary_index = i
                     # clear the node tracking counts, we are into a new file
                     subnode_at_depth = { 0: False }
+                    node_depth = 0
 
                 mn = re.search( "^\s*(.*){", f )
                 if mn:


### PR DESCRIPTION
When an include file is defined inside a node as shown below, lopper is throwing an error.

&qspi {
#include "...dtsi"
};

Whenever a line starting with # is detected, subnode_at_depth is re-initialized to 0 and False, but the key that is being used to traverse through subnode_at_depth i.e. node_depth never gets decremented in above situation.

Signed-off-by: Onkar Harsh <onkar.harsh@xilinx.com>