### PR TITLE
baremetal_assists: Modifying baremetal assists to support use of multiple ESW repos

### DIFF
--- a/lopper/assists/baremetal_bspconfig_xlnx.py
+++ b/lopper/assists/baremetal_bspconfig_xlnx.py
@@ -13,9 +13,10 @@ import os
 import glob
 
 sys.path.append(os.path.dirname(__file__))
+
 from baremetalconfig_xlnx import compat_list, get_cpu_node
 from baremetallinker_xlnx import get_memranges
-from bmcmake_metadata_xlnx import to_cmakelist
+from common_utils import to_cmakelist
 
 def is_compat( node, compat_string_to_test ):
     if "module,baremetal_bspconfig_xlnx" in compat_string_to_test:

--- a/lopper/assists/baremetal_getsupported_comp_xlnx.py
+++ b/lopper/assists/baremetal_getsupported_comp_xlnx.py
@@ -7,16 +7,15 @@
 # * SPDX-License-Identifier: BSD-3-Clause
 # */
 import sys
-import types
-from lopper import Lopper
-from lopper import LopperFmt
-import lopper
-from lopper.tree import *
-from re import *
 import os
-import yaml
-import json
 import glob
+import yaml
+import re
+
+sys.path.append(os.path.dirname(__file__))
+
+import common_utils as utils
+from baremetalconfig_xlnx import get_cpu_node
 
 def is_compat( node, compat_string_to_test ):
     if re.search( "module,baremetal_getsupported_comp_xlnx", compat_string_to_test):
@@ -27,77 +26,86 @@ class VerboseSafeDumper(yaml.SafeDumper):
     def ignore_aliases(self, data):
         return True
 
-def xlnx_get_supported_component(root_dir, proc_ip_name):
-    standalone_app_dict = {}
-    freertos_app_dict = {}
-    # Get supported component names
-    for yaml_file in glob.iglob(root_dir + '**/*.yaml', recursive=True):
-        with open(str(yaml_file), "r") as stream:
-            schema = yaml.safe_load(stream)
-            try:
-                proc_list = schema['supported_processors']
-                is_supported_app = [proc for proc in proc_list if re.match(proc, proc_ip_name)]
-                os_list = schema['supported_os']
-                app_description = schema['description']
-                if is_supported_app:
-                    if "standalone" in os_list:
-                        standalone_app_dict.update({Path(yaml_file).stem:{"description":app_description}})
-                    if "freertos10_xilinx" in os_list:
-                        freertos_app_dict.update({Path(yaml_file).stem:{"description":app_description}})
-                dep_lib_list = list(schema['depends_libs'].keys())
-                if is_supported_app:
-                    if "standalone" in os_list:
-                        standalone_app_dict[Path(yaml_file).stem].update({"depends_libs":dep_lib_list})
-                    if "freertos10_xilinx" in os_list:
-                        freertos_app_dict[Path(yaml_file).stem].update({"depends_libs":dep_lib_list})
-            except KeyError:
-                pass
+def get_yaml_data(comp_name, comp_dir):
+    yaml_file = os.path.join(comp_dir, 'data', f'{comp_name}.yaml')
+    schema = utils.load_yaml(yaml_file)
+    supported_proc_list = schema.get('supported_processors',[])
+    supported_os_list = schema.get('supported_os',[])
+    description = schema.get('description',"")
+    dep_lib_list = list(schema.get('depends_libs',{}).keys())
 
-    return standalone_app_dict, freertos_app_dict
+    return supported_proc_list, supported_os_list, description, dep_lib_list
 
 def xlnx_baremetal_getsupported_comp(tgt_node, sdt, options):
     proc_name = options['args'][0]
-    repo_path = options['args'][1]
+    repo_path_data = utils.get_abs_path(options['args'][1])
 
-    root_node_subnodes = sdt.tree[tgt_node].subnodes()
-    prop_dict = sdt.tree['/__symbols__'].__props__
-    proc_ip_name = None
-    for c_node in root_node_subnodes:
-        try:
-            match = [label for label,node_abs in prop_dict.items() if re.match(node_abs[0], c_node.abs_path) and len(node_abs[0]) == len(c_node.abs_path)]
-            if re.match(proc_name, match[0]):
-                proc_ip_name = c_node['xlnx,ip-name'].value[0]
-        except:
-            pass
+    matched_node = get_cpu_node(sdt, options)
+    proc_ip_name = matched_node['xlnx,ip-name'].value[0]
 
