### PR TITLE
base/phandle: add resets and assigned-clocks

### DIFF
--- a/lopper/base.py
+++ b/lopper/base.py
@@ -452,6 +452,8 @@ class lopper_base:
                     "cpus" : [ 'phandle mask mode' ],
                     "clocks" : [ 'phandle:#clock-cells:+1' ],
                     "reset-gpios" : [ 'phandle field field' ],
+                    "resets" : [ 'phandle field' ],
+                    "assigned-clocks" : [ 'phandle field' ],
                 }
         except:
             return {}


### PR DESCRIPTION
resets and assigned-clocks are generic property that contains phandles and fields. We add it to our base configuration so lopper can do phandle symbolic replacement during output processing.