### PR TITLE
lopper: lops: Remove R5 cpu nodes while generating linux dtb

### DIFF
--- a/lopper/lops/lop-domain-a72-prune.dts
+++ b/lopper/lops/lop-domain-a72-prune.dts
@@ -23,6 +23,11 @@
                         compatible = "system-device-tree-v1,lop,modify";
                         modify = "/cpus-r5@3::";
                 };
+                lop_1_0 {
+                        // modify to "nothing", is a remove operation
+                        compatible = "system-device-tree-v1,lop,modify";
+                        modify = "/cpus-r5@4::";
+                };
                 lop_2 {
                         // modify to "nothing", is a remove operation
                         compatible = "system-device-tree-v1,lop,modify";

--- a/lopper/lops/lop-domain-linux-a53-prune.dts
+++ b/lopper/lops/lop-domain-linux-a53-prune.dts
@@ -18,6 +18,11 @@
                         compatible = "system-device-tree-v1,lop,modify";
                         modify = "/cpus-r5@1::";
                 };
+                lop_1_0 {
+                        // modify to "nothing", is a remove operation
+                        compatible = "system-device-tree-v1,lop,modify";
+                        modify = "/cpus-r5@2::";
+                };
                 lop_2 {
                         // modify to "nothing", is a remove operation
                         compatible = "system-device-tree-v1,lop,modify";


### PR DESCRIPTION
system device-tree generator tool is now generating the R5 cores as individual cpu cluster nodes, update the lops file for the same.

Signed-off-by: Appana Durga Kedareswara rao <appana.durga.kedareswara.rao@amd.com>