### PR TITLE
lopper: assists: Add support for pruned system device-tree

### DIFF
--- a/lopper/assists/baremetal_gentestapp_xlnx.py
+++ b/lopper/assists/baremetal_gentestapp_xlnx.py
@@ -43,7 +43,8 @@ def xlnx_generate_testapp(tgt_node, sdt, options):
         except:
            pass
 
-    node_list = get_mapped_nodes(sdt, node_list, options)
+    if sdt.tree[tgt_node].propval('pruned-sdt') == ['']:
+        node_list = get_mapped_nodes(sdt, node_list, options)
     for node in node_list:
         compatible_dict.update({node: node["compatible"].value})
 

--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -104,7 +104,8 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
                        node_list = [x for x in node_list if not(x.abs_path == node)]
                        if node1:
                            match_nodes.append(node1[0])
-            match_nodes = bm_config.get_mapped_nodes(sdt, match_nodes, options)
+            if sdt.tree[tgt_node].propval('pruned-sdt') == ['']:
+                match_nodes = bm_config.get_mapped_nodes(sdt, match_nodes, options)
             for index, node in enumerate(match_nodes):
                 label_name = bm_config.get_label(sdt, symbol_node, node)
                 label_name = label_name.upper()
@@ -256,7 +257,8 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
                 plat.buf('\n')
                                     
     # Generate Defines for Generic Nodes
-    node_list = bm_config.get_mapped_nodes(sdt, node_list, options)
+    if sdt.tree[tgt_node].propval('pruned-sdt') == ['']:
+        node_list = bm_config.get_mapped_nodes(sdt, node_list, options)
     prev = ""
     count = 0
     for node in node_list:

--- a/lopper/assists/baremetalconfig_xlnx.py
+++ b/lopper/assists/baremetalconfig_xlnx.py
@@ -641,7 +641,8 @@ def xlnx_generate_bm_config(tgt_node, sdt, options):
 
     # Remove duplicate nodes
     driver_nodes = list(set(driver_nodes))
-    driver_nodes = get_mapped_nodes(sdt, driver_nodes, options)
+    if sdt.tree[tgt_node].propval('pruned-sdt') == ['']:
+        driver_nodes = get_mapped_nodes(sdt, driver_nodes, options)
     if not config_struct:
         config_struct = str("X") + drvname.capitalize() + str("_Config")
     else:

--- a/lopper/assists/baremetaldrvlist_xlnx.py
+++ b/lopper/assists/baremetaldrvlist_xlnx.py
@@ -46,7 +46,10 @@ def xlnx_generate_bm_drvlist(tgt_node, sdt, options):
 
     driver_ip_dict = {}
     mapped_ip_dict = {}
-    mapped_nodelist = get_mapped_nodes(sdt, node_list, options)
+    if sdt.tree[tgt_node].propval('pruned-sdt') == ['']:
+        mapped_nodelist = get_mapped_nodes(sdt, node_list, options)
+    else:
+        mapped_nodelist = node_list
     for node in mapped_nodelist:
         compatible_dict.update({node: node["compatible"].value})
         node_name = node.propval('xlnx,name')

--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -55,7 +55,8 @@ def generate_drvcmake_metadata(sdt, node_list, src_dir, options):
                if compat in compat_string:
                    driver_nodes.append(node)
 
-    driver_nodes = bm_config.get_mapped_nodes(sdt, driver_nodes, options)
+    if sdt.tree['/'].propval('pruned-sdt') == ['']:
+        driver_nodes = bm_config.get_mapped_nodes(sdt, driver_nodes, options)
     nodename_list = []
     reg_list = []
     example_dict = {}
@@ -164,7 +165,8 @@ def getmatch_nodes(sdt, node_list, yaml_file, options):
 
     # Remove duplicate nodes
     driver_nodes = list(set(driver_nodes))
-    driver_nodes = bm_config.get_mapped_nodes(sdt, driver_nodes, options)
+    if sdt.tree['/'].propval('pruned-sdt') == ['']:
+        driver_nodes = bm_config.get_mapped_nodes(sdt, driver_nodes, options)
     return driver_nodes
 
 def getxlnx_phytype(sdt, value):

--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -131,4 +131,7 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
         if prop not in match_label_list:
             sdt.tree['/__symbols__'].delete(prop)
 
+    # Add new property which will be consumed by other assists
+    sdt.tree['/']['pruned-sdt'] = 1
+
     return True


### PR DESCRIPTION
If the system devic-tree is already pruned no need to run the get_mapped_nodes() API update the assist logic for the same.