### PR TITLE
lopper:assists:baremetal_xparams Generate the Memory region names within NOC macros

### DIFF
--- a/lopper/assists/baremetal_bspconfig_xlnx.py
+++ b/lopper/assists/baremetal_bspconfig_xlnx.py
@@ -49,9 +49,12 @@ def xlnx_generate_bm_bspconfig(tgt_node, sdt, options):
             if "ps7_ddr" in key:
                 start = 1048576
                 size -= start
-            name = f"XPAR_{key.upper()}_BASEADDRESS"
+            suffix = "ADDRESS"
+            if "axi_noc" in key:
+                suffix = "ADDR"
+            name = f"XPAR_{key.upper()}_BASE{suffix}"
             mem_name_list.append(name)
-            name = f"XPAR_{key.upper()}_HIGHADDRESS"
+            name = f"XPAR_{key.upper()}_HIGH{suffix}"
             mem_name_list.append(name)
             mem_size_list.append(hex(start))
             mem_size_list.append(hex(start + size))

--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -323,8 +323,11 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
     mem_ranges = get_memranges(tgt_node, sdt, options)
     for key, value in sorted(mem_ranges.items(), key=lambda e: e[1][1], reverse=True):
         start,size = value[0], value[1]
-        plat.buf(f"\n#define XPAR_{key.upper()}_BASEADDRESS {hex(start)}")
-        plat.buf(f"\n#define XPAR_{key.upper()}_HIGHADDRESS {hex(start + size)}")
+        suffix = "ADDRESS"
+        if "axi_noc" in key:
+            suffix = "ADDR"
+        plat.buf(f"\n#define XPAR_{key.upper()}_BASE{suffix} {hex(start)}")
+        plat.buf(f"\n#define XPAR_{key.upper()}_HIGH{suffix} {hex(start + size - 1)}")
 
     if cci_en:
         plat.buf("\n#define XPAR_CACHE_COHERENT \n")


### PR DESCRIPTION
Presently, the NOC address related macros come in a generic way. To inline with the existing macro names and make the existing Translation Table work, improvise the logic to add region names of all the possible regions for AXI_NOC and AXI_NOC2.