### PR TITLE
lopper: assists: baremetal_validate_comp_xlnx: Update memory test che…

### DIFF
--- a/lopper/assists/baremetal_validate_comp_xlnx.py
+++ b/lopper/assists/baremetal_validate_comp_xlnx.py
@@ -111,6 +111,8 @@ def xlnx_baremetal_validate_comp(tgt_node, sdt, options):
         if name == "memory_tests":
             if proc_ip_name == "microblaze":
                 mem_type = "bram"
+            elif proc_ip_name == "ps7_cortexa9":
+                mem_type = "ps7_ram"
             else:
                 mem_type = "ocm"
         required_mem = required_mem_schema[mem_type]


### PR DESCRIPTION
…cks for zynq platform

Update the memory test checks for cortexa9 processor it is currently looking for ocm memory instead of ps7_ram update checks for the same.