### PR TITLE
lopper: assists: baremetal_xparameters_xlnx: Fix whitespace after the macro name warning

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -252,6 +252,7 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
             temp_label = temp_label[0]
             if temp_label != node_name:
                 plat.buf('\n/* Canonical definitions for peripheral %s */' % label_name)
+                node_name = node_name.replace("-", "_")
                 plat.buf('\n#define XPAR_%s_%s_BASEADDR %s\n' % (node_name, count, hex(val[0])))
                 plat.buf('#define XPAR_%s_%s_HIGHADDR %s\n' % (node_name, count, hex(val[0] + val[1] - 1)))
         except KeyError:


### PR DESCRIPTION


While generate c defines don't geneate define with - it should be generated with _ between name spaces.

Signed-off-by: Appana Durga Kedareswara rao <appana.durga.kedareswara.rao@amd.com>