### PR TITLE
Bug fixes

### DIFF
--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -26,7 +26,7 @@ def generate_drvcmake_metadata(sdt, node_list, src_dir, options):
 
     # Get the example_schema
     schema = utils.load_yaml(yaml_file)
-    driver_compatlist = compat_list(schema)
+    driver_compatlist = bm_config.compat_list(schema)
     example_schema = schema.get('examples',{})
        
     driver_nodes = []

--- a/lopper/assists/cfg_obj/modules/sdtinfo.py
+++ b/lopper/assists/cfg_obj/modules/sdtinfo.py
@@ -155,9 +155,9 @@ class SdtInfo:
                                     None
                 if node.name == "cpus-a53@0":
                     self.masters["psu_cortexa53_0"]["slaves"] = slaves
-                elif node.name == "cpus-r5@1":
+                elif node.name == "cpus-r5@0":
                     self.masters["psu_cortexr5_0"]["slaves"] = slaves
-                elif node.name == "cpus-r5@2":
+                elif node.name == "cpus-r5@1":
                     self.masters["psu_cortexr5_1"]["slaves"] = slaves
             except:
                 None

--- a/lopper/lops/lop-domain-a72-prune.dts
+++ b/lopper/lops/lop-domain-a72-prune.dts
@@ -20,23 +20,20 @@
                 };
                 lop_1 {
                         // modify to "nothing", is a remove operation
-                        compatible = "system-device-tree-v1,lop,modify";
-                        modify = "/cpus-r5@3::";
-                };
-                lop_1_0 {
-                        // modify to "nothing", is a remove operation
-                        compatible = "system-device-tree-v1,lop,modify";
-                        modify = "/cpus-r5@4::";
+                        compatible = "system-device-tree-v1,lop,select-v1";
+                        select_1;
+                        select_2 = "/.*:compatible:.*arm,cortex-r5.*";
+                        select_3 = "/.*:compatible:.*pmc-microblaze.*";
+                        select_4 = "/.*:compatible:.*psm-microblaze.*";
                 };
                 lop_2 {
-                        // modify to "nothing", is a remove operation
-                        compatible = "system-device-tree-v1,lop,modify";
-                        modify = "/cpus_microblaze@1::";
-                };
-                lop_3 {
-                        // modify to "nothing", is a remove operation
-                        compatible = "system-device-tree-v1,lop,modify";
-                        modify = "/cpus_microblaze@2::";
+                        compatible = "system-device-tree-v1,lop,code-v1";
+                        code = "
+                            # Check for domain node
+                            for s in tree.__selected__:
+                                tree.delete(s.parent)
+                                tree.delete(s)
+                        ";
                 };
                 lop_4 {
                         // modify to "nothing", is a remove operation

--- a/lopper/lops/lop-domain-linux-a53-prune.dts
+++ b/lopper/lops/lop-domain-linux-a53-prune.dts
@@ -15,18 +15,19 @@
                 // compatible = "system-device-tree-v1,lop";
                 lop_1 {
                         // modify to "nothing", is a remove operation
-                        compatible = "system-device-tree-v1,lop,modify";
-                        modify = "/cpus-r5@1::";
-                };
-                lop_1_0 {
-                        // modify to "nothing", is a remove operation
-                        compatible = "system-device-tree-v1,lop,modify";
-                        modify = "/cpus-r5@2::";
+                        compatible = "system-device-tree-v1,lop,select-v1";
+                        select_1;
+                        select_2 = "/.*:compatible:.*arm,cortex-r5.*";
+                        select_3 = "/.*:compatible:.*pmu-microblaze.*";
                 };
                 lop_2 {
-                        // modify to "nothing", is a remove operation
-                        compatible = "system-device-tree-v1,lop,modify";
-                        modify = "/cpus_microblaze@1::";
+                        compatible = "system-device-tree-v1,lop,code-v1";
+                        code = "
+                            # Check for domain node
+                            for s in tree.__selected__:
+                                tree.delete(s.parent)
+                                tree.delete(s)
+                        ";
                 };
                 lop_3 {
                         // modify to "nothing", is a remove operation


### PR DESCRIPTION
This pull request does the below
1.  Delete unneeded processor node in a generic way while generating linux device-tree
2. lopper: assists: bmcmake_metadata_xlnx: Fix failed name 'compat_list' is not defined