### PR TITLE
lopper: assists: gen_domain_dts: Add option to prune TCM nodes

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -71,6 +71,12 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
     except IndexError:
         pass
 
+    keep_tcms = None
+    try:
+        keep_tcms = options['args'][2]
+    except IndexError:
+        pass
+
     # Delete other CPU Cluster nodes
     cpunode_list = sdt.tree.nodes('/cpu.*@.*')
     clustercpu_nodes = []
@@ -96,6 +102,8 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
     for node in root_sub_nodes:
         if linux_dt:
             if node.name == "memory@fffc0000" or node.name == "memory@bbf00000":
+                sdt.tree.delete(node)
+            if keep_tcms == None and 'tcm' in node.name:
                 sdt.tree.delete(node)
             if node.propval('memory_type', list) == ['linear_flash']:
                 sdt.tree.delete(node)

--- a/lopper/lops/lop-gen_domain_dts-invoke.dts
+++ b/lopper/lops/lop-gen_domain_dts-invoke.dts
@@ -24,7 +24,7 @@
 			compatible = "system-device-tree-v1,lop,assist-v1";
 			node = "/";
 			id = "module,gen_domain_dts";
-			options = " psv_cortexa72_0 linux_dt ";
+			options = " psv_cortexa72_0 linux_dt keep_tcm ";
 
 		};
 		lop_5_2 {


### PR DESCRIPTION
Add option that if present allows user to prune TCM DT nodes.

To remove TCM nodes, add third option on command line for this assist.