### PR TITLE
lops: fix comment style

### DIFF
--- a/lopper/lops/lop-domain-a72-prune.dts
+++ b/lopper/lops/lop-domain-a72-prune.dts
@@ -170,7 +170,7 @@
                         for i in n.subnodes():
                             if 'xlnx,axi-intc-4.1' in i.propval('compatible'):
                                 tree.delete(i)
-                            // Delete the un needed axi_noc node if present
+                            # Delete the un needed axi_noc node if present
                             if re.search('axi_noc@', i.name):
                                 tree.delete(i)
                        ";


### PR DESCRIPTION
Somehow device tree style comments (//) have appeared in the python code blocks of these lops. That is a syntax error, and makes them invalid.

convert to python style #, to at least make them executable again.

Signed-off-by: Appana Durga Kedareswara rao <appana.durga.kedareswara.rao@amd.com>