### PR TITLE
lopper:assists:baremetal*: Correct the steps to construct a 64 bit value from 2 32-bit cells

### DIFF
--- a/lopper/assists/baremetalconfig_xlnx.py
+++ b/lopper/assists/baremetalconfig_xlnx.py
@@ -97,19 +97,13 @@ def scan_reg_size(node, value, idx):
     if cells > 2:
         reg1 = value[cells * idx]
         if reg1 != 0:
-            val = str(hex(value[cells * idx + 1]))[2:]
-            pad = 8 - len(val)
-            val = val.ljust(pad + len(val), '0')
-            reg = int((str(hex(reg1)) + val), base=16)
+            reg = int(f"{hex(reg1)}{value[cells * idx + 1]:08x}", base=16)
         else:
             reg = value[cells * idx + 1]
 
         size1 = value[cells * idx + na]
         if size1 != 0:
-            val = str(hex(value[cells * idx + ns + 1]))[2:]
-            pad = 8 - len(val)
-            val = val.ljust(pad + len(val), '0')
-            size = int((str(hex(size1)) + val), base=16)
+            size = int(f"{hex(size1)}{value[cells * idx + ns + 1]:08x}", base=16)
         else:
             size = value[cells * idx + ns + 1]
     elif cells == 2:
@@ -211,19 +205,18 @@ def scan_ranges_size(range_value, ns):
     concatenate the higher and the lower cells.
     e.g. <0x4 0x80000000> => 0x480000000
     """
-    addr = hex(range_value[2])
-    high_addr_cell = hex(range_value[1])
-    if high_addr_cell != "0x0":
-        addr = high_addr_cell + addr.lstrip('0x').ljust(8, '0')
+    addr = range_value[2]
+    high_addr_cell = range_value[1]
+    if high_addr_cell != 0:
+        addr = int(f"{hex(high_addr_cell)}{addr:08x}", base=16)
 
-    size = hex(range_value[-1])
-    high_size_cell = hex(range_value[-2])
+    size = range_value[-1]
+    high_size_cell = range_value[-2]
     # If ns = 1, then there is no use of high_size_cells
-    if high_size_cell != "0x0" and ns > 1:
-        size = high_size_cell + size.lstrip('0x').ljust(8, '0')
+    if high_size_cell != 0 and ns > 1:
+        size = int(f"{hex(high_size_cell)}{size:08x}", base=16)
 
-    return int(addr, base=16), int(size, base=16)
-
+    return addr, size
 
 def get_clock_prop(sdt, value):
     clk_node = [node for node in sdt.tree['/'].subnodes() if node.phandle == value[0]]

--- a/lopper/assists/baremetallinker_xlnx.py
+++ b/lopper/assists/baremetallinker_xlnx.py
@@ -101,10 +101,7 @@ def get_memranges(tgt_node, sdt, options):
                start = [address_map[inx+i+1] for i in range(na)]
                size_list.append(address_map[inx+2*na])
                if na == 2 and start[0] != 0:
-                   val = str(start[1])
-                   pad = 8 - len(val)
-                   val = val.ljust(pad + len(val), '0')
-                   reg = int((str(hex(start[0])) + val), base=16)
+                   reg = int(f"{hex(start[0])}{start[1]:08x}", base=16)
                    addr_list.append(reg)
                elif na == 2:
                    addr_list.append(start[1])

--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -120,10 +120,7 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
             for inx in indx_list:
                 start = [address_map[inx+i+1] for i in range(na)]
                 if na == 2 and start[0] != 0:
-                    val = str(start[1])
-                    pad = 8 - len(val)
-                    val = val.ljust(pad + len(val), '0')
-                    reg = int((str(hex(start[0])) + val), base=16)
+                    reg = int(f"{hex(start[0])}{start[1]:08x}", base=16)
                     prop_val.append(reg)
                 elif na == 2:
                     prop_val.append(start[1])
@@ -137,10 +134,7 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
                 else:
                     high_size_cell = "0x0"
                 if high_size_cell != "0x0" and ns > 1:
-                    val = hex(size_cells[1]).lstrip('0x')
-                    pad = 8 - len(val)
-                    val = val.ljust(pad + len(val), '0')
-                    size = str(hex(size_cells[0])) + val
+                    size = f"{hex(size_cells[0])}{size_cells[1]:08x}"
                 prop_val.append(int(size, base=16))
         else:
             invalid_memnode.append(node)

--- a/lopper/lops/lop-domain-linux-a53-prune.dts
+++ b/lopper/lops/lop-domain-linux-a53-prune.dts
@@ -171,10 +171,7 @@
                                       start = [address_map[inx+i+1] for i in range(na)]
                                       # start addresss is non zero means 40-bit address update it accordingly
                                       if na == 2 and start[0] != 0:
-                                          val = str(start[1])
-                                          pad = 8 - len(val)
-                                          val = val.ljust(pad + len(val), '0')
-                                          reg = int((str(hex(start[0])) + val), base=16)
+                                          reg = int(f"{hex(start[0])}{start[1]:08x}", base=16)
                                           prop_val.append(reg)
                                       elif na == 2:
                                           prop_val.append(start[1])


### PR DESCRIPTION
There is often a use case to construct a 64-bit value from 2 32-bit cells in a device tree. Presently, ljust is being used to convert the lower cell value into a valid 32-bit number. Use of ljust for this is not taking the leading zeroes into account. It is appending 0s always at the end which means 0x927 and 0x9270000 entries of device tree becomes the same after processing. Fix this by replacing ljust with string formating to 32 bit values (:08x).