### PR TITLE
openamp: xlnx: Enable Linux generated Device Tree to work for OpenAMP…

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -157,15 +157,15 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
                             'psv_coresight_a721_etm', 'psv_coresight_a721_pmu', 'psv_coresight_a721_cti',
                             'psv_coresight_a721_pmu', 'psv_coresight_a721_cti', 'psv_coresight_apu_ela',
                             'psv_coresight_apu_etf', 'psv_coresight_apu_fun', 'psv_coresight_cpm_atm', 'psv_coresight_cpm_cti2a',
-                            'psv_tcm_global', 'psv_r5_tcm', 'psu_apu', 'psu_bbram_0', 'psu_cci_gpv', 'psu_crf_apb', 'psu_crl_apb',
+                            'psu_apu', 'psu_bbram_0', 'psu_cci_gpv', 'psu_crf_apb', 'psu_crl_apb',
                             'psu_csu_0', 'psu_ddr_phy', 'psu_ddr_qos_ctrl', 'psu_ddr_xmpu0_cfg', 'psu_ddr_xmpu1_cfg',
                             'psu_ddr_xmpu2_cfg', 'psu_ddr_xmpu3_cfg', 'psu_ddr_xmpu4_cfg', 'psu_ddr_xmpu5_cfg', 'psu_efuse',
                             'psu_fpd_gpv', 'psu_fpd_slcr', 'psu_fpd_slcr_secure', 'psu_fpd_xmpu_cfg', 'psu_fpd_xmpu_sink',
                             'psu_iou_scntr', 'psu_iou_scntrs', 'psu_iousecure_slcr', 'psu_iouslcr_0', 'psu_lpd_slcr',
                             'psu_lpd_slcr_secure', 'psu_lpd_xppu_sink', 'psu_mbistjtag', 'psu_message_buffers', 'psu_ocm_xmpu_cfg',
                             'psu_pcie_attrib_0', 'psu_pcie_dma', 'psu_pcie_high1', 'psu_pcie_high2', 'psu_pcie_low',
-                            'psu_pmu_global_0', 'psu_qspi_linear_0', 'psu_rpu', 'psu_rsa', 'psu_siou', 'psu_ipi', 'psu_r5_tcm_ram',
-                            'psx_tcm_global', 'psx_PSM_PPU', 'psx_ram_instr_cntlr', 'psx_rpu',
+                            'psu_pmu_global_0', 'psu_qspi_linear_0', 'psu_rpu', 'psu_rsa', 'psu_siou', 'psu_ipi',
+                            'psx_PSM_PPU', 'psx_ram_instr_cntlr', 'psx_rpu',
                             'psx_fpd_gpv']
 
     for node in root_sub_nodes:
@@ -173,6 +173,8 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
             if node.propval('xlnx,ip-name') != ['']:
                 val = node.propval('xlnx,ip-name', list)[0]
                 if val in linux_ignore_ip_list:
+                    sdt.tree.delete(node)
+                elif 'xlnx,zynqmp-ipi-mailbox' in node.propval('compatible'):
                     sdt.tree.delete(node)
             elif node.name == "rpu-bus":
                 sdt.tree.delete(node)
@@ -182,6 +184,8 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
                     continue
             if node.propval('status') != ['']:
                 if 'disabled' in node.propval('status', list)[0] and linux_dt:
+                    continue
+                elif "tcm" in node.propval('compatible', list)[0]:
                     continue
                 else:
                     sdt.tree.delete(node)

--- a/lopper/lops/lop-gen_domain_dts-invoke.dts
+++ b/lopper/lops/lop-gen_domain_dts-invoke.dts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023 Xilinx Inc. All rights reserved.
+ *
+ *
+ * this lop file will hold all the basic information for openamp use cases
+ *
+ * there should be reserved-mem, remoteproc driver code, interrupts,
+ * shared mem resources and specify remote's information
+ *
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+
+/dts-v1/;
+
+/ {
+	compatible = "system-device-tree-v1,lop";
+	lops {
+	/* common for both linux kernel or rpmsg userspace to rpus  */
+	/* handle linux kernel space to rpus case */
+
+		lop_5_1 {
+			compatible = "system-device-tree-v1,lop,assist-v1";
+			node = "/";
+			id = "module,gen_domain_dts";
+			options = " psv_cortexa72_0 linux_dt ";
+
+		};
+		lop_5_2 {
+			compatible = "system-device-tree-v1,lop,meta-v1","phandle-desc-v1";
+			// mbox
+			mbox = "phandle";
+			// remote
+			remote = "phandle";
+			// host
+			host = "phandle";
+			// carveouts
+			carveouts = "phandle";
+			// elfload
+			elfload = "phandle";
+
+		};
+	};
+};

--- a/lopper/lops/lop-load.dts
+++ b/lopper/lops/lop-load.dts
@@ -35,5 +35,10 @@
                         compatible = "system-device-tree-v1,lop,load";
                         load = "assists/openamp_xlnx.py";
                 };
+                lop_3 {
+                        compatible = "system-device-tree-v1,lop,load";
+                        load = "assists/gen_domain_dts.py";
+                };
+
         };
 };


### PR DESCRIPTION
… use cases

Update pruning in gen_domain_dts so that:
- TCM banks remain. Need these for OpenAMP ELF Loading
- Remove extra IPI nodes. These conflict if other domains want to use IPI too.

Add lop file to invoke gen_domain_dts. Make sure it is present in lop-load.dts so that the assist gen_domain_dts can be invoked as a lop file. This enables user to control the order of assist invocations upon the input SDT.

Sample usage:
./lopper.py -f -v --enhanced --permissive     \
 -i <OpenAMP YAML>                            \
 -i lopper/lops//lop-load.dts                 \
 -i lopper/lops//lop-xlate-yaml.dts           \
 -i lopper/lops/lop-openamp-invoke.dts        \
 -i lopper/lops/lop-gen_domain_dts-invoke.dts \
 -i lopper/lops/lop-a72-imux.dts              \
 system-top.dts out.dtb