### PR TITLE
yaml: Remove the unused import of "packaging" module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
     include_package_data=True,
     install_requires=[ "humanfriendly","configparser" ],
     extras_require={ "server": ["flask>=1.1.2","flask_restful>=0.3.8","pandas"],
-                     "yaml": ["pyaml","ruamel.yaml","anytree"],
+                     "yaml": ["pyaml","ruamel.yaml","anytree","packaging"],
                      "dt" : ["devicetree"],
                      "pcpp" : ["pcpp"],
                     },


### PR DESCRIPTION
commit 738df8cc6819 (yaml: support ruamel versions > 0.17.x) added support to check the ruamel version before employing the yaml specific APIs. While doing so, packaging module was imported but it was never invoked. Moreover, if at all it had to be used, it should have been updated under the requirements in setup.py. This statement is leading to missing packaging module related errors as packaging doesnt come with all python versions by default.

Remove this unused import statement of packaging module.