### PR TITLE
lopper: assists: baremetal_xparameters_xlnx: Add support for generati…

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -329,6 +329,16 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
         plat.buf(f"\n/* Device ID */")
         plat.buf(f'\n#define XPAR_DEVICE_ID "{val}"\n')
 
+    #Define for XSEM_CFRSCAN_EN
+    if sdt.tree[tgt_node].propval('semmem-scan') != ['']:
+        val = sdt.tree[tgt_node].propval('semmem-scan', list)[0]
+        plat.buf(f'\n#define XSEM_CFRSCAN_EN {val}\n')
+
+    #Define for XSEM_NPISCAN_EN
+    if sdt.tree[tgt_node].propval('semnpi-scan') != ['']:
+        val = sdt.tree[tgt_node].propval('semnpi-scan', list)[0]
+        plat.buf(f'\n#define XSEM_NPISCAN_EN {val}\n')
+
     plat.buf('\n#endif  /* end of protection macro */')
     plat.out(''.join(plat.get_buf()))
 


### PR DESCRIPTION
…ng XSEM_CFRSCAN_EN and XSEM_NPISCAN_EN defines

If the root node contains semmem-scan and semnpi-scan variables Generate the XSEM_CFRSCAN_EN and XSEM_NPISCAN_EN defines in xparameters.h file.