### PR TITLE
lopper: assists: xlnx_overlay_dt: fixed the closing bracket missing i…

### DIFF
--- a/lopper/assists/xlnx_overlay_dt.py
+++ b/lopper/assists/xlnx_overlay_dt.py
@@ -284,6 +284,10 @@ def xlnx_generate_overlay_dt(tgt_node, sdt, options):
         except:
            pass
 
+    if parent_tab == 1:
+        plat.buf('\n')
+        plat.buf('\t' * int(rt))
+        plat.buf('};')
     plat.buf('\n};')
     plat.out(''.join(plat.get_buf()))
     if pl_node:


### PR DESCRIPTION
…ssue

With the current implemetation closing bracket was missing for the few design due to the improper logic existing with the child nodes. This patch address this issue.