### PR TITLE
lopper: assists: gen_domain_dts: Don't delete child nodes when prunin…

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -20,12 +20,6 @@ import common_utils as utils
 from domain_access import update_mem_node
 
 def delete_unused_props( node, driver_proplist ):
-    child_list = list(node.child_nodes.keys())
-    for child in child_list:
-        child_node = node.child_nodes[child]
-        delete_unused_props( child_node, driver_proplist)
-        if not child_node.child_nodes.keys() and not child_node.__props__.keys():
-            node.delete(child_node)
     prop_list = list(node.__props__.keys())
     for prop in prop_list:
         if prop not in driver_proplist:


### PR DESCRIPTION
…g yaml files

Commit 6ce8ab4898e8("lopper: assists: Enhance special proprety removal"), Updated the logic to delete the child node with below assumption --> If a child node doe not have any of of the properties listed in the YAML (or a child with any of these properties), it will be removed from the device tree, which is wrong as per linux device-tree binding if a property is a child node reference we shouldn't be deleting the underlying child nodes as those can be consumed by the linux driver update the logic to not to delete the child nodes.