### PR TITLE
bmconfig: Change in the logic to get the _g.c name for the drivers

### DIFF
--- a/lopper/assists/baremetalconfig_xlnx.py
+++ b/lopper/assists/baremetalconfig_xlnx.py
@@ -598,9 +598,16 @@ def xlnx_generate_bm_config(tgt_node, sdt, options):
         config_struct = str("X") + drvname.capitalize() + str("_Config")
     else:
         config_struct = config_struct[0]
+
+    out_g_file_name = utils.find_files("*_g.c", src_dir)
+    if out_g_file_name:
+        out_g_file_name = utils.get_base_name(out_g_file_name[0])
+        drvname = out_g_file_name.replace('_g.c','')
+    else:
         drvname = config_struct.split('_Config')[0].lower()
-        drvname = drvname[1:]
-    outfile = os.path.join(sdt.outdir,f"x{drvname}_g.c")
+        drvname = f"x{drvname[1:]}"
+        out_g_file_name = f"{drvname}_g.c"
+    outfile = os.path.join(sdt.outdir, out_g_file_name)
 
     plat = DtbtoCStruct(outfile)
     nodename_list = []
@@ -620,7 +627,7 @@ def xlnx_generate_bm_config(tgt_node, sdt, options):
         drvprop_list = []
         drvoptprop_list = []
         if index == 0:
-            plat.buf('#include "x%s.h"\n' % drvname)
+            plat.buf('#include "%s.h"\n' % drvname)
             plat.buf('\n%s %s __attribute__ ((section (".drvcfg_sec"))) = {\n' % (config_struct, config_struct + str("Table[]")))
         xlnx_generate_config_struct(sdt, node, drvprop_list, plat, driver_proplist, 0)
         if index == len(driver_nodes)-1:

--- a/lopper/assists/common_utils.py
+++ b/lopper/assists/common_utils.py
@@ -121,3 +121,18 @@ def copy_file(src: str, dest: str, follow_symlinks: bool = False, silent_discard
     """
     is_file(src, silent_discard)
     shutil.copy2(src, dest, follow_symlinks=follow_symlinks)
+
+def find_files(search_pattern, search_path):
+    """
+    This api find the files matching regex directories and returns absolute
+    path of files, if file exists
+
+    Args:
+        | search_pattern: The regex pattern to be searched in file names
+        | search_path: The directory that needs to be searched
+    Returns:
+        string: All the file paths that matches the pattern in the searched path.
+
+    """
+
+    return glob.glob(f"{search_path}{os.path.sep}{search_pattern}")


### PR DESCRIPTION
Currently we are relying on the Config sturcture name to get the _g.c file name. Instead we can rely on the _g.c file name already present in the driver folder and create the _g.c file with the same name as the output of this assist. This solves the issue with devcfg driver where the Config name is DCfg but the driver name and the file name starts with devcfg