### PR TITLE
Support for linear flash IPs in linker/ Removal of BRAM from linux DT

### DIFF
--- a/lopper/assists/baremetallinker_xlnx.py
+++ b/lopper/assists/baremetallinker_xlnx.py
@@ -32,7 +32,14 @@ def get_memranges(tgt_node, sdt, options):
     mem_nodes = []
 
     #Maintain a static memory IP list this is needed inorder to capture proper ip name in the linker script
-    xlnx_memipname = {"axi_bram": 0, "ps7_ddr": 0, "psu_ddr": 0, "psv_ddr": 0, "mig": 0, "lmb_bram": 0, "axi_noc2": 0, "axi_noc": 0,"psu_ocm": 0,  "psv_ocm": 0, "psx_ocm": 0, "ddr4": 0, "ddr5": 0, "mig_7series": 0, "ps7_ram": 0}
+    xlnx_memipname = {
+        "axi_bram": 0, "ps7_ddr": 0, "psu_ddr": 0,
+        "psv_ddr": 0, "mig": 0, "lmb_bram": 0,
+        "axi_noc2": 0, "axi_noc": 0,"psu_ocm": 0,
+        "psv_ocm": 0, "psx_ocm": 0, "ddr4": 0,
+        "ddr5": 0, "mig_7series": 0, "ps7_ram": 0,
+        "axi_emc": 0, "psu_qspi_linear": 0, "ps7_qspi_linear": 0
+    }
     for node in root_sub_nodes:
         try:
             device_type = node["device_type"].value

--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -97,6 +97,8 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
         if linux_dt:
             if node.name == "memory@fffc0000" or node.name == "memory@bbf00000":
                 sdt.tree.delete(node)
+            if node.propval('memory_type', list) == ['linear_flash']:
+                sdt.tree.delete(node)
             for entry in node.propval('compatible', list):
                 if entry.startswith("xlnx,ddr4-"):
                     sdt.tree.delete(node)

--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -100,7 +100,8 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
             if node.propval('memory_type', list) == ['linear_flash']:
                 sdt.tree.delete(node)
             for entry in node.propval('compatible', list):
-                if entry.startswith("xlnx,ddr4-"):
+                pl_memory_compatible_list = ["xlnx,ddr4","xlnx,mig-7series","xlnx,lmb-bram","xlnx,axi-bram"]
+                if any(entry.startswith(compatible_prefix) for compatible_prefix in pl_memory_compatible_list):
                     sdt.tree.delete(node)
                     break
 


### PR DESCRIPTION
assists: gen_domain_dts: Remove BRAM memory nodes from linux device tree

  As an extension of this commit 8476601a9fb1 (assists:gen_domain_dts.py: Remove
  PL DDR from default linux device tree), add bram IP into the list of PL memory
  IPs that need to be removed.

assists: linker/domain: Add support for linear flash memories in linker script

  Memory segments from Linear flash IPs like axi_emc, psu_qspi_linear and ps7_qspi_linear
  can also be used in linker script. At the same time, these memory nodes have to be
  removed from the linux device tree. Add the support for these two use cases.