### PR TITLE
lops: lop-microblaze-riscv: Add support for library fallback mechanism

### DIFF
--- a/lopper/lops/lop-microblaze-riscv.dts
+++ b/lopper/lops/lop-microblaze-riscv.dts
@@ -101,6 +101,18 @@
                                    libpath = []
                                    libpath.append('riscv64-unknown-elf/riscv32-xilinx-elf/usr/lib/')
                                    cflags_data = {}
+                                   archflags_lib_map = {
+                                       'rv32i' : 'rv32i',
+                                       'rv32im' : 'rv32im',
+                                       'rv32iac' : 'rv32iac',
+                                       'rv32imc' : 'rv32imc',
+                                       'rv32imac' : 'rv32imac',
+                                       'rv32imafc' : 'rv32imafc',
+                                       'rv32imafdc' : 'rv32imafdc',
+                                       'rv32ic' : 'rv32i',
+                                       'rv32ia' : 'rv32i',
+                                       'rv32ima' : 'rv32im'
+                                   }
 
                                    for property in proplist:
                                        try:
@@ -120,6 +132,11 @@
                                                bsp_linkflags = arch_option + arch_linkflags
                                                archflags.append('_zicsr_zifencei')
                                            continue
+
+
+                                   for val in archflags_lib_map.keys():
+                                       if val == archflags_libpath:
+                                           archflags_libpath = archflags_lib_map[val]
 
                                    libpath.append(archflags_libpath)
                                    libpath.append('/')


### PR DESCRIPTION
For MB V HW designs, 16 combinations of architecture dependent flags are possible(m, a, f, c). Based on parameters enabled in HW design, corresponding GNU library needs to be used during linking.

As of now, in Vitis installation, only 7 combinations of 32 bit libraries are present (rv32i, rv32im, rv32iac, rv32imac, rv32imc, rv32imafc, rv32imafdc). If library corresponding to configuration used in specific MB V design is not present in Vitis installation, ideally library nearest to given HW configuration should be used.

For now, update logic to support fallback mechanism for rv32ic, rv32ia and rv32ima libraries, in future support would be extended to other libraries as well.