### PR TITLE
lopper:assists: Update assists to support outdir option and the changed yaml format in embeddedsw

### DIFF
--- a/lopper/assists/baremetal_gentestapp_xlnx.py
+++ b/lopper/assists/baremetal_gentestapp_xlnx.py
@@ -60,11 +60,11 @@ def xlnx_generate_testapp(tgt_node, sdt, options):
            pass
 
     node_list = get_mapped_nodes(sdt, node_list, options)
-    tmpdir = os.getcwd()
-    file_fd = open('file_list.txt', 'w')
+    tmpdir = sdt.outdir
+    file_fd = open(os.path.join(tmpdir, 'file_list.txt'), 'w')
     file_fd.write('testperiph.c')
     file_fd.write("\n")
-    plat = DtbtoCStruct('testperiph.c')
+    plat = DtbtoCStruct(os.path.join(tmpdir,'testperiph.c'))
     src_dir = options['args'][1]
     os.chdir(src_dir)
     os.chdir("XilinxProcessorIPLib/drivers/")

--- a/lopper/assists/baremetal_getsupported_comp_xlnx.py
+++ b/lopper/assists/baremetal_getsupported_comp_xlnx.py
@@ -44,7 +44,7 @@ def xlnx_get_supported_component(root_dir, proc_ip_name):
                         standalone_app_dict.update({Path(yaml_file).stem:{"description":app_description}})
                     if "freertos10_xilinx" in os_list:
                         freertos_app_dict.update({Path(yaml_file).stem:{"description":app_description}})
-                dep_lib_list = schema['depends_libs']
+                dep_lib_list = list(schema['depends_libs'].keys())
                 if is_supported_app:
                     if "standalone" in os_list:
                         standalone_app_dict[Path(yaml_file).stem].update({"depends_libs":dep_lib_list})
@@ -78,7 +78,7 @@ def xlnx_baremetal_getsupported_comp(tgt_node, sdt, options):
     if freertos_app_dict:
         supported_apps.update({"freertos":freertos_app_dict})
     app_supported_dict = {proc_name:supported_apps}
-    with open('app_list.yaml', 'w') as fd:
+    with open(os.path.join(sdt.outdir, 'app_list.yaml'), 'w') as fd:
         fd.write(yaml.dump(app_supported_dict, sort_keys=False, indent=2, width=32768))
 
     supported_libs = {}
@@ -97,7 +97,7 @@ def xlnx_baremetal_getsupported_comp(tgt_node, sdt, options):
         else:
             supported_libs['freertos'].update(freertos_lib_dict)
     lib_supported_dict = {proc_name:supported_libs}
-    with open('lib_list.yaml', 'w') as fd:
+    with open(os.path.join(sdt.outdir, 'lib_list.yaml'), 'w') as fd:
         fd.write(yaml.dump(lib_supported_dict, sort_keys=False, indent=2, width=32768, Dumper=VerboseSafeDumper))
 
     return True

--- a/lopper/assists/baremetalconfig_xlnx.py
+++ b/lopper/assists/baremetalconfig_xlnx.py
@@ -45,6 +45,7 @@ def get_cpu_node(sdt, options):
 
     if not match_cpu_node:
         print("ERROR: In valid CPU Name valid Processors for a given SDT are %s\n"%' '.join(cpu_lables))
+        sys.exit(1)
 
     return match_cpu_node
 

--- a/lopper/assists/baremetaldrvlist_xlnx.py
+++ b/lopper/assists/baremetaldrvlist_xlnx.py
@@ -132,21 +132,21 @@ def xlnx_generate_bm_drvlist(tgt_node, sdt, options):
     driver_list.sort()
     os.chdir(tmpdir)
 
