### PR TITLE
lopper: assists: Generate board information in the cmake meta-data

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -268,7 +268,11 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
     board_list = ["zcu102", "kc705", "kcu105"]
     root_compat = sdt.tree['/']['compatible'].value
     board_name = [b for b in board_list for board in root_compat if b in board]
-    if board_name:
+    if sdt.tree[tgt_node].propval('board') != ['']:
+        board = sdt.tree[tgt_node].propval('board', list)[0]
+        plat.buf(f"\n/*  BOARD  */")
+        plat.buf(f"\n#define XPAR_BOARD_{board.upper()}\n")
+    elif board_name:
         plat.buf(f'\n\n#define XPS_BOARD_{board_name[0].upper()}\n')
     
     # Memory Node related defines

--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -278,6 +278,9 @@ def generate_hwtocmake_medata(sdt, node_list, src_path, repo_path_data, options,
             if sdt.tree['/'].propval('device_id') != ['']:
                 val = sdt.tree['/'].propval('device_id', list)[0]
                 fd.write(f'set(DEVICE_ID "{val}" CACHE STRING "Device Id")\n')
+            if sdt.tree['/'].propval('board') != ['']:
+                val = sdt.tree['/'].propval('board', list)[0]
+                fd.write(f'set(BOARD "{val}" CACHE STRING "Device Id")\n')
 
     if topology_data:
         lwip_topolgy(sdt.outdir, topology_data)


### PR DESCRIPTION
If board variable is present in the root node generate the value of this property in the cmake meta-data and in xparameters.h file