### PR TITLE
lopper: assists: gen_domain_dts: Fix race condition in deleting the c…

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -53,7 +53,7 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
     cpunode_list = sdt.tree.nodes('/cpu.*@.*')
     clustercpu_nodes = []
     for node in cpunode_list:
-        if node.parent.phandle != match_cpunode.parent.phandle:
+        if node.parent.phandle != match_cpunode.parent.phandle and node.phandle != match_cpunode.parent.phandle:
             clustercpu_nodes.append(node.parent)
     clustercpu_nodes = list(dict.fromkeys(clustercpu_nodes))
     for node in clustercpu_nodes:


### PR DESCRIPTION
…luster cpu node

Cluster cpu parent node name can also have cpu prefix handle, Update the checks to handle this use case as well.