### PR TITLE
lopper: assits: Improvements in baremetal assists

### DIFF
--- a/lopper/assists/baremetal_bspconfig_xlnx.py
+++ b/lopper/assists/baremetal_bspconfig_xlnx.py
@@ -7,34 +7,18 @@
 # * SPDX-License-Identifier: BSD-3-Clause
 # */
 
-import struct
-import sys
-import types
-import unittest
-import os
-import getopt
-import re
-import subprocess
-import shutil
-from pathlib import Path
-from pathlib import PurePath
-from io import StringIO
-import contextlib
-import importlib
-from lopper import Lopper
-from lopper import LopperFmt
-import lopper
-from lopper.tree import *
-from re import *
 import yaml
+import sys
+import os
+import glob
 
 sys.path.append(os.path.dirname(__file__))
-from baremetalconfig_xlnx import *
-from baremetallinker_xlnx import *
+from baremetalconfig_xlnx import compat_list, get_cpu_node
+from baremetallinker_xlnx import get_memranges
 from bmcmake_metadata_xlnx import to_cmakelist
 
 def is_compat( node, compat_string_to_test ):
-    if re.search( "module,baremetal_bspconfig_xlnx", compat_string_to_test):
+    if "module,baremetal_bspconfig_xlnx" in compat_string_to_test:
         return xlnx_generate_bm_bspconfig
     return ""
 
@@ -49,63 +33,60 @@ def xlnx_generate_bm_bspconfig(tgt_node, sdt, options):
     if not mem_ranges:
         return
     # Generate Memconfig cmake meta-data file.
-    with open('MemConfig.cmake', 'w') as fd:
+    memconfig_path = os.path.join(sdt.outdir,'MemConfig.cmake')
+    with open(memconfig_path, 'w') as fd:
         mem_name_list = []
         mem_size_list = []
         for key, value in sorted(mem_ranges.items(), key=lambda e: e[1][1], reverse=True):
             start,size = value[0], value[1]
-            name = "XPAR_{}_BASEADDRESS".format(key.upper())
+            name = f"XPAR_{key.upper()}_BASEADDRESS"
             mem_name_list.append(name)
-            name = "XPAR_{}_HIGHADDRESS".format(key.upper())
+            name = f"XPAR_{key.upper()}_HIGHADDRESS"
             mem_name_list.append(name)
             mem_size_list.append(hex(start))
             mem_size_list.append(hex(start + size))
-        fd.write("set(MEM_DEF_NAMES %s)\n" % to_cmakelist(mem_name_list))
-        fd.write("set(MEM_RANGES %s)\n" % to_cmakelist(mem_size_list))
+        fd.write(f"set(MEM_DEF_NAMES {to_cmakelist(mem_name_list)})\n")
+        fd.write(f"set(MEM_RANGES {to_cmakelist(mem_size_list)})\n")
 
     machine = options['args'][0]
     # Get the cpu node for a given Processor
     match_cpunode = get_cpu_node(sdt, options)
 
-    tmpdir = os.getcwd()
-    os.chdir(options['args'][1])
-    os.chdir("../data")
-    cwd = os.getcwd()
-    files = os.listdir(cwd)
-    # Generate CPU specific config struct file.
-    for name in files:
-        os.chdir(cwd)
-        if os.path.isdir(name):
-            os.chdir(name)
-            yamlfile = name + str(".yaml")
-            with open(yamlfile) as stream:
-                schema = yaml.safe_load(stream)
-                compatlist = compat_list(schema)
-                prop_list = schema['required']
-                match = [compat for compat in compatlist if compat in match_cpunode['compatible'].value]
-                if match:
-                   config_struct = schema['config'][0] 
-                   outfile = tmpdir + str("/") + str("x") + name.lower() + str("_g.c")
-                   with open(outfile, 'w') as fd:
-                       fd.write('#include "x%s.h"\n' % name.lower())
-                       fd.write('\n%s %s __attribute__ ((section (".drvcfg_sec"))) = {\n' % (config_struct, config_struct + str("Table[]")))
-                       for index,prop in enumerate(prop_list):
-                           if index == 0:
-                               fd.write("\t{")
-                           try:
-                               for i in range(0, len(match_cpunode[prop].value)):
-                                   fd.write("\n\t\t%s" % hex(match_cpunode[prop].value[i]))
-                                   if i != (len(match_cpunode[prop].value) - 1):
-                                       fd.write(",")
-                           except:
-                               fd.write("\n\t\t 0")
-                           if prop == prop_list[-1]:
-                               fd.write("  /* %s */" % prop) 
-                               fd.write("\n\t}")
-                           else:
-                               fd.write(",")
-                               fd.write("  /* %s */" % prop) 
-                       fd.write("\n};")
-    os.chdir(tmpdir)
+    srcdir = options['args'][1].rstrip(os.sep)
+    datadir = os.path.join(os.path.dirname(srcdir),'data')
+    yaml_paths = glob.glob(f"{datadir}/*/*.yaml")
     
