### PR TITLE
lopper: assists: Generate device_id and slrcount information in the cmake meta-data

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -311,6 +311,12 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
         plat.buf(f"\n/* Number of SLRs */")
         plat.buf(f"\n#define NUMBER_OF_SLRS {hex(val)}\n")
 
+    #Define for DEVICE_ID
+    if sdt.tree[tgt_node].propval('device_id') != ['']:
+        val = sdt.tree[tgt_node].propval('device_id', list)[0]
+        plat.buf(f"\n/* Device ID */")
+        plat.buf(f'\n#define XPAR_DEVICE_ID "{val}"\n')
+
     plat.buf('\n#endif  /* end of protection macro */')
     plat.out(''.join(plat.get_buf()))
 

--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -266,6 +266,12 @@ def generate_hwtocmake_medata(sdt, node_list, src_path, repo_path_data, options,
                 fd.write(f'set(STDIN_INSTANCE "{stdin_node.propval("xlnx,name")[0]}")\n')
             else:
                 fd.write(f'set(STDIN_INSTANCE "{bm_config.get_label(sdt, symbol_node, stdin_node)}")\n')
+            if sdt.tree['/'].propval('slrcount') != ['']:
+                val = sdt.tree['/'].propval('slrcount', list)[0]
+                fd.write(f'set(NUMBER_OF_SLRS {hex(val)} CACHE STRING "Number of slrs")\n')
+            if sdt.tree['/'].propval('device_id') != ['']:
+                val = sdt.tree['/'].propval('device_id', list)[0]
+                fd.write(f'set(DEVICE_ID "{val}" CACHE STRING "Device Id")\n')
 
     if topology_data:
         lwip_topolgy(sdt.outdir, topology_data)


### PR DESCRIPTION


If device_id and slrcount variable present in the root node generate the value of these properites in the cmake meta-data couple of secure libraries needs this information. Generate device_id param in the xparameters.h file.