### PR TITLE
lopper: assists: baremetal_xparameters_xlnx: Fix race condition in th…

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -89,7 +89,10 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
             driver_compatlist = bm_config.compat_list(schema)
             driver_proplist = schema.get('required',{})
             if schema.get('additionalProperties', {}):
-                driver_proplist.extend(schema.get('additionalProperties',{}))
+                if driver_proplist:
+                    driver_proplist.extend(schema.get('additionalProperties',{}))
+                else:
+                    driver_proplist = schema.get('additionalProperties',{})
             match_nodes = []
             for comp in driver_compatlist:
                 for node,compatible_list in sorted(node_dict.items(), key=lambda e: e[0], reverse=False):


### PR DESCRIPTION
…e additionalProperties handling

In case driver yaml doesn't have required section and have only the additionalProperties existing code is not handling this use case properly fix the same.