-    supported_apps = {}
-    root_dir = repo_path + "/lib/sw_apps/"
-    standalone_app_dict, freertos_app_dict  = xlnx_get_supported_component(root_dir, proc_ip_name)
-    if standalone_app_dict:
-        supported_apps.update({"standalone":standalone_app_dict})
-    if freertos_app_dict:
-        supported_apps.update({"freertos":freertos_app_dict})
-    app_supported_dict = {proc_name:supported_apps}
+    supported_app_dict = {proc_name: {'standalone': {}, 'freertos': {}}}
+    supported_libs_dict = {proc_name: {'standalone': {}, 'freertos': {}}}
+
+    if utils.is_file(repo_path_data):
+        path_schema = utils.load_yaml(repo_path_data)
+    else:
+        path_schema = {
+            'library' : {},
+            'apps'    : {}
+        }
+
+        files = glob.glob(repo_path_data + '/**/data/*.yaml', recursive=True)
+        for entries in files:
+            dir_path = utils.get_dir_path(utils.get_dir_path(entries))
+            comp_name = utils.get_base_name(dir_path)
+            comp_name =  re.sub("_v(\d+)_(\d+)", "", comp_name)
+            yaml_data = utils.load_yaml(entries)
+            version = yaml_data.get('version','vless')
+
+            if yaml_data['type'] not in ['library','apps']:
+                continue
+
+            if yaml_data['type'] in ['library'] and version == 'vless':
+                print(f"""\b
+                    [ERROR]:  Couldnt set the paths correctly.
+                    {comp_name} in {repo_path_data} doesnt have a version.
+                    Library and OS needs version numbers in its yaml.
+                """)
+                sys.exit(1)
+
+            path_schema[yaml_data['type']][comp_name] = {version : dir_path}
+
+    apps_dict = path_schema.get('apps', {})
+    libs_dict = path_schema.get('library', {})
+
+    for app_name in list(apps_dict.keys()):
+        supported_proc_list, supported_os_list, description, dep_lib_list = get_yaml_data(app_name, apps_dict[app_name]['vless'])
+        if proc_ip_name in supported_proc_list:
+            app_dict = {app_name : {'description': description, 'depends_libs': dep_lib_list}}
+            if 'standalone' in supported_os_list:
+                supported_app_dict[proc_name]['standalone'].update(app_dict)
+            if "freertos10_xilinx" in supported_os_list:
+                supported_app_dict[proc_name]['freertos'].update(app_dict)
+
+    for lib_name in list(libs_dict.keys()):
+        cur_lib_dict = libs_dict[lib_name]
+        version_list = list(cur_lib_dict.keys())
+        version_list.sort(key = float, reverse = True)
+        sorted_lib_dict = {version: cur_lib_dict[version] for version in version_list}
+        lib_dir = cur_lib_dict[version_list[0]]
+        supported_proc_list, supported_os_list, description, dep_lib_list = get_yaml_data(lib_name, lib_dir)
+        if proc_ip_name in supported_proc_list:
+            lib_dict = {lib_name : {'description': description, 'depends_libs': dep_lib_list, 'versions': sorted_lib_dict}}
+            if 'standalone' in supported_os_list:
+                supported_libs_dict[proc_name]['standalone'].update(lib_dict)
+            if "freertos10_xilinx" in supported_os_list:
+                supported_libs_dict[proc_name]['freertos'].update(lib_dict)
+
+
     with open(os.path.join(sdt.outdir, 'app_list.yaml'), 'w') as fd:
-        fd.write(yaml.dump(app_supported_dict, sort_keys=False, indent=2, width=32768))
+        fd.write(yaml.dump(supported_app_dict, sort_keys=False, indent=2, width=32768))
 
-    supported_libs = {}
-    root_dir = repo_path + "/lib/sw_services/"
-    standalone_lib_dict, freertos_lib_dict = xlnx_get_supported_component(root_dir, proc_ip_name)
-    if standalone_lib_dict:
-        supported_libs.update({"standalone":standalone_lib_dict})
-    if freertos_lib_dict:
-        supported_libs.update({"freertos":freertos_lib_dict})
-    
-    root_dir = repo_path + "/ThirdParty/sw_services/"
-    standalone_lib_dict, freertos_lib_dict = xlnx_get_supported_component(root_dir, proc_ip_name)
-    for lib in supported_libs:
-        if lib == "standalone":
-            supported_libs['standalone'].update(standalone_lib_dict)
-        else:
-            supported_libs['freertos'].update(freertos_lib_dict)
-    lib_supported_dict = {proc_name:supported_libs}
     with open(os.path.join(sdt.outdir, 'lib_list.yaml'), 'w') as fd:
-        fd.write(yaml.dump(lib_supported_dict, sort_keys=False, indent=2, width=32768, Dumper=VerboseSafeDumper))
+        fd.write(yaml.dump(supported_libs_dict, sort_keys=False, indent=2, width=32768, Dumper=VerboseSafeDumper))
 
     return True

--- a/lopper/assists/baremetaldrvlist_xlnx.py
+++ b/lopper/assists/baremetaldrvlist_xlnx.py
@@ -7,23 +7,15 @@
 # * SPDX-License-Identifier: BSD-3-Clause
 # */
 import sys
-import types
 import os
 import re
-from pathlib import Path
-from pathlib import PurePath
-from io import StringIO
-import contextlib
-import importlib
-from lopper import Lopper
-from lopper import LopperFmt
-import lopper
-from lopper.tree import *
-from re import *
 import yaml
+import glob
 
 sys.path.append(os.path.dirname(__file__))
-from baremetalconfig_xlnx import *
+
+from baremetalconfig_xlnx import compat_list, get_mapped_nodes
+import common_utils as utils
 
 def is_compat(node, compat_string_to_test):
     if re.search( "module,baremetaldrvlist_xlnx", compat_string_to_test):
@@ -35,8 +27,10 @@ def is_compat(node, compat_string_to_test):
 def xlnx_generate_bm_drvlist(tgt_node, sdt, options):
     root_node = sdt.tree[tgt_node]
     root_sub_nodes = root_node.subnodes()
-    compatible_list = []
-    driver_list = []
+    compatible_dict = {}
+    ip_dict = {}
+
+    driver_list = ["common"]
     node_list = []
     # Traverse the tree and find the nodes having status=ok property
     # and create a compatible_list from these nodes.
@@ -48,68 +42,78 @@ def xlnx_generate_bm_drvlist(tgt_node, sdt, options):
         except:
            pass
 
+    driver_ip_list = []
+    mapped_ip_list = []
     mapped_nodelist = get_mapped_nodes(sdt, node_list, options)
     for node in mapped_nodelist:
-        compatible_list.append(node["compatible"].value)
+        compatible_dict.update({node: node["compatible"].value})
+        node_ip_name = node.propval('xlnx,ip-name')
+        if node_ip_name != ['']:
+            mapped_ip_list += node_ip_name
 
-    tmpdir = os.getcwd()
-    src_dir = options['args'][1]
-    os.chdir(src_dir)
-    os.chdir("XilinxProcessorIPLib/drivers/")
-    cwd = os.getcwd()
-    files = os.listdir(cwd)
-    depdrv_list = []
-    for name in files:
-        os.chdir(cwd)
-        if os.path.isdir(name):
-            os.chdir(name)
-            if os.path.isdir("data"):
-                os.chdir("data")
-                yamlfile = name + str(".yaml")
-                try:
-                    # Traverse each driver and find supported compatible list
-                    # match it aginst the compatible_list created above, if there
-                    # is a match append the driver name to the driver list.
-                    with open(yamlfile, 'r') as stream:
-                        schema = yaml.safe_load(stream)
-                        driver_compatlist = compat_list(schema)
-                        for comp in driver_compatlist:
-                            for c in compatible_list:
-                                match = [x for x in c if comp == x]
-                                if match:
-                                    driver_list.append(name)
-                                    if schema.get('depends',{}):
-                                        depdrv_list.append(list(schema['depends'].keys()))
-                except FileNotFoundError:
-                    pass
+    yaml_file_list = []
+    repo_path_data = options['args'][1]
+    if utils.is_file(repo_path_data):
+        repo_schema = utils.load_yaml(repo_path_data)
+        drv_data = repo_schema['driver']
+        for entries in drv_data.keys():
+            drv_path = drv_data[entries]['vless']
+            drv_name = os.path.basename(drv_path)
+            yaml_file_list += [os.path.join(drv_path, 'data', f"{drv_name}.yaml")]
+    else:
+        drv_dir = os.path.join(repo_path_data, "XilinxProcessorIPLib", "drivers")
+        if utils.is_dir(drv_dir, silent_discard=False):
+            yaml_file_list = glob.glob(drv_dir + '/**/data/*.yaml', recursive=True)
 
