### PR TITLE
lopper: assists: gen_domain_dts: Update symbol node entry for gic_its…

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -239,7 +239,7 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
     for prop in prop_list:
         if prop not in match_label_list:
             sdt.tree['/__symbols__'].delete(prop)
-        if prop == "gic_a53" or prop == "gic_a72" and linux_dt:
+        if prop == "gic_a53" or prop == "gic_a72" or prop == "gic_its":
             val = sdt.tree['/__symbols__'].propval(prop, list)[0]
             val = val.replace("apu-bus", "axi")
             sdt.tree['/__symbols__'].propval(prop, list)[0] = val


### PR DESCRIPTION
… node

lop-a72-imux.dts file is renaming the interrupt-controller node to axi, For gic_its symbol node entries are not matching fix the same.