### PR TITLE
lopper: assists: bmcmake_metadata_xlnx: Fix the lwip topology index

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -290,6 +290,9 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
         if match_cpunode.propval('xlnx,ddr-reserve-sa') != ['']:
             ddr_sa = match_cpunode.propval('xlnx,ddr-reserve-sa', list)[0]
             plat.buf(f'\n#define XPAR_MICROBLAZE_DDR_RESERVE_SA {hex(ddr_sa)}\n')
+        if match_cpunode.propval('xlnx,addr-size') != ['']:
+            addr_size = match_cpunode.propval('xlnx,addr-size', list)[0]
+            plat.buf(f'\n#define XPAR_MICROBLAZE_ADDR_SIZE {addr_size}\n')
     else:
         if match_cpunode.propval('xlnx,cpu-clk-freq-hz') != ['']:
             cpu_freq = match_cpunode.propval('xlnx,cpu-clk-freq-hz', list)[0]

--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -284,21 +284,19 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
     #CPU Freq related defines
     match_cpunode = bm_config.get_cpu_node(sdt, options)
     if re.search("microblaze", match_cpunode['compatible'].value[0]):
-        try:
-            cpu_freq = match_cpunode['xlnx,freq'].value[0]
+        if match_cpunode.propval('xlnx,freq') != ['']:
+            cpu_freq = match_cpunode.propval('xlnx,freq', list)[0]
             plat.buf(f'\n#define XPAR_CPU_CORE_CLOCK_FREQ_HZ {cpu_freq}\n')
-            ddr_sa = match_cpunode['xlnx,ddr-reserve-sa'].value[0]
+        if match_cpunode.propval('xlnx,ddr-reserve-sa') != ['']:
+            ddr_sa = match_cpunode.propval('xlnx,ddr-reserve-sa', list)[0]
             plat.buf(f'\n#define XPAR_MICROBLAZE_DDR_RESERVE_SA {hex(ddr_sa)}\n')
-        except KeyError:
-            pass
     else:
-        try:
-            cpu_freq = match_cpunode['xlnx,cpu-clk-freq-hz'].value[0]
+        if match_cpunode.propval('xlnx,cpu-clk-freq-hz') != ['']:
+            cpu_freq = match_cpunode.propval('xlnx,cpu-clk-freq-hz', list)[0]
             plat.buf(f'\n\n#define XPAR_CPU_CORE_CLOCK_FREQ_HZ {cpu_freq}\n')
-            timestamp_clk = match_cpunode['xlnx,timestamp-clk-freq'].value[0]
+        if match_cpunode.propval('xlnx,timestamp-clk-freq') != ['']:
+            timestamp_clk = match_cpunode.propval('xlnx,timestamp-clk-freq', list)[0]
             plat.buf(f'#define XPAR_CPU_TIMESTAMP_CLK_FREQ {timestamp_clk}\n')
-        except KeyError:
-            pass
 
     #PSS REF clocks define
     if match_cpunode.propval('xlnx,pss-ref-clk-freq') != ['']:

--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -212,7 +212,6 @@ def generate_hwtocmake_medata(sdt, node_list, src_path, repo_path_data, options,
     cmake_file = os.path.join(sdt.outdir, f"{name.capitalize()}Example.cmake")
     topology_data = {}
     with open(cmake_file, "a") as fd:
-        lwiptype_index = 0
         for drv, prop_list in sorted(meta_dict.items(), key=lambda kv:(kv[0], kv[1])):
             if utils.is_file(repo_path_data):
                 repo_schema = utils.load_yaml(repo_path_data)
@@ -244,7 +243,14 @@ def generate_hwtocmake_medata(sdt, node_list, src_path, repo_path_data, options,
                        reg,size = bm_config.scan_reg_size(node, node[prop].value, 0)
                        val = hex(reg)
                        if lwip and comp_type == "library":
-                           topology_data[val] = lwiptype_index
+                           if drv == "emaclite":
+                                topology_data[val] = 0
+                           elif drv == "ll_temac":
+                                topology_data[val] = 1
+                           elif drv == "axi_ethernet":
+                                topology_data[val] = 2
+                           elif drv == "emacps":
+                                topology_data[val] = 3
                     elif prop == "interrupts":
                        val = bm_config.get_interrupt_prop(sdt, node, node[prop].value)
                        val = val[0]
@@ -260,7 +266,6 @@ def generate_hwtocmake_medata(sdt, node_list, src_path, repo_path_data, options,
                     val_list.append(val)
                 fd.write(f"set({drv.upper()}{index}_PROP_LIST {utils.to_cmakelist(val_list)})\n")
                 fd.write(f"list(APPEND TOTAL_{drv.upper()}_PROP_LIST {drv.upper()}{index}_PROP_LIST)\n")
-            lwiptype_index += 1
         if standalone:
             stdin_node = bm_config.get_stdin(sdt, chosen_node, node_list)
             if stdin_node.propval('xlnx,name') != ['']:


### PR DESCRIPTION
lwip library topology index is currently being generated based on the driver probe order which may vary based on the repo order fix is by updating the index based on the driver name.