### PR TITLE
base: add expression to clock phandle description

### DIFF
--- a/lopper/base.py
+++ b/lopper/base.py
@@ -453,7 +453,7 @@ class lopper_base:
                     "clocks" : [ 'phandle:#clock-cells:+1' ],
                     "reset-gpios" : [ 'phandle field field' ],
                     "resets" : [ 'phandle field' ],
-                    "assigned-clocks" : [ 'phandle field' ],
+                    "assigned-clocks" : [ 'phandle:#clock-cells:+1' ],
                 }
         except:
             return {}


### PR DESCRIPTION
To full handle the clock-cells property as defined in the clock dts binding:
https://github.com/devicetree-org/dt-schema/blob/main/dtschema/schemas/clock/clock.yaml

We must adjust our phandle map to not only specify the field to look up, but also allow an expression to indicate how many fields the looked up value should skip.

In the case of clock. A found value of '0' means that there are no clock inputs, and the next field should be looked at. A found value of '1' means that there's an input specified so the next phandle field will be in '2'

This is a different behaviour from address cells, so to keep things generic we specify a +1 expression to be evaluated against the found value.