### PR TITLE
lopper: lops: lop-domain-linux-a53-prune: prune symbol node

### DIFF
--- a/lopper/lops/lop-domain-linux-a53-prune.dts
+++ b/lopper/lops/lop-domain-linux-a53-prune.dts
@@ -56,6 +56,7 @@
                       code = "
                           # Check for domain node
                           from domain_access import update_mem_node
+                          from baremetalconfig_xlnx import get_label
                           domain_node = []
                           for n in __selected__:
                               if re.search('domains', n.name):
@@ -179,6 +180,18 @@
                                       prop_val.append(address_map[inx+2*na])
                               modify_val = update_mem_node(node1, prop_val)
                               node1['reg'].value = modify_val
+
+                              # Update symbol node referneces
+                              symbol_node = tree['/__symbols__']
+                              prop_list = list(symbol_node.__props__.keys())
+                              match_label_list = []
+                              for n in tree['/'].subnodes():
+                                  matched_label = get_label(tree, symbol_node, n)
+                                  if matched_label:
+                                      match_label_list.append(matched_label)
+                              for prop in prop_list:
+                                  if prop not in match_label_list:
+                                      tree['/__symbols__'].delete(prop)
                       ";
                 };
         };


### PR DESCRIPTION
After pruning the system device-tree for linux need to prune symbol node as well so that it will be in sync with the generated linux device-tree nodes, updated the logic for the same.