### PR TITLE
lopper: assists: baremetallinker: Adjust heap size for microblaze lmb…

### DIFF
--- a/lopper/assists/baremetallinker_xlnx.py
+++ b/lopper/assists/baremetallinker_xlnx.py
@@ -258,6 +258,8 @@ def xlnx_generate_bm_linker(tgt_node, sdt, options):
         if cpu_ip_name == "microblaze" and start < 80:
             start = 80
             size -= start
+            if size <= 0x2000:
+                heap_size = 0x400
         """
         For R5 PSU DDR initial 1MB is reserved for tcm
         Adjust the size and start address accordingly.


### PR DESCRIPTION
…_bram designs having size less than 8k

In classic flow microblaze core code uses conditional compilation checks/defines where as in SDT flow Microblaze BSP core code changed to use config struct due to which there is an increase in text size so for the designs having less than 8k bram need to tweak heap size to 0x400 update the lopper linker assist for the same.