### PR TITLE
assists: bmcmake_metadata_xlnx: Add check for interrupt property

### DIFF
--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -255,8 +255,11 @@ def generate_hwtocmake_medata(sdt, node_list, src_path, repo_path_data, options,
                            elif drv == "emacps":
                                 topology_data[val] = 3
                     elif prop == "interrupts":
-                       val = bm_config.get_interrupt_prop(sdt, node, node[prop].value)
-                       val = val[0]
+                        if node.propval('interrupts') != ['']:
+                            val = bm_config.get_interrupt_prop(sdt, node, node[prop].value)
+                            val = val[0]
+                        else:
+                            continue
                     elif prop == "axistream-connected":
                        val = hex(bm_config.get_phandle_regprop(sdt, prop, node[prop].value))
                     elif prop == "phy-handle":


### PR DESCRIPTION
interrupt property is optional property for all peripheral devices. It is fair scenario to not to have interrupt property in specific device node.

bmcmake_metadata_xlnx assist assumes that each timer device always contains interrupt property. It is trying to get interrupt property details without confirming whether property is present in given node.

Update assist file to check for presence of interrupt property before accessing it to avoid BSP creation failure.

Note: This bug found while testing ZU+ HW design, where AXI timer is present in PL and interrupt for AXI Timer IP is not enabled.