### PR TITLE
lopper: Update r5 node names as per latest system device-tree changes

### DIFF
--- a/lopper/assists/cfg_obj/modules/sdtinfo.py
+++ b/lopper/assists/cfg_obj/modules/sdtinfo.py
@@ -155,9 +155,9 @@ class SdtInfo:
                                     None
                 if node.name == "cpus-a53@0":
                     self.masters["psu_cortexa53_0"]["slaves"] = slaves
-                elif node.name == "cpus-r5@1":
+                elif node.name == "cpus-r5@0":
                     self.masters["psu_cortexr5_0"]["slaves"] = slaves
-                elif node.name == "cpus-r5@2":
+                elif node.name == "cpus-r5@1":
                     self.masters["psu_cortexr5_1"]["slaves"] = slaves
             except:
                 None

--- a/lopper/lops/lop-domain-a72-prune.dts
+++ b/lopper/lops/lop-domain-a72-prune.dts
@@ -20,23 +20,20 @@
                 };
                 lop_1 {
                         // modify to "nothing", is a remove operation
-                        compatible = "system-device-tree-v1,lop,modify";
-                        modify = "/cpus-r5@3::";
-                };
-                lop_1_0 {
-                        // modify to "nothing", is a remove operation
-                        compatible = "system-device-tree-v1,lop,modify";
-                        modify = "/cpus-r5@4::";
+                        compatible = "system-device-tree-v1,lop,select-v1";
+                        select_1;
+                        select_2 = "/.*:compatible:.*arm,cortex-r5.*";
+                        select_3 = "/.*:compatible:.*pmc-microblaze.*";
+                        select_4 = "/.*:compatible:.*psm-microblaze.*";
                 };
                 lop_2 {
-                        // modify to "nothing", is a remove operation
-                        compatible = "system-device-tree-v1,lop,modify";
-                        modify = "/cpus_microblaze@1::";
-                };
-                lop_3 {
-                        // modify to "nothing", is a remove operation
-                        compatible = "system-device-tree-v1,lop,modify";
-                        modify = "/cpus_microblaze@2::";
+                        compatible = "system-device-tree-v1,lop,code-v1";
+                        code = "
+                            # Check for domain node
+                            for s in tree.__selected__:
+                                tree.delete(s.parent)
+                                tree.delete(s)
+                        ";
                 };
                 lop_4 {
                         // modify to "nothing", is a remove operation

--- a/lopper/lops/lop-domain-linux-a53-prune.dts
+++ b/lopper/lops/lop-domain-linux-a53-prune.dts
@@ -15,18 +15,19 @@
                 // compatible = "system-device-tree-v1,lop";
                 lop_1 {
                         // modify to "nothing", is a remove operation
-                        compatible = "system-device-tree-v1,lop,modify";
-                        modify = "/cpus-r5@1::";
-                };
-                lop_1_0 {
-                        // modify to "nothing", is a remove operation
-                        compatible = "system-device-tree-v1,lop,modify";
-                        modify = "/cpus-r5@2::";
+                        compatible = "system-device-tree-v1,lop,select-v1";
+                        select_1;
+                        select_2 = "/.*:compatible:.*arm,cortex-r5.*";
+                        select_3 = "/.*:compatible:.*pmu-microblaze.*";
                 };
                 lop_2 {
-                        // modify to "nothing", is a remove operation
-                        compatible = "system-device-tree-v1,lop,modify";
-                        modify = "/cpus_microblaze@1::";
+                        compatible = "system-device-tree-v1,lop,code-v1";
+                        code = "
+                            # Check for domain node
+                            for s in tree.__selected__:
+                                tree.delete(s.parent)
+                                tree.delete(s)
+                        ";
                 };
                 lop_3 {
                         // modify to "nothing", is a remove operation


### PR DESCRIPTION
As per system device-tree specification each cpu cluster cpu node name should start from 0, update the code for the same.

Signed-off-by: Appana Durga Kedareswara rao <appana.durga.kedareswara.rao@amd.com>