+
+    # Generate CPU specific config struct file.
+    for yamlfile in yaml_paths:
+        name = os.path.basename(os.path.dirname(yamlfile))
+        with open(yamlfile) as stream:
+            schema = yaml.safe_load(stream)
+            compatlist = compat_list(schema)
+            prop_list = schema['required']
+            match = [compat for compat in compatlist if compat in match_cpunode['compatible'].value]
+            if match:
+               config_struct = schema['config'][0]
+               outfile = os.path.join(sdt.outdir, f"x{name.lower()}_g.c")
+               with open(outfile, 'w') as fd:
+                   fd.write(f'#include "x{name.lower()}.h"\n')
+                   fd.write(f'\n{config_struct} {config_struct}Table[] __attribute__ ((section (".drvcfg_sec"))) = {{\n')
+                   for index,prop in enumerate(prop_list):
+                       if index == 0:
+                           fd.write("\t{")
+                       try:
+                           for i in range(0, len(match_cpunode[prop].value)):
+                               fd.write(f"\n\t\t{hex(match_cpunode[prop].value[i])}")
+                               if i != (len(match_cpunode[prop].value) - 1):
+                                   fd.write(",")
+                       except:
+                           fd.write("\n\t\t 0")
+                       if prop == prop_list[-1]:
+                           fd.write(f"  /* {prop} */")
+                           fd.write("\n\t}")
+                       else:
+                           fd.write(",")
+                           fd.write(f"  /* {prop} */") 
+                   fd.write("\n};")
+
     return True

--- a/lopper/assists/baremetal_getsupported_comp_xlnx.py
+++ b/lopper/assists/baremetal_getsupported_comp_xlnx.py
@@ -1,0 +1,103 @@
+#/*
+# * Copyright (C) 2022 Advanced Micro Devices, Inc.  All rights reserved.
+# *
+# * Author:
+# *       Appana Durga Kedareswara rao <appana.durga.kedareswara.rao@amd.com>
+# *
+# * SPDX-License-Identifier: BSD-3-Clause
+# */
+import sys
+import types
+from lopper import Lopper
+from lopper import LopperFmt
+import lopper
+from lopper.tree import *
+from re import *
+import os
+import yaml
+import json
+import glob
+
+def is_compat( node, compat_string_to_test ):
+    if re.search( "module,baremetal_getsupported_comp_xlnx", compat_string_to_test):
+        return xlnx_baremetal_getsupported_comp
+    return ""
+
+class VerboseSafeDumper(yaml.SafeDumper):
+    def ignore_aliases(self, data):
+        return True
+
+def xlnx_get_supported_component(root_dir, proc_ip_name):
+    standalone_app_dict = {}
+    freertos_app_dict = {}
+    # Get supported component names
+    for yaml_file in glob.iglob(root_dir + '**/*.yaml', recursive=True):
+        with open(str(yaml_file), "r") as stream:
+            schema = yaml.safe_load(stream)
+            try:
+                proc_list = schema['supported_processors']
+                is_supported_app = [proc for proc in proc_list if re.match(proc, proc_ip_name)]
+                os_list = schema['supported_os']
+                app_description = schema['description']
+                if is_supported_app:
+                    if "standalone" in os_list:
+                        standalone_app_dict.update({Path(yaml_file).stem:{"description":app_description}})
+                    if "freertos10_xilinx" in os_list:
+                        freertos_app_dict.update({Path(yaml_file).stem:{"description":app_description}})
+                dep_lib_list = schema['depends_libs']
+                if is_supported_app:
+                    if "standalone" in os_list:
+                        standalone_app_dict[Path(yaml_file).stem].update({"depends_libs":dep_lib_list})
+                    if "freertos10_xilinx" in os_list:
+                        freertos_app_dict[Path(yaml_file).stem].update({"depends_libs":dep_lib_list})
+            except KeyError:
+                pass
+
+    return standalone_app_dict, freertos_app_dict
+
+def xlnx_baremetal_getsupported_comp(tgt_node, sdt, options):
+    proc_name = options['args'][0]
+    repo_path = options['args'][1]
+
+    root_node_subnodes = sdt.tree[tgt_node].subnodes()
+    prop_dict = sdt.tree['/__symbols__'].__props__
+    proc_ip_name = None
+    for c_node in root_node_subnodes:
+        try:
+            match = [label for label,node_abs in prop_dict.items() if re.match(node_abs[0], c_node.abs_path) and len(node_abs[0]) == len(c_node.abs_path)]
+            if re.match(proc_name, match[0]):
+                proc_ip_name = c_node['xlnx,ip-name'].value[0]
+        except:
+            pass
+
+    supported_apps = {}
+    root_dir = repo_path + "/lib/sw_apps/"
+    standalone_app_dict, freertos_app_dict  = xlnx_get_supported_component(root_dir, proc_ip_name)
+    if standalone_app_dict:
+        supported_apps.update({"standalone":standalone_app_dict})
+    if freertos_app_dict:
+        supported_apps.update({"freertos":freertos_app_dict})
+    app_supported_dict = {proc_name:supported_apps}
+    with open('app_list.yaml', 'w') as fd:
+        fd.write(yaml.dump(app_supported_dict, sort_keys=False, indent=2, width=32768))
+
+    supported_libs = {}
+    root_dir = repo_path + "/lib/sw_services/"
+    standalone_lib_dict, freertos_lib_dict = xlnx_get_supported_component(root_dir, proc_ip_name)
+    if standalone_lib_dict:
+        supported_libs.update({"standalone":standalone_lib_dict})
+    if freertos_lib_dict:
+        supported_libs.update({"freertos":freertos_lib_dict})
+    
+    root_dir = repo_path + "/ThirdParty/sw_services/"
+    standalone_lib_dict, freertos_lib_dict = xlnx_get_supported_component(root_dir, proc_ip_name)
+    for lib in supported_libs:
+        if lib == "standalone":
+            supported_libs['standalone'].update(standalone_lib_dict)
+        else:
+            supported_libs['freertos'].update(freertos_lib_dict)
+    lib_supported_dict = {proc_name:supported_libs}
+    with open('lib_list.yaml', 'w') as fd:
+        fd.write(yaml.dump(lib_supported_dict, sort_keys=False, indent=2, width=32768, Dumper=VerboseSafeDumper))
+
+    return True

