### PR TITLE
lopper: assists: baremetallinker_xlnx: Fix UnboundLocalError has_ocm

### DIFF
--- a/lopper/assists/baremetallinker_xlnx.py
+++ b/lopper/assists/baremetallinker_xlnx.py
@@ -285,6 +285,8 @@ def xlnx_generate_bm_linker(tgt_node, sdt, options):
     has_ddr = [x for x in mem_ranges.keys() for ddr in lower_ddrs if re.search(ddr, x)]
     if has_ddr and not memtest_config:
         default_ddr = has_ddr[0]
+    has_ocm = None
+    has_ram = None
     ## For memory tests configuration default memory should be ocm if available
     if memtest_config:
         has_ocm = [x for x in mem_ranges.keys() if "ocm" in x]
@@ -307,8 +309,11 @@ def xlnx_generate_bm_linker(tgt_node, sdt, options):
             size -= start
         memip_list.append(key)
         cfd.write("set(%s %s)\n" % (key, to_cmakelist([hex(start), hex(size)])))
-    if has_ocm and memtest_config:
-        memip_list.insert(0, memip_list.pop(memip_list.index(has_ocm[0])))
+    if memtest_config:
+        if has_ocm:
+            memip_list.insert(0, memip_list.pop(memip_list.index(has_ocm[0])))
+        elif has_ram:
+            memip_list.insert(0, memip_list.pop(memip_list.index(has_ram[0])))
     cfd.write("set(TOTAL_MEM_CONTROLLERS %s)\n" % to_cmakelist(memip_list))
     cfd.write(f'set(MEMORY_SECTION "MEMORY\n{{{mem_sec}\n}}")\n')
     if stack_size:


### PR DESCRIPTION
Commit 64f6ad5e9cf8 (lopper: assists: baremetallinker_xlnx: Fix race condition in the memtest config) is not handling the has_ocm variable properly due to which getting the Fix UnboundLocalError has_ocm, this commit fixes the same.