### PR TITLE
Don't generate  config file in case driver is compatible with the given sdt

### DIFF
--- a/lopper/assists/baremetalconfig_xlnx.py
+++ b/lopper/assists/baremetalconfig_xlnx.py
@@ -658,6 +658,9 @@ def xlnx_generate_bm_config(tgt_node, sdt, options):
         out_g_file_name = f"{drvname}_g.c"
     outfile = os.path.join(sdt.outdir, out_g_file_name)
 
+    if driver_nodes == []:
+        return True
+
     plat = DtbtoCStruct(outfile)
     nodename_list = []
     for node in driver_nodes:

--- a/lopper/assists/xlnx_overlay_dt.py
+++ b/lopper/assists/xlnx_overlay_dt.py
@@ -20,8 +20,6 @@ from pathlib import PurePath
 from lopper import Lopper
 from lopper import LopperFmt
 import lopper
-from lopper_tree import *
-from lopper_tree import LopperNode
 from re import *
 import yaml
 import glob


### PR DESCRIPTION
Existing logic is generating empty config file in case driver
is not compatible with the given sdt, ideally we shouldn't
generate the config file