### PR TITLE
lopper: assists: barmetal*: Fix race condition in the version driver handling

### DIFF
--- a/lopper/assists/baremetal_gentestapp_xlnx.py
+++ b/lopper/assists/baremetal_gentestapp_xlnx.py
@@ -68,7 +68,7 @@ def xlnx_generate_testapp(tgt_node, sdt, options):
                 drv_path_in_yaml = drv_data[entries]['path'][0]
             drv_name_in_yaml = os.path.basename(drv_path_in_yaml)
             # Incase of versioned component strip the version info
-            drv_name_in_yaml = re.sub(r"_v.*_.*$", "", drv_name_in_yaml)
+            drv_name_in_yaml = re.split("_v(\d+)_(\d+)", drv_name_in_yaml)[0]
             yaml_file_list += [os.path.join(drv_path_in_yaml, 'data', f"{drv_name_in_yaml}.yaml")]
     else:
         drv_dir = os.path.join(repo_path_data, "XilinxProcessorIPLib", "drivers")

--- a/lopper/assists/baremetal_getsupported_comp_xlnx.py
+++ b/lopper/assists/baremetal_getsupported_comp_xlnx.py
@@ -58,7 +58,7 @@ def xlnx_baremetal_getsupported_comp(tgt_node, sdt, options):
         for entries in files:
             dir_path = utils.get_dir_path(utils.get_dir_path(entries))
             comp_name = utils.get_base_name(dir_path)
-            comp_name =  re.sub("_v(\d+)_(\d+)", "", comp_name)
+            comp_name = re.split("_v(\d+)_(\d+)", comp_name)[0]
             yaml_data = utils.load_yaml(entries)
             version = yaml_data.get('version','vless')
 

--- a/lopper/assists/baremetalconfig_xlnx.py
+++ b/lopper/assists/baremetalconfig_xlnx.py
@@ -604,7 +604,7 @@ def xlnx_generate_bm_config(tgt_node, sdt, options):
     drvpath = utils.get_dir_path(src_dir.rstrip(os.sep))
     drvname = utils.get_base_name(drvpath)
     # Incase of versioned driver strip the version info
-    drvname = re.sub(r"_v.*_.*$", "", drvname)
+    drvname = re.split("_v(\d+)_(\d+)", drvname)[0]
     yaml_file = os.path.join(drvpath, f"data/{drvname}.yaml")
     if not utils.is_file(yaml_file):
         print(f"{drvname} Driver doesn't have yaml file")

--- a/lopper/assists/baremetaldrvlist_xlnx.py
+++ b/lopper/assists/baremetaldrvlist_xlnx.py
@@ -69,7 +69,7 @@ def xlnx_generate_bm_drvlist(tgt_node, sdt, options):
                 drv_path = drv_data[entries]['path'][0]
             drv_name = os.path.basename(drv_path)
             # Incase of versioned driver strip the version info
-            drv_name = re.sub(r"_v.*_.*$", "", drv_name)
+            drv_name = re.split("_v(\d+)_(\d+)", drv_name)[0]
             yaml_file_list += [os.path.join(drv_path, 'data', f"{drv_name}.yaml")]
         has_drivers = [dir_name for dir_name in os.listdir(utils.get_dir_path(sdt.dts)) if "drivers" in dir_name]
         if has_drivers:

--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -36,7 +36,7 @@ def generate_drvcmake_metadata(sdt, node_list, src_dir, options):
     driver_compatlist = []
     drvname = utils.get_base_name(utils.get_dir_path(src_dir))
     # Incase of versioned component strip the version info
-    drvname = re.sub(r"_v.*_.*$", "", drvname)
+    drvname = re.split("_v(\d+)_(\d+)", drvname)[0]
     yaml_file = os.path.join(utils.get_dir_path(src_dir), "data", f"{drvname}.yaml")
     if not utils.is_file(yaml_file):
         print(f"{drvname} Driver doesn't have yaml file")
@@ -198,7 +198,7 @@ def generate_hwtocmake_medata(sdt, node_list, src_path, repo_path_data, options,
     src_path = src_path.rstrip(os.path.sep)
     name = utils.get_base_name(utils.get_dir_path(src_path))
     # Incase of versioned component strip the version info
-    name = re.sub(r"_v.*_.*$", "", name)
+    name = re.split("_v(\d+)_(\d+)", name)[0]
     yaml_file = os.path.join(utils.get_dir_path(src_path), "data", f"{name}.yaml")
 
     if not utils.is_file(yaml_file):


### PR DESCRIPTION


To get the driver name of the version driver we are using re.sub with v_* string there can be driver with v_* name example (v_vcresampler) for such drivers existing code is returning wron driver name fix this issue by using re.split().