### PR TITLE
lopper: assists: baremetalconfig_xlnx: Special handling for Handler-table property

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -281,6 +281,8 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
         try:
             cpu_freq = match_cpunode['xlnx,freq'].value[0]
             plat.buf(f'\n#define XPAR_CPU_CORE_CLOCK_FREQ_HZ {cpu_freq}\n')
+            ddr_sa = match_cpunode['xlnx,ddr-reserve-sa'].value[0]
+            plat.buf(f'\n#define XPAR_MICROBLAZE_DDR_RESERVE_SA {hex(ddr_sa)}\n')
         except KeyError:
             pass
     else:

--- a/lopper/assists/baremetalconfig_xlnx.py
+++ b/lopper/assists/baremetalconfig_xlnx.py
@@ -504,6 +504,11 @@ def xlnx_generate_prop(sdt, node, prop, drvprop_list, plat, pad, phandle_prop):
                 if j != (len(prop_vallist) - 1):
                     plat.buf(',')
                 drvprop_list.append(prop_val)
+    elif prop == "Handler-table":
+        # In the driver config structure this property is of type struct
+        # to avoid Missing braces around initializer warning add braces
+        # around value (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53119)
+        plat.buf('\n\t\t{{0U}}')
     else:
         try:
             prop_val = node[prop].value


### PR DESCRIPTION

In the driver config structure this property is of type struct to avoid Missing braces around initializer warning add braces around value (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53119 )