### PR TITLE
lopper: lops: Keep the status disabled nodes in the pruned tree

### DIFF
--- a/lopper/lops/lop-domain-a72-prune.dts
+++ b/lopper/lops/lop-domain-a72-prune.dts
@@ -120,6 +120,10 @@
                               if 'tcm' in node1.name:
                                   continue
 
+                              if node1.propval('status') != ['']:
+                                  if 'disabled' in node1.propval('status', list)[0]:
+                                      continue
+
                               for handle in phandles:
                                   if handle == node1.phandle:
                                       match += 1

--- a/lopper/lops/lop-domain-linux-a53-prune.dts
+++ b/lopper/lops/lop-domain-linux-a53-prune.dts
@@ -113,6 +113,9 @@
                                          'psu_pmu_global_0', 'psu_qspi_linear_0', 'psu_rpu', 'psu_rsa', 'psu_siou']
                           for node1 in node_list:
                               match = 0
+                              if node1.propval('status') != ['']:
+                                  if 'disabled' in node1.propval('status', list)[0]:
+                                      continue
                               for handle in phandles:
                                   if handle and handle == node1.phandle:
                                       try:


### PR DESCRIPTION
Make sure to keep the status disabled nodes in the pruned tree as they are essential for Xen.