### PR TITLE
lopper: xilinx baremetal assist updates

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -10,6 +10,7 @@
 import sys
 import os
 import re
+import glob
 
 sys.path.append(os.path.dirname(__file__))
 
@@ -70,7 +71,16 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
         else:
             drv_dir = os.path.join(repo_path_data, "XilinxProcessorIPLib", "drivers", drv)
 
-        yaml_file_abs = os.path.join(drv_dir, "data", f"{drv}.yaml")
+        if not drv_dir:
+            has_drivers = [dir_name for dir_name in os.listdir(utils.get_dir_path(sdt.dts)) if "drivers" in dir_name]
+            if has_drivers:
+                has_drivers = os.path.join(utils.get_dir_path(sdt.dts), "drivers")
+                yaml_list = glob.glob(has_drivers + '/**/data/*.yaml', recursive=True)
+                yaml_file_abs = [yaml for yaml in yaml_list if f"{drv}.yaml" in yaml]
+                if yaml_file_abs:
+                    yaml_file_abs = yaml_file_abs[0]
+        else:
+            yaml_file_abs = os.path.join(drv_dir, "data", f"{drv}.yaml")
 
         if utils.is_file(yaml_file_abs):
             schema = utils.load_yaml(yaml_file_abs)

--- a/lopper/assists/baremetaldrvlist_xlnx.py
+++ b/lopper/assists/baremetaldrvlist_xlnx.py
@@ -47,7 +47,7 @@ def xlnx_generate_bm_drvlist(tgt_node, sdt, options):
     mapped_nodelist = get_mapped_nodes(sdt, node_list, options)
     for node in mapped_nodelist:
         compatible_dict.update({node: node["compatible"].value})
-        node_ip_name = node.propval('xlnx,ip-name')
+        node_ip_name = node.propval('xlnx,name')
         if node_ip_name != ['']:
             mapped_ip_list += node_ip_name
 
@@ -81,7 +81,7 @@ def xlnx_generate_bm_drvlist(tgt_node, sdt, options):
                     driver_list += [drv_name]
                     if schema.get('depends',{}):
                         driver_list += list(schema['depends'].keys())
-                    ip_name = node.propval('xlnx,ip-name')
+                    ip_name = node.propval('xlnx,name')
                     driver_ip_list += ip_name
                     if ip_name != ['']:
                         ip_dict.update({ip_name[0]:drv_name})

--- a/lopper/assists/baremetaldrvlist_xlnx.py
+++ b/lopper/assists/baremetaldrvlist_xlnx.py
@@ -62,6 +62,12 @@ def xlnx_generate_bm_drvlist(tgt_node, sdt, options):
             # Incase of versioned driver strip the version info
             drv_name = re.sub(r"_v.*_.*$", "", drv_name)
             yaml_file_list += [os.path.join(drv_path, 'data', f"{drv_name}.yaml")]
+        has_drivers = [dir_name for dir_name in os.listdir(utils.get_dir_path(sdt.dts)) if "drivers" in dir_name]
+        if has_drivers:
+            has_drivers = os.path.join(utils.get_dir_path(sdt.dts), "drivers")
+            if utils.is_dir(has_drivers, silent_discard=False):
+                yaml_list = glob.glob(has_drivers + '/**/data/*.yaml', recursive=True)
+                yaml_file_list.extend(yaml_list)
     else:
         drv_dir = os.path.join(repo_path_data, "XilinxProcessorIPLib", "drivers")
         if utils.is_dir(drv_dir, silent_discard=False):

--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -191,10 +191,12 @@ struct xtopology_t xtopology[] = {{'''
 def generate_hwtocmake_medata(sdt, node_list, src_path, repo_path_data, options, chosen_node, symbol_node):
     src_path = src_path.rstrip(os.path.sep)
     name = utils.get_base_name(utils.get_dir_path(src_path))
+    # Incase of versioned component strip the version info
+    name = re.sub(r"_v.*_.*$", "", name)
     yaml_file = os.path.join(utils.get_dir_path(src_path), "data", f"{name}.yaml")
 
     if not utils.is_file(yaml_file):
-        print(f"{drvname} Driver doesn't have yaml file")
+        print(f"{name} Driver doesn't have yaml file")
         return False
 
     schema = utils.load_yaml(yaml_file)


### PR DESCRIPTION
This pull request does the below
1. Update the assists to handle drivers which are part of system device-tree folder.
2. Update the ip_dict to use xlnx,name property instead of xlnx,ip-name
to provide all the hardware instances in the ip_drv_map.yaml file