### PR TITLE
lopper: assists: baremetalconfig_xlnx: Fix race condition in the cmake meta file name

### DIFF
--- a/lopper/assists/baremetalconfig_xlnx.py
+++ b/lopper/assists/baremetalconfig_xlnx.py
@@ -614,7 +614,7 @@ def xlnx_generate_bm_config(tgt_node, sdt, options):
     for node in driver_nodes:
         nodename_list.append(node.name)
 
-    cmake_file = drvname.upper() + str("Config.cmake")
+    cmake_file = drvname[1:].upper() + str("Config.cmake")
     cmake_file = os.path.join(sdt.outdir,f"{cmake_file}")
     with open(cmake_file, 'a') as fd:
        fd.write("set(DRIVER_INSTANCES %s)\n" % utils.to_cmakelist(nodename_list))


### PR DESCRIPTION


Commit 9d7f530eabc4 bmconfig: Change in the logic to get the _g.c name for the drivers overridden the drvname variable accoridng to the _g.c file name but the the drivers are looking for the cmake meta-data file with the driver name update the logic for the same.