-    for depdrv in depdrv_list:
-        if isinstance(depdrv, list):
-            for dep in depdrv:
-                driver_list.append(dep)
-        else:
-            driver_list.append(depdrv)
-    driver_list = list(dict.fromkeys(driver_list))
-    # common driver needs to be present always
-    driver_list.append("common")
+    for yaml_file in yaml_file_list:
+        # Traverse each driver and find supported compatible list
+        # match it aginst the compatible_dict created above, if there
+        # is a match append the driver name to the driver list.
+        schema = utils.load_yaml(yaml_file)
+        driver_compatlist = compat_list(schema)
+        for comp in driver_compatlist:
+            for node,c in compatible_dict.items():
+                match = [x for x in c if comp == x]
+                if match:
+                    drv_name = utils.get_base_name(yaml_file).replace('.yaml','')
+                    driver_list += [drv_name]
+                    if schema.get('depends',{}):
+                        driver_list += list(schema['depends'].keys())
+                    ip_name = node.propval('xlnx,ip-name')
+                    driver_ip_list += ip_name
+                    if ip_name != ['']:
+                        ip_dict.update({ip_name[0]:drv_name})
+
+    generic_driver_set = list(set(mapped_ip_list) - set(driver_ip_list))
+    for entries in generic_driver_set:
+        ip_dict.update({entries:"None"})
+
+    ip_dict_keys = list(ip_dict.keys())
+    ip_dict_keys.sort()
+    ip_sorted_dict = {entries: ip_dict[entries] for entries in ip_dict_keys}
+
+    driver_list = list(set(driver_list))
     driver_list.sort()
-    os.chdir(tmpdir)
+
+    driver_list_for_yocto = []
+    yocto_pkg_config_entries = ""
+
+    for drv in driver_list:
+        yocto_drv_name = drv.replace("_", "-")
+        driver_list_for_yocto += [yocto_drv_name]
+        yocto_pkg_config_entries += f'''
+PACKAGECONFIG[{yocto_drv_name}] = "${{RECIPE_SYSROOT}}/usr/lib/lib{drv}.a,,{yocto_drv_name},,"'''
 
     with open(os.path.join(sdt.outdir, 'distro.conf'), 'w') as fd:
-        tmpdrv_list = [drv.replace("_", "-") for drv in driver_list]
-        tmp_str =  ' '.join(tmpdrv_list)
-        tmp_str = '"{}"'.format(tmp_str)
-        fd.write("DISTRO_FEATURES = %s" % tmp_str)
+        fd.write(f'DISTRO_FEATURES = "{" ".join(driver_list_for_yocto)}"')
 
-    with open(os.path.join(sdt.outdir, 'DRVLISTConfig.cmake'), 'w') as cfd:
-        cfd.write("set(DRIVER_LIST %s)\n" % to_cmakelist(driver_list))
+    with open(os.path.join(sdt.outdir, 'ip_drv_map.yaml'), 'w') as fd:
+        yaml.dump(ip_sorted_dict, fd, default_flow_style=False, sort_keys=False)
 
     with open(os.path.join(sdt.outdir, 'libxil.conf'), 'w') as fd:
-        for drv in driver_list:
-            drv1 = drv.replace("_", "-")
-            tmp_str1 = str("${RECIPE_SYSROOT}")
-            tmp_str = tmp_str1 + "/usr/lib/lib{}.a,,{},,".format(drv, drv1)
-            tmp_str = '"{}"'.format(tmp_str)
-            fd.write("\nPACKAGECONFIG[%s] = %s" % (drv1, tmp_str))
+        fd.write(yocto_pkg_config_entries)
+
+    with open(os.path.join(sdt.outdir, 'DRVLISTConfig.cmake'), 'w') as cfd:
+        cfd.write(f'set(DRIVER_LIST {";".join(driver_list)})\n')
 
     return driver_list

--- a/lopper/assists/baremetallinker_xlnx.py
+++ b/lopper/assists/baremetallinker_xlnx.py
@@ -7,31 +7,15 @@
 # * SPDX-License-Identifier: BSD-3-Clause
 # */
 
-import struct
 import sys
-import types
-import unittest
 import os
-import getopt
 import re
-import subprocess
-import shutil
-from pathlib import Path
-from pathlib import PurePath
-from io import StringIO
-import contextlib
-import importlib
-from lopper import Lopper
-from lopper import LopperFmt
-import lopper
 import lopper_lib
