### PR TITLE
lopper: assists: baremetal_xparameters_xlnx: Ignore Subnodes

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -166,6 +166,10 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
                     elif prop == "child,required":
                         for j,child in enumerate(list(node.child_nodes.items())):
                             for k,p in enumerate(pad):
+                                if type(p) is dict:
+                                    break
+                                if p == "nosub":
+                                    continue
                                 try:
                                     val = hex(child[1][p].value[0])
                                 except KeyError:


### PR DESCRIPTION
The subnodes within a device (where they exist) are not necessary to be included in xparamaters.h, the base paramaters are sufficeint.

This patch excudes the submodes by using a break on finding a dict withing the node being parsed.

"nosub" is also a command that should not be included, a continue is used for this instance.