### PR TITLE
assists:baremetal_xparameters_xlnx: Fix for the wrong reuse of variable "index"

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -219,11 +219,11 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
 
                         if pad:
                             address_prop = ""
-                            for index in range(0,pad):
-                                if index == 0:
-                                    address_prop = hex(node[prop].value[index])
-                                elif index < len(node[prop].value):
-                                    address_prop += f"{node[prop].value[index]:08x}"
+                            for pad_num in range(0,pad):
+                                if pad_num == 0:
+                                    address_prop = hex(node[prop].value[pad_num])
+                                elif pad_num < len(node[prop].value):
+                                    address_prop += f"{node[prop].value[pad_num]:08x}"
                             prop = prop.replace("-", "_")
                             prop = prop.replace("xlnx,", "")
                             if address_prop:


### PR DESCRIPTION
c4c0b126fc8f5b commit added support to get a 64 bit property in xparameters.h. While adding the support, the "index" variable was wrongly used as a loop variable. The "index" variable was already declared before as a top level loop variable and this led to a wrong canonical entry in xparameters file. Renaming this index loop variable to fix this issue.