### PR TITLE
lopper: assists: bmcmake_metadata_xlnx: Add proper checks

### DIFF
--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -260,7 +260,10 @@ def generate_hwtocmake_medata(sdt, node_list, src_path, repo_path_data, options,
                         else:
                             continue
                     elif prop == "axistream-connected":
-                       val = hex(bm_config.get_phandle_regprop(sdt, prop, node[prop].value))
+                       try:
+                            val = hex(bm_config.get_phandle_regprop(sdt, prop, node[prop].value))
+                       except KeyError:
+                            val = hex(0)
                     elif prop == "phy-handle":
                        try:
                            val = getxlnx_phytype(sdt, node[prop].value)


### PR DESCRIPTION
Update the assists to have a proper checks inorder to avoid Python KeyError failed to read axistream-connected property.