### PR TITLE
lopper: assists: baremetal_gentestapp_xlnx: Update the assist to handle versioned drivers

### DIFF
--- a/lopper/assists/baremetal_gentestapp_xlnx.py
+++ b/lopper/assists/baremetal_gentestapp_xlnx.py
@@ -66,6 +66,8 @@ def xlnx_generate_testapp(tgt_node, sdt, options):
             except KeyError:
                 drv_path_in_yaml = drv_data[entries]['path'][0]
             drv_name_in_yaml = os.path.basename(drv_path_in_yaml)
+            # Incase of versioned component strip the version info
+            drv_name_in_yaml = re.sub(r"_v.*_.*$", "", drv_name_in_yaml)
             yaml_file_list += [os.path.join(drv_path_in_yaml, 'data', f"{drv_name_in_yaml}.yaml")]
     else:
         drv_dir = os.path.join(repo_path_data, "XilinxProcessorIPLib", "drivers")


### PR DESCRIPTION


If the driver folder name is versioned current logic is reading incorrect yaml file, this commit fixes the same.