### PR TITLE
lops: lop-microblaze-riscv: Add support for bit-manipulation extensions

### DIFF
--- a/lopper/lops/lop-microblaze-riscv.dts
+++ b/lopper/lops/lop-microblaze-riscv.dts
@@ -124,6 +124,18 @@
                                    libpath.append(archflags_libpath)
                                    libpath.append('/')
 
+                                   if n['xlnx,use-bitman-a'].value[0] == 1:
+                                       archflags.append('_zba')
+					
+                                   if n['xlnx,use-bitman-b'].value[0] == 1:
+                                       archflags.append('_zbb')
+
+                                   if n['xlnx,use-bitman-c'].value[0] == 1:
+                                       archflags.append('_zbc')
+
+                                   if n['xlnx,use-bitman-s'].value[0] == 1:
+                                       archflags.append('_zbs')
+
                                    if n['xlnx,use-dcache'].value[0] == 1 or n['xlnx,use-icache'].value[0] == 1:
                                        archflags.append('_zicbom')
 


### PR DESCRIPTION
Include bit manipulation extensions zba, zbb, zbc, and zbs in archflags, 
if said extensions are enabled in given HW design.