### PR TITLE
lopper: assists: gen_domain_dts: Remove dupe TCM node

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -192,6 +192,9 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
                     sdt.tree.delete(node)
                 elif 'xlnx,zynqmp-ipi-mailbox' in node.propval('compatible'):
                     sdt.tree.delete(node)
+                elif "tcm" in node.propval('compatible', list)[0] and "global" in node.propval('compatible', list)[0]:
+                    sdt.tree.delete(node)
+
             elif node.name == "rpu-bus":
                 sdt.tree.delete(node)
         if node not in mapped_nodelist:


### PR DESCRIPTION
As there are 2 of each TCM bank in the input SDT, prune the global TCM node for each register space.