### PR TITLE
lopper: assists: baremetal_xparameters_xlnx: Fix whitespace after the…

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -224,6 +224,7 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
                     elif phandle_prop:
                         try:
                             prop_val = bm_config.get_phandle_regprop(sdt, prop, node[prop].value)
+                            prop = prop.replace("-", "_")
                             plat.buf(f'\n#define XPAR_{label_name}_{prop.upper()} {hex(prop_val)}')
                             canondef_dict.update({prop:hex(prop_val)})
                         except KeyError:


### PR DESCRIPTION
… marco name warning

While generating c defines don't geneate define with - it should be generated with _ between name spaces.