--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -76,7 +76,8 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
             cci_en = None
 
     drvlist = xlnx_generate_bm_drvlist(tgt_node, sdt, options)
-    plat = DtbtoCStruct('xparameters.h')
+    xparams = os.path.join(sdt.outdir, f"xparameters.h")
+    plat = DtbtoCStruct(xparams)
     plat.buf('#ifndef XPARAMETERS_H   /* prevent circular inclusions */\n')
     plat.buf('#define XPARAMETERS_H   /* by using protection macros */\n')
     total_nodes = node_list

--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -282,18 +282,18 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
         plat.buf("\n#define XPAR_CACHE_COHERENT \n")
 
     #CPU Freq related defines
-    match_cpunodes = get_cpu_node(sdt, options)
-    if re.search("microblaze", options['args'][0]):
+    match_cpunode = get_cpu_node(sdt, options)
+    if re.search("microblaze", match_cpunode['compatible'].value[0]):
         try:
-            cpu_freq = match_cpunodes[0]['xlnx,freq'].value[0]
+            cpu_freq = match_cpunode['xlnx,freq'].value[0]
             plat.buf('\n#define XPAR_CPU_CORE_CLOCK_FREQ_HZ %s\n' % cpu_freq)
         except KeyError:
             pass
     else:
         try:
-            cpu_freq = match_cpunodes[0]['xlnx,cpu-clk-freq-hz'].value[0]
+            cpu_freq = match_cpunode['xlnx,cpu-clk-freq-hz'].value[0]
             plat.buf('\n\n#define XPAR_CPU_CORE_CLOCK_FREQ_HZ %s\n' % cpu_freq)
-            pss_ref = match_cpunodes[0]['xlnx,pss-ref-clk-freq'].value[0]
+            pss_ref = match_cpunode['xlnx,pss-ref-clk-freq'].value[0]
             plat.buf('#define XPAR_PSU_PSS_REF_CLK_FREQ_HZ %s\n' % pss_ref)
         except KeyError:
             pass

--- a/lopper/assists/baremetalconfig_xlnx.py
+++ b/lopper/assists/baremetalconfig_xlnx.py
@@ -389,8 +389,9 @@ def xlnx_generate_bm_config(tgt_node, sdt, options):
     except IndexError:
         pass
 
