### PR TITLE
lopper: assists: baremetal_validate_comp_xlnx: Add special handling for emacps

### DIFF
--- a/lopper/assists/baremetal_validate_comp_xlnx.py
+++ b/lopper/assists/baremetal_validate_comp_xlnx.py
@@ -179,6 +179,12 @@ def xlnx_baremetal_validate_comp(tgt_node, sdt, options):
                 driver_list.append(drv)
                 nodes = getmatch_nodes(sdt, node_list, drv_yamlpath, options)
                 if nodes:
+                    """
+                    For emacps driver phy-handle property presence is optional
+                    remove the same from the list if exists.
+                    """
+                    if (drv == "emacps") and ("phy-handle" in prop_list):
+                        prop_list.remove("phy-handle")
                     valid_hw = nodes[0],prop_list
         if valid_hw:
             prop_dict = check_required_prop(sdt, valid_hw[0], valid_hw[1])

--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -291,6 +291,9 @@ def generate_hwtocmake_medata(sdt, node_list, src_path, repo_path_data, options,
             if re.search("microblaze", match_cpunode['compatible'].value[0]):
                 if match_cpunode.propval('xlnx,family') != ['']:
                     family = match_cpunode.propval('xlnx,family', list)[0]
+                    # Special handling for Versal platform update the variable to inline with PS processors.
+                    if family == "versal":
+                        family = "Versal"
                     fd.write(f'set(CMAKE_MACHINE "{family}" CACHE STRING "CMAKE MACHINE")\n')
             if match_cpunode.propval('reg') != ['']:
                 cpu_id = match_cpunode.propval('reg', list)[0]


### PR DESCRIPTION
For emacps driver phy-handle property is optional for some configurations, update the checks for the same.