### PR TITLE
lopper: assists: Add proper checks for chosen node handling

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -334,9 +334,10 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
     #Defines for STDOUT and STDIN Baseaddress
     if chosen_node:
         stdin_node = bm_config.get_stdin(sdt, chosen_node, total_nodes)
-        val, size = bm_config.scan_reg_size(stdin_node, stdin_node['reg'].value, 0)
-        plat.buf(f"\n#define STDOUT_BASEADDRESS {hex(val)}")
-        plat.buf(f"\n#define STDIN_BASEADDRESS {hex(val)}\n")
+        if stdin_node:
+            val, size = bm_config.scan_reg_size(stdin_node, stdin_node['reg'].value, 0)
+            plat.buf(f"\n#define STDOUT_BASEADDRESS {hex(val)}")
+            plat.buf(f"\n#define STDIN_BASEADDRESS {hex(val)}\n")
 
     #Define for NUMBER_OF_SLRS
     if sdt.tree[tgt_node].propval('slrcount') != ['']:

--- a/lopper/assists/baremetalconfig_xlnx.py
+++ b/lopper/assists/baremetalconfig_xlnx.py
@@ -277,10 +277,13 @@ def is_compat(node, compat_string_to_test):
     return ""
 
 def get_stdin(sdt, chosen_node, node_list):
-    prop_val = chosen_node['stdout-path'].value
-    serial_node = sdt.tree.alias_node(prop_val[0].split(':')[0])
-    match = [x for x in node_list if re.search(x.name, serial_node.name)]
-    return match[0]
+    if chosen_node.propval('stdout-path') != ['']:
+        prop_val = chosen_node['stdout-path'].value
+        serial_node = sdt.tree.alias_node(prop_val[0].split(':')[0])
+        match = [x for x in node_list if re.search(x.name, serial_node.name)]
+        return match[0]
+    else:
+        return 0
 
 def get_mapped_nodes(sdt, node_list, options):
     # Yocto Machine to CPU compat mapping
@@ -662,9 +665,10 @@ def xlnx_generate_bm_config(tgt_node, sdt, options):
     with open(cmake_file, 'a') as fd:
        fd.write("set(DRIVER_INSTANCES %s)\n" % utils.to_cmakelist(nodename_list))
        if stdin:
-           match = [x for x in nodename_list if re.search(x, stdin_node.name)]
-           if match:
-               fd.write("set(STDIN_INSTANCE %s)\n" % '"{}"'.format(match[0]))
+           if stdin_node:
+               match = [x for x in nodename_list if re.search(x, stdin_node.name)]
+               if match:
+                   fd.write("set(STDIN_INSTANCE %s)\n" % '"{}"'.format(match[0]))
 
     for index,node in enumerate(driver_nodes):
         drvprop_list = []


### PR DESCRIPTION
In case of chosen node is empty add proper checks to handle stdin by avoiding KeyError.