### PR TITLE
assists:baremetal_validate_comp_xlnx: Avoid the hw check when device_type property is missing in YAML

### DIFF
--- a/lopper/assists/baremetal_validate_comp_xlnx.py
+++ b/lopper/assists/baremetal_validate_comp_xlnx.py
@@ -157,7 +157,7 @@ def xlnx_baremetal_validate_comp(tgt_node, sdt, options):
             else:
                 dev_dict.update({hw_type:[{drv:prop_list}]})
         else:
-            dev_dict.update({drv:[{drv:prop_list}]})
+            continue
 
     for dev_type, dev_list in dev_dict.items():
         valid_hw = None


### PR DESCRIPTION
There is no need to do hardware check and report the error when the driver YAML is missing the device_type property. Trying this is leading to backward compatibility issues with previous version released sources.