### PR TITLE
lopper: assists: baremetal_xparams: Done generate interruptIDs for PS peripherals

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -170,9 +170,6 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
                                 if is_pl:
                                     plat.buf(f'\n#define XPAR_FABRIC_{label_name}_INTR {intr_id[0]}')
                                     canondef_dict.update({"FABRIC":intr_id[0]})
-                            else:
-                                plat.buf(f'\n#define XPAR_{label_name}_INTR {intr_id[0]}')
-                                canondef_dict.update({"INTR":intr_id[0]})
                         except KeyError:
                             intr_id = [0xFFFF]
 


### PR DESCRIPTION
Interrupt IDs for PS peripherals are already part of xparameters_ps.h in embeddedsw source so don't generate interrupts ID for PS peripherals in xparameters.h