### PR TITLE
lopper: assists: baremetalconfig_xlnx: Make sure node order is preserved

### DIFF
--- a/lopper/assists/baremetal_gentestapp_xlnx.py
+++ b/lopper/assists/baremetal_gentestapp_xlnx.py
@@ -114,7 +114,7 @@ def xlnx_generate_testapp(tgt_node, sdt, options):
 
             for compat in driver_compatlist:
                 for node in node_list:
-                    compat_string = node['compatible'].value[0]
+                    compat_string = node['compatible'].value
                     label_name = get_label(sdt, symbol_node, node)
                     if compat in compat_string:
                         driver_nodes.append(node)

--- a/lopper/assists/baremetal_getsupported_comp_xlnx.py
+++ b/lopper/assists/baremetal_getsupported_comp_xlnx.py
@@ -114,7 +114,7 @@ def xlnx_baremetal_getsupported_comp(tgt_node, sdt, options):
 
 
     with open(os.path.join(sdt.outdir, 'app_list.yaml'), 'w') as fd:
-        fd.write(yaml.dump(supported_app_dict, sort_keys=False, indent=2, width=32768))
+        fd.write(yaml.dump(supported_app_dict, sort_keys=False, indent=2, width=32768, Dumper=VerboseSafeDumper))
 
     with open(os.path.join(sdt.outdir, 'lib_list.yaml'), 'w') as fd:
         fd.write(yaml.dump(supported_libs_dict, sort_keys=False, indent=2, width=32768, Dumper=VerboseSafeDumper))

--- a/lopper/assists/baremetalconfig_xlnx.py
+++ b/lopper/assists/baremetalconfig_xlnx.py
@@ -353,6 +353,8 @@ def get_mapped_nodes(sdt, node_list, options):
     # Remove shared phandles from invalid phandles list
     invalid_phandles_list = [phandle for phandle in invalid_phandles if phandle not in shared_phandles]
     valid_phandles = [phandle for phandle in all_phandles if phandle not in invalid_phandles_list]
+    # Make sure node order is preserved
+    node_list.sort(key=lambda n: n.phandle, reverse=False)
     valid_nodes = [node for node in node_list for handle in valid_phandles if handle == node.phandle]
     return valid_nodes
 


### PR DESCRIPTION
Make sure node order is preserved.