### PR TITLE
lopper: lops: lop-domain-linux-a53-prune.dts: Fix undefined reference  to valid_phandles in case of no domain file passed

### DIFF
--- a/lopper/lops/lop-domain-linux-a53-prune.dts
+++ b/lopper/lops/lop-domain-linux-a53-prune.dts
@@ -55,9 +55,9 @@
                                   domain_node = n
                           # Peipheral node handling
                           invalid_phandles = []
+                          valid_phandles = []
                           if domain_node:
                               shared_dev = []
-                              valid_phandles = []
                               for n in domain_node.subnodes():
                                   if n.propval('access') != [''] and n.propval('os,type') == ['']:
                                       shared_dev.append(n)


### PR DESCRIPTION


Signed-off-by: Appana Durga Kedareswara rao <appana.durga.kedareswara.rao@amd.com>