### PR TITLE
assists:gen_domain_dts.py: Remove PL DDR from default linux device tree

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -94,8 +94,14 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
 
     node_list = []
     for node in root_sub_nodes:
-        if linux_dt and (node.name == "memory@fffc0000" or node.name == "memory@bbf00000"):
-            sdt.tree.delete(node)
+        if linux_dt:
+            if node.name == "memory@fffc0000" or node.name == "memory@bbf00000":
+                sdt.tree.delete(node)
+            for entry in node.propval('compatible', list):
+                if entry.startswith("xlnx,ddr4-"):
+                    sdt.tree.delete(node)
+                    break
+
         if node.propval('status') != ['']:
             if linux_dt and node.name == "smmu@fd800000" and machine == "psu_cortexa53_0":
                 # It needs to be disabled only for ZynqMP


### PR DESCRIPTION
ddr4 is a mig series memory IP. Remove the PL DDRs from default linux device trees. With these present, a kernel crash is observed This needs to be revisited while adding linux support for Soft Microblaze.