### PR TITLE
lopper: assists: bmcmake_metadata_xlnx: Remove unneeded list set operation on node list

### DIFF
--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -38,7 +38,6 @@ def generate_drvcmake_metadata(sdt, node_list, src_dir, options):
                    driver_nodes.append(node)
 
     driver_nodes = bm_config.get_mapped_nodes(sdt, driver_nodes, options)
-    driver_nodes = list(set(driver_nodes))
     nodename_list = []
     reg_list = []
     example_dict = {}
@@ -123,7 +122,6 @@ def getmatch_nodes(sdt, node_list, yaml_file, options):
                driver_nodes.append(node)
 
     driver_nodes = bm_config.get_mapped_nodes(sdt, driver_nodes, options)
-    driver_nodes = list(set(driver_nodes))
     return driver_nodes
 
 def getxlnx_phytype(sdt, value):


### PR DESCRIPTION


Remove unneeded list set operations on node list becasue of this line nodes names are coming out of order in cmake meta-data.