### PR TITLE
lopper: assists: baremetal_xparameters_xlnx: Generate interrupt ID fo…

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -179,6 +179,12 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
                                 if is_pl:
                                     plat.buf(f'\n#define XPAR_FABRIC_{label_name}_INTR {intr_id[0]}')
                                     canondef_dict.update({"FABRIC":intr_id[0]})
+                            else:
+                                if node.propval('xlnx,ip-name') != ['']:
+                                    ip_name = node.propval('xlnx,ip-name', list)[0]
+                                    if ip_name in ["psu_ipi", "psv_ipi", "psx_ipi", "psxl_ipi"]:
+                                        plat.buf(f'\n#define XPAR_{label_name}_INTR {intr_id[0]}')
+                                        canondef_dict.update({"INTR":intr_id[0]})
                         except KeyError:
                             intr_id = [0xFFFF]
 


### PR DESCRIPTION
…r IPI

Commit 8eaf02704a20("lopper: assists: baremetal_xparams: Done generate interruptIDs for PS peripherals") deleted the code for generating the interrupt id for PS peripherals as it was present in the xparameters_ps.h file but it's not true for IPI update the assist to generate generic interrupt ID for IPI.