### PR TITLE
Spec fixes march 2023

### DIFF
--- a/specification/source/chapter2-hardware.rst
+++ b/specification/source/chapter2-hardware.rst
@@ -169,11 +169,12 @@ Within each quartet:
    Property    ``#ranges-address-cells``
    =========== ==============================================================
    Value type  ``<u32>``
-   Description The number of cells used to represent an address within
-               the memory map of a CPU cluster node (the node in which the
-               *#ranges-address-cells* property appears). This should
-               be large enough to represent the maximum size of an address
-               in the data model of the cluster's CPU nodes.
+   Description Required; the number of cells used to represent an address
+               within the memory map of a CPU cluster node (the node in
+               which the *#ranges-address-cells* property appears).
+
+               This should be large enough to represent the maximum size of
+               an address in the data model of the cluster's CPU nodes.
    Example     CPUs have 64-bit addresses: ``#ranges-address-cells = <2>;``
    =========== ==============================================================
 
@@ -189,9 +190,10 @@ Within each quartet:
    Property    ``#ranges-size-cells``
    =========== ==============================================================
    Value type  ``<u32>``
-   Description The number of cells used to represent the size of a range of
-               addresses in the memory map of a CPU cluster node (the node
-               in which the *#ranges-size-cells* property appears), in bytes.
+   Description Required; the number of cells used to represent the size of a
+               range of addresses in the memory map of a CPU cluster node
+               (the node in which the *#ranges-size-cells* property
+               appears), in bytes.
 
                This must be large enough to specify all address ranges
                within the CPU cluster node's *address-map* property.

--- a/specification/source/chapter3-execution-domains.rst
+++ b/specification/source/chapter3-execution-domains.rst
@@ -104,8 +104,8 @@ Execution Domain Binding, v1
                                                                    the default value is zero.
    ``sram``                            SD    ``<prop encoded       See :numref:`domains-sram`. Specifies
                                              array>``              the MMIO SRAM assigned to the domain.
-   ``id``                              R     ``<u32>``             A 32-bit integer that uniquely
-                                                                   identifies the domain
+   ``id``                              SD    ``<u32>``             See :numref:`domains-id`. A 32-bit integer
+                                                                   that uniquely identifies the domain.
    ``os,type``                         SD    ``<string>``          See :numref:`domains-os-type`
    ``#access-implicit-default-cells``  SD    ``<u32>``             See :numref:`domains-implicit-flags`
    ``access-implicit-default``         SD    array                 See :numref:`domains-implicit-flags`
@@ -297,6 +297,24 @@ Within each triplet:
   property.
 - *flags* contains domain-specific flags. The number of cells in each flag is
   defined by the *#sram-flags-cells* property of the execution domain.
+
+.. _domains-id:
+
+id Property
+~~~~~~~~~~~
+
+This property may be used to provide a unique numeric identifier for the
+domain.
+
+Although it is optional in general, the *id* property is required if the
+*compatible* property of the domain node contains any string which matches one
+of the following patterns:
+
+- "xilinx,subsystem*"
+- "xen,domain*"
+
+For example, a domain whose *compatible* property includes
+"xilinx,subsystem-v1" must have an *id* property.
 
 .. _domains-os-type:
 

--- a/specification/source/chapter3-execution-domains.rst
+++ b/specification/source/chapter3-execution-domains.rst
@@ -89,7 +89,7 @@ Execution Domain Binding, v1
                                                                    device in the *access* property. If absent,
                                                                    the default value is zero.
    ``access``                          SD    ``<prop encoded       See :numref:`domains-access`. Specifies
-                                             array>``              devices configured to only be accessible
+                                             array>``              devices configured to be accessible
                                                                    by this domain (the node in which the
                                                                    *access* property appears).
    ``#memory-flags-cells``             O     ``<u32>``             Specifies the number of ``<u32>`` cells used
@@ -188,10 +188,29 @@ access Property
    Value type  Optional ``<prop-encoded-array>`` encoded as an arbitrary
                number of (*device*, *flags*) pairs.
 
-   Description A list of devices the domain shall have exclusive access to,
+   Description A list of devices the domain shall have access to,
                using bus firewalls or other similar technologies.
    Example     ``access = <&mmc0>;``
    =========== ==============================================================
+
+The device access configured by this property is not exclusive. For instance,
+domains ``foo`` and ``bar`` both have access to the device node with phandle
+``&mmc0`` in this example:
+
+.. code-block:: DTS
+
+   foo {
+           /* ... */
+           access = <&mmc0>;
+   };
+   bar {
+           /* ... */
+           access = <&mmc0>;
+   };
+
+Note that most devices don't support concurrent accesses by multiple
+independent parties. It is responsibility of the two domains to
+arbitrate access to the device appropriately.
 
 Within each pair:
 

--- a/specification/source/chapter3-execution-domains.rst
+++ b/specification/source/chapter3-execution-domains.rst
@@ -224,9 +224,6 @@ Within each pair:
 memory Property
 ~~~~~~~~~~~~~~~
 
-.. FIXME: start and size #cells are unclear:
-   https://github.com/devicetree-org/lopper/issues/138
-
 .. FIXME: specify content of flags:
    https://github.com/devicetree-org/lopper/issues/137
 
@@ -249,10 +246,12 @@ Within each triplet:
 
 - *start* is the physical address of the start of the memory range. The
   number of cells used to represent the start address is determined by
-  the *#address-cells* property.
+  the *#address-cells* property of the parent node of the domain containing
+  the *memory* property.
 - *size* is the size of the memory range, in bytes. The number of cells
   used to represent the size is determined by the *#size-cells*
-  property.
+  property of the parent node of the domain containing
+  the *memory* property.
 - *flags* contains domain-specific flags. The number of cells in each flag is
   defined by the *#memory-flags-cells* property of the execution domain.
 
@@ -284,9 +283,6 @@ between two domains.
 sram Property
 ~~~~~~~~~~~~~
 
-.. FIXME: start and size #cells are unclear:
-   https://github.com/devicetree-org/lopper/issues/138
-
 .. FIXME: specify content of flags:
    https://github.com/devicetree-org/lopper/issues/137
 
@@ -310,10 +306,12 @@ Within each triplet:
 
 - *start* is the physical address of the start of the memory range. The
   number of cells used to represent the start address is determined by
-  the *#address-cells* property.
+  the *#address-cells* property of the parent node of the domain containing
+  the *sram* property.
 - *size* is the size of the memory range, in bytes. The number of cells
   used to represent the size is determined by the *#size-cells*
-  property.
+  property of the parent node of the domain containing
+  the *sram* property.
 - *flags* contains domain-specific flags. The number of cells in each flag is
   defined by the *#sram-flags-cells* property of the execution domain.
 

--- a/specification/source/chapter3-execution-domains.rst
+++ b/specification/source/chapter3-execution-domains.rst
@@ -151,6 +151,33 @@ Within the triplet:
   the domain runs on
 - *execution-level* is a cluster-specific execution level for the domain
 
+A zero value for the *cpu-mask* cell must be treated as though the bits for all
+CPUs in the node with phandle *cpu-cluster* were set. For example, with the
+following CPU cluster:
+
+.. code-block:: DTS
+
+   cpus_r5: cpus-r5 {
+           compatible = "cpus,cluster";
+
+           /* ... */
+
+           cpu@0 { /* ... */ };
+           cpu@1 { /* ... */ };
+   };
+
+This *cpus* property value:
+
+.. code-block:: none
+
+   cpus = <&cpus_r5 0x0 0x80000001>;
+
+must be treated identically to:
+
+.. code-block:: none
+
+   cpus = <&cpus_r5 0x3 0x80000001>;
+
 The execution level is the most privileged level that the domain can
 make use of. The permissible values for the *execution-level* cell in a
 *cpus* property depend on the CPU cluster hardware. The following


### PR DESCRIPTION
@zeddii This is a roll-up of the patches that I've sent to the list and which @sstabellini reviewed.

I left his reviewed-by off of `specification: domains: fix access property semantics` just to be conservative, although he did say he was OK with it with one suggested improvement, which I did make in this updated version of the patch.