-    with open('distro.conf', 'w') as fd:
+    with open(os.path.join(sdt.outdir, 'distro.conf'), 'w') as fd:
         tmpdrv_list = [drv.replace("_", "-") for drv in driver_list]
         tmp_str =  ' '.join(tmpdrv_list)
         tmp_str = '"{}"'.format(tmp_str)
         fd.write("DISTRO_FEATURES = %s" % tmp_str)
 
-    with open('DRVLISTConfig.cmake', 'w') as cfd:
+    with open(os.path.join(sdt.outdir, 'DRVLISTConfig.cmake'), 'w') as cfd:
         cfd.write("set(DRIVER_LIST %s)\n" % to_cmakelist(driver_list))
 
-    cfd = open('CMakeLists.txt', 'w')
+    cfd = open(os.path.join(sdt.outdir, 'CMakeLists.txt'), 'w')
     cfd.write("cmake_minimum_required(VERSION 3.15)\n")
     cfd.write("project(libxil)\n")
     proc_name = options['args'][0]
     drv_targets = []
-    with open('libxil.conf', 'w') as fd:
+    with open(os.path.join(sdt.outdir, 'libxil.conf'), 'w') as fd:
         for drv in driver_list:
             drv_src = Path( os.path.join(src_dir,f"XilinxProcessorIPLib/drivers/{drv}/src"))
             # if driver has yaml then only add it to custom_target

--- a/lopper/assists/baremetaldrvlist_xlnx.py
+++ b/lopper/assists/baremetaldrvlist_xlnx.py
@@ -115,11 +115,8 @@ def xlnx_generate_bm_drvlist(tgt_node, sdt, options):
                                 match = [x for x in c if comp == x]
                                 if match:
                                     driver_list.append(name)
-                                    try:
-                                        if schema['depends']:
-                                            depdrv_list.append(schema['depends'])
-                                    except:
-                                        pass
+                                    if schema.get('depends',{}):
+                                        depdrv_list.append(list(schema['depends'].keys()))
                 except FileNotFoundError:
                     pass
 

--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -156,8 +156,8 @@ def getxlnx_phytype(sdt, value):
     phy_type = child_node[0]['xlnx,phy-type'].value[0]
     return hex(phy_type)
 
-def lwip_topolgy(config):
-    topology_fd = open('xtopology_g.c', 'w')
+def lwip_topolgy(outdir, config):
+    topology_fd = open(os.path.join(outdir, 'xtopology_g.c'), 'w')
     tmp_str = "netif/xtopology.h"
     tmp_str = '"{}"'.format(tmp_str)
     topology_fd.write("\n#include %s\n" % tmp_str)
@@ -194,10 +194,10 @@ def generate_hwtocmake_medata(sdt, node_list, src_path, repo_path, options):
 
     with open(yamlfile, 'r') as stream:
         schema = yaml.safe_load(stream)
-        meta_dict = schema['required']
+        meta_dict = schema['depends']
 
     lwip = re.search("lwip211", name)
-    cmake_file = name.capitalize() + str("Example.cmake")
+    cmake_file = os.path.join(sdt.outdir, f"{name.capitalize()}Example.cmake")
     topology_data = []
     with open(cmake_file, "a") as fd:
         lwiptype_index = 0
@@ -233,7 +233,7 @@ def generate_hwtocmake_medata(sdt, node_list, src_path, repo_path, options):
                 fd.write("list(APPEND TOTAL_%s_PROP_LIST %s%s_PROP_LIST)\n" % (drv.upper(), drv.upper(), index))
             lwiptype_index += 1
     if topology_data:
-        lwip_topolgy(topology_data)
+        lwip_topolgy(sdt.outdir, topology_data)
 
 def is_compat( node, compat_string_to_test ):
     if re.search( "module,bmcmake_metadata_xlnx", compat_string_to_test):


### PR DESCRIPTION
After last updates in assists, there were still few places left where outdir option was not being used. This patch adds outdir support at the remaining places. In addition it adds support to use the changed yaml format in embeddedsw.
Signed-off-by: Onkar Harsh <onkar.harsh@amd.com>