### PR TITLE
lopper: assists: baremetal*: Add proper checks

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -50,6 +50,7 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
            pass
 
     repo_path_data = options['args'][1]
+    cci_en = None
     for node in node_list:
         try:
             prop_val = node['dma-coherent'].value

--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -271,10 +271,11 @@ def generate_hwtocmake_medata(sdt, node_list, src_path, repo_path_data, options,
                 fd.write(f"list(APPEND TOTAL_{drv.upper()}_PROP_LIST {drv.upper()}{index}_PROP_LIST)\n")
         if standalone:
             stdin_node = bm_config.get_stdin(sdt, chosen_node, node_list)
-            if stdin_node.propval('xlnx,name') != ['']:
-                fd.write(f'set(STDIN_INSTANCE "{stdin_node.propval("xlnx,name")[0]}")\n')
-            else:
-                fd.write(f'set(STDIN_INSTANCE "{bm_config.get_label(sdt, symbol_node, stdin_node)}")\n')
+            if stdin_node:
+                if stdin_node.propval('xlnx,name') != ['']:
+                    fd.write(f'set(STDIN_INSTANCE "{stdin_node.propval("xlnx,name")[0]}")\n')
+                else:
+                    fd.write(f'set(STDIN_INSTANCE "{bm_config.get_label(sdt, symbol_node, stdin_node)}")\n')
             if sdt.tree['/'].propval('slrcount') != ['']:
                 val = sdt.tree['/'].propval('slrcount', list)[0]
                 fd.write(f'set(NUMBER_OF_SLRS {hex(val)} CACHE STRING "Number of slrs")\n')


### PR DESCRIPTION
Update the assists to have a proper checks inorder to avoid Python NameError, variable 'not defined'.