### PR TITLE
lopper: assists: baremetal*: Add provision to pass float numbers from SDT as is

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -263,8 +263,12 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
                             prop = prop.replace("xlnx,", "")
 
                             if isinstance(prop_val[0], str):
-                                canondef_dict.update({prop:f'"{prop_val[0]}"'})
-                                plat.buf(f'\n#define XPAR_{label_name}_{prop.upper()} "{prop_val[0]}"')
+                                if prop_val[0].replace('.','',1).isdigit():
+                                    canondef_dict.update({prop:f'{prop_val[0]}'})
+                                    plat.buf(f'\n#define XPAR_{label_name}_{prop.upper()} {prop_val[0]}')
+                                else:
+                                    canondef_dict.update({prop:f'"{prop_val[0]}"'})
+                                    plat.buf(f'\n#define XPAR_{label_name}_{prop.upper()} "{prop_val[0]}"')
                             elif len(prop_val) > 1:
                                 for k,item in enumerate(prop_val):
                                     cannon_prop = prop + str("_") + str(k)

--- a/lopper/assists/baremetalconfig_xlnx.py
+++ b/lopper/assists/baremetalconfig_xlnx.py
@@ -605,7 +605,10 @@ def xlnx_generate_prop(sdt, node, prop, drvprop_list, plat, pad, phandle_prop):
                 prop_val = [int(prop_val[-1][3:-1], base=16)]
 
             if isinstance(prop_val[0], str):
-                plat.buf('\n\t\t%s' % '"{}"'.format(node[prop].value[0]))
+                if prop_val[0].replace('.','',1).isdigit():
+                    plat.buf('\n\t\t%s' % '{}'.format(node[prop].value[0]))
+                else:
+                    plat.buf('\n\t\t%s' % '"{}"'.format(node[prop].value[0]))
                 drvprop_list.append(node[prop].value[0])
             elif len(prop_val) > 1:
                 plat.buf('\n\t\t{')


### PR DESCRIPTION

Device Tree doesn't allow a floating point number in it as is. This is leading to complexity in the baremetal use case as we have one to one mapping of data types between the device tree entries and the baremetal xparameters/config structures. Therefore, provide a flexibility to pass the floating number in device tree as a string. Add intelligence in the assist to deduce a floating number within string.