### PR TITLE
lops: lop-microblaze-riscv: Fix handling of use-muldiv and use-fpu

### DIFF
--- a/lopper/lops/lop-microblaze-riscv.dts
+++ b/lopper/lops/lop-microblaze-riscv.dts
@@ -13,7 +13,7 @@
                       compatible = "system-device-tree-v1,lop,select-v1";
                       select_1;
                       select_2 = "/cpus_microblaze.*/cpu*.*:compatible:.*microblaze_riscv";
-                      select_3 = ":xlnx,use-muldiv:1";
+                      select_3 = ":xlnx,use-muldiv:!0";
                       lop_1_1_1 {
                           compatible = "system-device-tree-v1,lop,code-v1";
                           code = "
@@ -136,8 +136,10 @@
 
                                    if n['xlnx,use-fpu'].value[0] == 1:
                                        libpath.append('f')
+                                       archflags.append('f') 
                                    elif n['xlnx,use-fpu'].value[0] == 2:
                                        libpath.append('d')
+                                       archflags.append('d') 
                                    
                                    libpath.append('/')
 


### PR DESCRIPTION
Existing logic for use-muldiv fails for HW designs where use-muldiv is set to 2. In such desgns "m" would not be added to compiler flags, it results into generation of invalid compiler flags.

Also, existing logic is not considering use-fpu property value while setting abi flags.  It results into incorrect abi flags for HW designs where use_fpu is set to 1 or 2.

This patch fixes issues explained above.