### PR TITLE
lopper: Add initial PL Microblaze support

### DIFF
--- a/lopper/assists/baremetallinker_xlnx.py
+++ b/lopper/assists/baremetallinker_xlnx.py
@@ -79,7 +79,7 @@ def get_memranges(tgt_node, sdt, options):
                         node['reg'].value = modify_val
 
     #Maintain a static memory IP list this is needed inorder to capture proper ip name in the linker script
-    xlnx_memipname = {"axi_bram": 0, "ps7_ddr": 0, "psu_ddr": 0, "psv_ddr": 0, "mig": 0, "lmb_bram": 0, "axi_noc": 0, "psu_ocm": 0,  "psv_ocm": 0, "ddr4": 0}
+    xlnx_memipname = {"axi_bram": 0, "ps7_ddr": 0, "psu_ddr": 0, "psv_ddr": 0, "mig": 0, "lmb_bram": 0, "axi_noc": 0, "psu_ocm": 0,  "psv_ocm": 0, "ddr4": 0, "mig_7series": 0}
     for node in root_sub_nodes:
         try:
             device_type = node["device_type"].value

--- a/lopper/lops/lop-microblaze.dts
+++ b/lopper/lops/lop-microblaze.dts
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2020 Xilinx Inc. All rights reserved.
+ * Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/dts-v1/;
+
+/ {
+        compatible = "system-device-tree-v1,lop";
+        lops {
+                lop_1_1 {
+                      compatible = "system-device-tree-v1,lop,select-v1";
+                      select_1;
+                      select_2 = "/cpus_microblaze.*/cpu*.*:compatible:.*microblaze";
+                      select_3 = ":xlnx,use-barrel:1";
+                      lop_1_1_1 {
+                          compatible = "system-device-tree-v1,lop,code-v1";
+                          code = "
+                               for n in tree.__selected__:
+                                   n['xlnx,use-barrel'].tunes = '-mxl-barrel-shift'
+                          ";
+                      };
+                };
+                lop_2_1 {
+                      compatible = "system-device-tree-v1,lop,select-v1";
+                      select_1;
+                      select_2 = "/cpus_microblaze.*/cpu*.*:compatible:.*microblaze";
+                      select_3 = ":xlnx,endianness:1";
+                      lop_2_1_1 {
+                          compatible = "system-device-tree-v1,lop,code-v1";
+                          code = "
+                               for n in tree.__selected__:
+                                   n['xlnx,endianness'].tunes = '-mlittle-endian'
+                          ";
+                      };
+                };
+                lop_3_1 {
+                      compatible = "system-device-tree-v1,lop,select-v1";
+                      select_1;
+                      select_2 = "/cpus_microblaze.*/cpu*.*:compatible:.*microblaze";
+                      select_3 = ":xlnx,data-size:0x40";
+                      lop_3_1_1 {
+                          compatible = "system-device-tree-v1,lop,code-v1";
+                          code = "
+                               for n in __selected__:
+                                   n['xlnx,data-size'].tunes = '-m64'
+                          ";
+                      };
+                };
+                lop_4_1 {
+                      compatible = "system-device-tree-v1,lop,select-v1";
+                      select_1;
+                      select_2 = "/cpus_microblaze.*/cpu*.*:compatible:.*microblaze";
+                      select_3 = ":xlnx,use-pcmp-instr:1";
+                      lop_4_1_1 {
+                          compatible = "system-device-tree-v1,lop,code-v1";
+                          code = "
+                               for n in tree.__selected__:
+                                   n['xlnx,use-pcmp-instr'].tunes = '-mxl-pattern-compare'
+                          ";
+                      };
+                };
+                lop_5_1 {
+                      compatible = "system-device-tree-v1,lop,select-v1";
+                      select_1;
+                      select_2 = "/cpus_microblaze.*/cpu*.*:compatible:.*microblaze";
+                      select_3 = ":xlnx,use-reorder-instr:0";
+                      lop_5_1_1 {
+                          compatible = "system-device-tree-v1,lop,code-v1";
+                          code = "
+                               for n in tree.__selected__:
+                                   n['xlnx,use-reorder-instr'].tunes = '-mno-xl-reorder'
+                          ";
+                      };
+                };
+                lop_6_1 {
+                      compatible = "system-device-tree-v1,lop,select-v1";
+                      select_1;
+                      select_2 = "/cpus_microblaze.*/cpu*.*:compatible:.*microblaze";
+                      select_3 = ":xlnx,area-optimized:2";
+                      lop_6_1_1 {
+                          compatible = "system-device-tree-v1,lop,code-v1";
+                          code = "
+                               for n in tree.__selected__:
+                                   n['xlnx,area-optimized'].tunes = '-mxl-frequency'
+                          ";
+                      };
+                };
+                lop_7_1 {
+                      compatible = "system-device-tree-v1,lop,select-v1";
+                      select_1;
+                      select_2 = "/cpus_microblaze.*/cpu*.*:compatible:.*microblaze";
+                      select_3 = ":xlnx,use-hw-mul:0";
+                      lop_7_1_1 {
+                          compatible = "system-device-tree-v1,lop,code-v1";
+                          code = "
+                               for n in tree.__selected__:
+                                   n['xlnx,use-hw-mul'].tunes = '-mxl-soft-mul'
+                          ";
+                      };
+                };
+                lop_8_1 {
+                      compatible = "system-device-tree-v1,lop,select-v1";
+                      select_1;
+                      select_2 = "/cpus_microblaze.*/cpu*.*:compatible:.*microblaze";
+                      select_3 = ":xlnx,use-hw-mul:!0";
+                      lop_8_1_1 {
+                          compatible = "system-device-tree-v1,lop,code-v1";
+                          code = "
+                               for n in tree.__selected__:
+                                   if n['xlnx,use-hw-mul'].value[0] > 1:
+                                       n['xlnx,use-hw-mul'].tunes = '-mno-xl-soft-mul -mxl-multiply-high'
+                                   else:
+                                       n['xlnx,use-hw-mul'].tunes = '-mno-xl-soft-mul'
+                          ";
+                      };
+                };
+                lop_9_1 {
+                      compatible = "system-device-tree-v1,lop,select-v1";
+                      select_1;
+                      select_2 = "/cpus_microblaze.*/cpu*.*:compatible:.*microblaze";
+                      select_3 = ":xlnx,use-div:1";
+                      lop_9_1_1 {
+                          compatible = "system-device-tree-v1,lop,code-v1";
+                          code = "
+                               for n in tree.__selected__:
+                                   n['xlnx,use-div'].tunes = '-mno-xl-soft-div'
+                          ";
+                      };
+                };
+                lop_10_1 {
+                      compatible = "system-device-tree-v1,lop,select-v1";
+                      select_1;
+                      select_2 = "/cpus_microblaze.*/cpu*.*:compatible:.*microblaze";
+                      select_3 = ":xlnx,use-fpu:!0";
+                      lop_10_1_1 {
+                          compatible = "system-device-tree-v1,lop,code-v1";
+                          code = "
+                               for n in tree.__selected__:
+                                   if n['xlnx,use-fpu'].value[0] > 1:
+                                       n['xlnx,use-fpu'].tunes = '-mhard-float -mxl-float-convert -mxl-float-sqrt'
+                                   else:
+                                       n['xlnx,use-fpu'].tunes = '-mhard-float'
+                                       
+                          ";
+                      };
+                };
+                lop_11_1 {
+                      compatible = "system-device-tree-v1,lop,select-v1";
+                      select_1;
+                      select_2 = "/cpus_microblaze.*/cpu*.*:compatible:.*microblaze";
+                      lop_11_1_1 {
+                          compatible = "system-device-tree-v1,lop,code-v1";
+                          code = "
+                               for n in tree.__selected__:
+                                       version = n['model'].value[0]
+                                       n['model'].tunes = '-mcpu=v' + version.split(',')[1]
+
+                          ";
+                      };
+                };
+
+                lop_output_tunes {
+                      compatible = "system-device-tree-v1,lop,select-v1";
+                      select_1;
+                      select_2 = "/cpus_microblaze.*/cpu*.*:compatible:.*microblaze";
+                      lop_output_code {
+                           compatible = "system-device-tree-v1,lop,code-v1";
+                           code = "
+                               import yaml
+                               for n in tree.__selected__:
+                                   proplist= ['xlnx,use-barrel', 'xlnx,endianness', 'xlnx,data-size', 'xlnx,use-pcmp-instr', 'xlnx,use-reorder-instr', 'xlnx,area-optimized', 'xlnx,use-hw-mul', 'xlnx,use-div', 'xlnx,use-fpu', 'model']
+
+                                   cflaglist = []
+                                   cflags_data = {}
+                                   for property in proplist:
+                                       try:
+                                           cflaglist.append(n[property].tunes)
+                                       except:
+                                           continue
+                                   cflags = ' '.join(cflaglist)
+                                   n.tunes = cflags
+
+                                   libpath = []
+                                   libpath.append('microblazeeb-xilinx-elf/usr/lib/')
+                                   if n['xlnx,endianness'].value[0] == 1:
+                                       libpath.append('le/')
+
+                                   if n['xlnx,use-barrel'].value[0] == 1:
+                                       libpath.append('bs/')
+                
+                                   if n['xlnx,use-fpu'].value[0] > 0:
+                                       libpath.append('fpd/')
+        
+                                   if n['xlnx,use-pcmp-instr'].value[0] == 1:
+                                       libpath.append('p/')
+                
+                                   if n['xlnx,use-hw-mul'].value[0] > 0:
+                                       libpath.append('m/')
+                                   libdir = ''.join(libpath)
+                                   cflags_data['cflags'] = cflags
+                                   cflags_data['libpath'] = libdir
+
+                                   with open('cflags.yaml', 'w') as fd:
+                                         fd.write(yaml.dump(cflags_data, indent = 4))
+                               ";
+                      };
+                };
+        };
+};


### PR DESCRIPTION
- Update assist file baremetallinker_xlnx to support mig7 memory in linker
  file generation
- Add lop-microblaze.dts lops file to generate compiler
  flags and library path for Microblaze processor.
  Microblaze compiler flags are tightly coupled with
  Microblaze processor configured in specific HW design.

  lop-microblaze.dts generates cflags.yaml based on CPU node
  properties, which contains compiler flags and standard library path.