-from lopper.tree import *
-from re import *
 
 sys.path.append(os.path.dirname(__file__))
 from baremetalconfig_xlnx import scan_reg_size, get_cpu_node
-from bmcmake_metadata_xlnx import to_cmakelist
-from domain_access import *
+from common_utils import to_cmakelist
+from domain_access import domain_get_subnodes
 
 def is_compat( node, compat_string_to_test ):
     if re.search( "module,baremetallinker_xlnx", compat_string_to_test):

--- a/lopper/assists/common_utils.py
+++ b/lopper/assists/common_utils.py
@@ -1,0 +1,123 @@
+#/*
+# * Copyright (c) 2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# *
+# * Author:
+# *       Onkar Harsh <onkar.harsh@amd.com>
+# *
+# * SPDX-License-Identifier: BSD-3-Clause
+# */
+
+import os
+import sys
+import re
+import glob
+import yaml
+from typing import Any, List, Optional, Dict, Union
+import shutil
+
+def to_cmakelist(pylist):
+    cmake_list = ';'.join(pylist)
+    cmake_list = '"{}"'.format(cmake_list)
+
+    return cmake_list
+
+def is_file(filepath: str, silent_discard: bool = True) -> bool:
+    """Return True if the file exists Else returns False and raises Not Found Error Message.
+    
+    Args:
+        filepath: File Path.
+    Raises:
+        FileNotFoundError: Raises exception if file not found.
+    Returns:
+        bool: True, if file is found Or False, if file is not found.
+    """
+   
+    if os.path.isfile(filepath):
+        return True
+    elif not silent_discard:
+        err_msg = f"No such file exists: {filepath}"
+        raise FileNotFoundError(err_msg) from None
+    else:
+        return False
+
+def is_dir(dirpath: str, silent_discard: bool = True) -> bool:
+    """Checks if directory exists.
+    
+    Args:
+        dirpath: Directory Path.
+    Raises:
+        ValueError (Exception): Raises exception if directory not found.
+    Returns:
+        bool: True, if directory is found Or False, if directory is not found.
+    """
+
+    if os.path.isdir(dirpath):
+        return True
+    elif not silent_discard:
+        err_msg = f"No such directory exists: {dirpath}"
+        raise ValueError(err_msg) from None
+    else:
+        return False
+
+def get_base_name(fpath):
+    """
+    This api takes rel path or full path and returns base name
+    Args:
+        fpath: Path to get the base name from.
+    Returns:
+        string: Base name of the path
+    """
+    return os.path.basename(fpath.rstrip(os.path.sep))
+
+def get_dir_path(fpath):
+    """
+    This api takes file path and returns it's directory path
+    
+    Args:
+        fpath: Path to get the directory path from.
+    Returns:
+        string: Full Directory path of the passed path
+    """
+    return os.path.dirname(fpath.rstrip(os.path.sep))
+
+def get_abs_path(fpath):
+    """
+    This api takes file path and returns it's absolute path
+    Args:
+        fpath: Path to get the absolute path from.
+    Returns:
+        string: Absolute location of the passed path
+    """
+    return os.path.abspath(fpath)
+
+def load_yaml(filepath: str) -> Optional[dict]:
+    """Read yaml file data and returns data in a dict format.
+    
+    Args:
+        filepath: Path of the yaml file.
+    Returns:
+        dict: Return Python dict if the file reading is successful.
+    """
+
+    if is_file(filepath):
+        try:
+            with open(filepath) as f:
+                data = yaml.safe_load(f)
+            return data
+        except:
+            print("%s file reading failed" % filepath)
+            return {}
+    else:
+        return {}
+
+def copy_file(src: str, dest: str, follow_symlinks: bool = False, silent_discard: bool = True) -> None:
+    """
+    copies the file from source to destination.
+    Args:
+        | src: source file path
+        | dest: destination file path
+        | follow_symlinks: maintain the symlink while copying
+        | silent_discard: Dont raise exception if the source file doesnt exist 
+    """
+    is_file(src, silent_discard)
+    shutil.copy2(src, dest, follow_symlinks=follow_symlinks)


### PR DESCRIPTION
Currently, the baremetal assists are taking ESW repo as an input to determine the required drivers/libs/apps yaml paths. This limits these assists to be used only with one repo input. This patch enables the usage of multiple esw repo paths, maintaining the one repo feature as is.

Signed-off-by: Onkar Harsh <onkar.harsh@amd.com>