-    drvname = src_dir.split('/')[-3]
-    yaml_file = Path( src_dir + "../data/" + drvname + ".yaml")
+    drvpath = os.path.dirname(src_dir.rstrip(os.sep))
+    drvname = os.path.basename(drvpath)
+    yaml_file = Path(os.path.join(drvpath, f"data/{drvname}.yaml"))
     try:
         yaml_file_abs = yaml_file.resolve()
     except FileNotFoundError:
@@ -438,7 +439,7 @@ def xlnx_generate_bm_config(tgt_node, sdt, options):
         config_struct = config_struct[0]
         driver_name = config_struct.split('_Config')[0].lower()
         driver_name = driver_name[1:]
-    outfile = str("x") + driver_name + str("_g.c")
+    outfile = os.path.join(sdt.outdir,f"x{driver_name}_g.c")
 
     plat = DtbtoCStruct(outfile)
     nodename_list = []
@@ -446,6 +447,7 @@ def xlnx_generate_bm_config(tgt_node, sdt, options):
         nodename_list.append(node.name)
 
     cmake_file = drvname.upper() + str("Config.cmake")
+    cmake_file = os.path.join(sdt.outdir,f"{cmake_file}")
     with open(cmake_file, 'a') as fd:
        fd.write("set(DRIVER_INSTANCES %s)\n" % to_cmakelist(nodename_list))
        if stdin:

--- a/lopper/assists/baremetallinker_xlnx.py
+++ b/lopper/assists/baremetallinker_xlnx.py
@@ -193,7 +193,7 @@ def xlnx_generate_bm_linker(tgt_node, sdt, options):
     except IndexError:
         pass
 
-    with open('memory.ld', 'w') as fd:
+    with open(os.path.join(sdt.outdir,'memory.ld'), 'w') as fd:
         fd.write("MEMORY\n")
         fd.write("{\n")
         if memtest_config:
@@ -232,10 +232,9 @@ def xlnx_generate_bm_linker(tgt_node, sdt, options):
             fd.write("\t%s : ORIGIN = %s, LENGTH = %s\n" % (key, hex(start), hex(size)))
         fd.write("}\n")
 
-    src_dir = os.path.dirname(options['args'][1])
-    src_dir = os.path.dirname(src_dir)
-    appname = src_dir.rsplit('/', 1)[-1]
-    cmake_file = appname.capitalize() + str("Example.cmake")
+    src_dir = options['args'][1].rstrip(os.path.sep)
+    appname = os.path.basename(os.path.dirname(src_dir))
+    cmake_file = os.path.join(sdt.outdir, f"{appname.capitalize()}Example.cmake")
 
     ## To inline with existing tools point default ddr for linker to lower DDR
     lower_ddrs = ["axi_noc_0", "psu_ddr_0", "ps7_ddr_0"]

--- a/lopper/assists/baremetallinker_xlnx.py
+++ b/lopper/assists/baremetallinker_xlnx.py
@@ -57,12 +57,12 @@ def get_memranges(tgt_node, sdt, options):
         elif domain_node.propval('cpus') != ['']:
                 print('ERROR: os,type property is missing in the domain', domain_node.name)
 
-        match_cpunodes = get_cpu_node(sdt, options)
+        match_cpunode = get_cpu_node(sdt, options)
 
         # Check whether domain is mapped for current processor or not
         if bm_domain:
             shared_mem = []
-            if not domain_node['cpus'][0] == match_cpunodes[0].parent.phandle:
+            if not domain_node['cpus'][0] == match_cpunode.parent.phandle:
                 continue
             else:
                if domain_node.propval('include') != ['']:
@@ -107,12 +107,13 @@ def get_memranges(tgt_node, sdt, options):
     versal_noc_ch_ranges =  {"DDR_CH_1": "0x50000000000", "DDR_CH_2": "0x60000000000", "DDR_CH_3": "0x70000000000"}
 
     # Yocto Machine to CPU compat mapping
-    match_cpunodes = get_cpu_node(sdt, options)
-   
-    address_map = match_cpunodes[0].parent["address-map"].value
+    match_cpunode = get_cpu_node(sdt, options)
+    if not match_cpunode:
+        return
+    address_map = match_cpunode.parent["address-map"].value
     all_phandles = []
-    ns = match_cpunodes[0].parent["#ranges-size-cells"].value[0]
-    na = match_cpunodes[0].parent["#ranges-address-cells"].value[0]
+    ns = match_cpunode.parent["#ranges-size-cells"].value[0]
+    na = match_cpunode.parent["#ranges-address-cells"].value[0]
     cells = na + ns
     tmp = na
     while tmp < len(address_map):

