### PR TITLE
lops: lop-microblaze.dts: Add check for model property

### DIFF
--- a/lopper/lops/lop-microblaze.dts
+++ b/lopper/lops/lop-microblaze.dts
@@ -187,17 +187,21 @@
                                    if n['xlnx,endianness'].value[0] == 1:
                                        libpath.append('le/')
 
+                                   if n['xlnx,data-size'].value[0] == 64:
+                                       libpath.append('m64/')
+
                                    if n['xlnx,use-barrel'].value[0] == 1:
                                        libpath.append('bs/')
-                
-                                   if n['xlnx,use-fpu'].value[0] > 0:
-                                       libpath.append('fpd/')
         
                                    if n['xlnx,use-pcmp-instr'].value[0] == 1:
                                        libpath.append('p/')
                 
                                    if n['xlnx,use-hw-mul'].value[0] > 0:
                                        libpath.append('m/')
+
+                                   if n['xlnx,use-fpu'].value[0] > 0:
+                                       libpath.append('fpd/')
+
                                    libdir = ''.join(libpath)
                                    cflags_data['cflags'] = cflags
                                    cflags_data['libpath'] = libdir

--- a/lopper/lops/lop-microblaze.dts
+++ b/lopper/lops/lop-microblaze.dts
@@ -150,6 +150,7 @@
                       compatible = "system-device-tree-v1,lop,select-v1";
                       select_1;
                       select_2 = "/cpus_microblaze.*/cpu*.*:compatible:.*microblaze";
+                      select_3 = ":model:";
                       lop_11_1_1 {
                           compatible = "system-device-tree-v1,lop,code-v1";
                           code = "


### PR DESCRIPTION
 For few HW designs "model" property might not be populated
 in system device tree. If so, code which reads model
 property throws exception.
    
 Add checks in lops, so that model property value would
 be read only when it is present in processor node.