### PR TITLE
lopper: assists: bmcmake_metadata_xlnx: Don't include IP subcores in …

### DIFF
--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -230,6 +230,7 @@ def generate_hwtocmake_medata(sdt, node_list, src_path, repo_path_data, options,
                 continue
 
             nodes = getmatch_nodes(sdt, node_list, drv_yamlpath, options)
+            nodes = [node for node in nodes if node.props('xlnx,is-hierarchy') == []]
             name_list = []
             for node in nodes:
                 if node.propval('xlnx,name') != ['']:


### PR DESCRIPTION
…the hw metadata

Video subsystems can have IP cores in it. Some examples of such IP cores are axi_vdma, axi_timer, axi_gpio etc. These IP cores are not visible from the processor and dont use the AXI Bus. But these cores are mapped as regular peripherals only in the system device-tree system device-tree we have a property called "xlnx,is-hierarchy" which will differentiate such IP subcores from the generic peripherals, update the code to not to pull the IP subcores info while generating the metadata.