### PR TITLE
lopper:assists:gen_domain_dts: Remove axi_noc and noc_ddr4 IPs from linux ignore list

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -176,8 +176,8 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
         for node in invalid_memnode:
             sdt.tree.delete(node)
 
-    linux_ignore_ip_list = ['xlconstant', 'proc_sys_reset', 'noc_mc_ddr4', 'psv_apu', 'psv_coresight_a720_dbg', 'psv_coresight_a720_etm',
-                            'axi_noc', 'psv_coresight_a720_pmu', 'psv_coresight_a720_cti', 'psv_coresight_a721_dbg',
+    linux_ignore_ip_list = ['xlconstant', 'proc_sys_reset', 'psv_apu', 'psv_coresight_a720_dbg', 'psv_coresight_a720_etm',
+                            'psv_coresight_a720_pmu', 'psv_coresight_a720_cti', 'psv_coresight_a721_dbg',
                             'psv_coresight_a721_etm', 'psv_coresight_a721_pmu', 'psv_coresight_a721_cti',
                             'psv_coresight_a721_pmu', 'psv_coresight_a721_cti', 'psv_coresight_apu_ela',
                             'psv_coresight_apu_etf', 'psv_coresight_apu_fun', 'psv_coresight_cpm_atm', 'psv_coresight_cpm_cti2a',


### PR DESCRIPTION

Till last release, System Device Tree used to have two nodes for memory IPs, one as a peripheral and other as memory@. As these IPs dont have a driver, the peripheral node for such IPs have been removed from system device tree itself.

Therefore, there is no need to maintain these memory IPs in linux ignore list. Moreover, the ip-name property has now been added to memory nodes as well and keeping these entries in the list is deleting the unintended memory node. Remove it from the linux ignore list.