### PR TITLE
assists:baremetallinker: Correct the logic to set the start address of linker section for microblaze

### DIFF
--- a/lopper/assists/baremetallinker_xlnx.py
+++ b/lopper/assists/baremetallinker_xlnx.py
@@ -248,8 +248,8 @@ def xlnx_generate_bm_linker(tgt_node, sdt, options):
         Initial 80 bytes is being used by the linker vectors section in case of Microblaze.
         Adjust the size and start address accordingly.
         """
-        if cpu_ip_name == "microblaze":
-            start += 80
+        if cpu_ip_name == "microblaze" and start < 80:
+            start = 80
             size -= start
         """
         For R5 PSU DDR initial 1MB is reserved for tcm


### PR DESCRIPTION
538f6b5c7171 commit (assists: baremetallinker: Correct the start address for text and data sections for microblaze) added the logic to start the BRAM or the DDR addresses from 0x50 for all the Microblaze designs. While doing so, the logic to check for the start address condition was missed. If the memory is not falling under first 0x50 bytes which is reserved for reset vectors, there is no need of this manipulation. Fix the same.