--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -29,9 +29,9 @@ from baremetalconfig_xlnx import *
 
 def generate_drvcmake_metadata(sdt, node_list, src_dir, options):
     driver_compatlist = []
-
-    drvname = src_dir.split('/')[-3]
-    yaml_file = Path( src_dir + "../data/" + drvname + ".yaml")
+    src_dir = src_dir.rstrip(os.path.sep)
+    drvname = os.path.basename(os.path.dirname(src_dir))
+    yaml_file = Path( os.path.join(os.path.dirname(src_dir), "data", f"{drvname}.yaml"))
     try:
         yaml_file_abs = yaml_file.resolve()
     except FileNotFoundError:
@@ -123,9 +123,8 @@ def generate_drvcmake_metadata(sdt, node_list, src_dir, options):
         example_dict.update({node.name:validex_list})
         depreg_dict.update({node.name:depreg_list})
 
-    drvname = yamlfile.rsplit('/', 1)[-1]
-    drvname = drvname.replace('.yaml', '')
-    cmake_file = drvname.capitalize() + str("Example.cmake")
+    drvname = os.path.basename(yamlfile).replace('.yaml', '')
+    cmake_file = os.path.join(sdt.outdir, f"{drvname.capitalize()}Example.cmake")
     with open(cmake_file, 'a') as fd:
         fd.write("set(NUM_DRIVER_INSTANCES %s)\n" % to_cmakelist(nodename_list))
         fd.write("set(REG_LIST %s)\n" % to_cmakelist(reg_list))
@@ -179,8 +178,9 @@ def lwip_topolgy(config):
 
 def generate_hwtocmake_medata(sdt, node_list, src_path, repo_path, options):
     meta_dict = {}
-    name = src_path.split('/')[-3]
-    yaml_file = Path( src_path + "../data/" + name + ".yaml")
+    src_path = src_path.rstrip(os.path.sep)
+    name = os.path.basename(os.path.dirname(src_path))
+    yaml_file = Path( os.path.join(os.path.dirname(src_path), "data", f"{name}.yaml"))
     try:
         yaml_file_abs = yaml_file.resolve()
     except FileNotFoundError:

--- a/lopper/lops/lop-cpulist.dts
+++ b/lopper/lops/lop-cpulist.dts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022 Advanced Micro Devices, Inc.  All rights reserved.
+ *
+ * Author:
+ *     Appana Durga Kedareswara rao <appana.durga.kedareswara.rao@amd.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/dts-v1/;
+
+/ {
+        compatible = "system-device-tree-v1,lop";
+        lops {
+                compatible = "system-device-tree-v1,lop";
+                lop_0 {
+                      compatible = "system-device-tree-v1,lop,select-v1";
+                      select_1;
+                      select_2 = "/.*:compatible:cpus,cluster";
+                      lop_0_1 {
+                              compatible = "system-device-tree-v1,lop,code-v1";
+                              inherit = "lopper_lib";
+                              code = "
+                                     import yaml
+                                     cpu_output = {}
+                                     for c in __selected__:
+                                         for c_node in c.subnodes( children_only = True ):
+                                             try:
+                                                 cpu_node = c_node['reg'].value
+                                                 cpu_node = c_node.name
+                                                 symbol_node = node.tree['/__symbols__']
+                                                 prop_dict = symbol_node.__props__
+                                                 match = [label for label,node_abs in prop_dict.items() if re.match(node_abs[0], c_node.abs_path) and len(node_abs[0]) == len(c_node.abs_path)]
+                                                 cpu_node = match[0]
+                                                 ip_name = c_node['xlnx,ip-name'].value
+                                             except:
+                                                 cpu_node = None
+                                             if cpu_node:
+                                             	 print( '%s' % cpu_node )
+                                             	 cpu_output[cpu_node] = ip_name[0]
+                                     with open('cpulist.yaml', 'w') as fd:
+                                         fd.write(yaml.dump(cpu_output, indent = 4))
+                                     ";
+                      };
+                };
+        };
+};


### PR DESCRIPTION
This pull request does the below
1) Add support for outdir option in assists 
2) Added new assist for getting the supported apps and libs list for supported os along with it's description 
3) Added new lops file getting cpu names for a given system device-tree
4) Updated the assists to remove hard coded cpu compatible to yocto machine dictionary and fixed assists to take cpu name as input instead of yocto machine name.