### PR TITLE
lopper: lops: lop-ttc-split.dts: Add new lops file for baremetal ttc driver

### DIFF
--- a/lopper/lops/lop-ttc-split.dts
+++ b/lopper/lops/lop-ttc-split.dts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024 Advanced Micro Devices, Inc. All Rights Reserved.
+ *
+ * Author:
+ *     Appana Durga Kedareswara rao <appana.durga.kedareswara.rao@amd.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/dts-v1/;
+
+/ {
+    compatible = "system-device-tree-v1";
+    lops {
+	    lop_1: lop_1 {
+                  compatible = "system-device-tree-v1,lop,select-v1";
+                  // clear any old selections
+                  select_1;
+                  select_2 = "/.*:compatible:.*cdns,ttc*";
+            };
+            lop_1_1: lop_1_1 {
+                  compatible = "system-device-tree-v1,lop,code-v1";
+                  // Baremetal ttc driver expects each ttc counter as a seperate node
+                  // below code does the same.
+                  code = "
+                          import os
+                          assist_dir = os.path.dirname(os.path.realpath(__file__)) + '/assists/'
+                          sys.path.append(assist_dir)
+                          from domain_access import update_mem_node
+                          from baremetalconfig_xlnx import scan_reg_size
+                          if __selected__:
+                              for s in tree.__selected__:
+
+                                  reg, size = scan_reg_size(s, s['reg'].value, 0)
+                                  inp = s['interrupt-parent'].value[0]
+                                  intr_parent = [s for s in tree['/'].subnodes() if s.phandle == inp]
+                                  inc = intr_parent[0]['#interrupt-cells'].value[0]
+                                  parent_node = s
+                                  for x in range(1, 3):
+                                        new_ttc_node = s()
+                                        new_ttc_node.name = f'{s.name[:-1]}{x*4}'
+                                        new_ttc_node.label = f'{s.label}_{x-1}'
+                                        modify_reg = f'{hex(reg)[:-1]}{x*4}'
+                                        modify_prop = [int(modify_reg, 16), size-(x*4)]
+                                        modify_val = update_mem_node(s, modify_prop)
+                                        new_ttc_node['reg'].value =  modify_val
+                                        new_ttc_node['interrupts'].value =  s['interrupts'].value[x*inc:]
+                                        name_val = s['xlnx,name'].value[0]
+                                        new_ttc_node['xlnx,name'].value[0] =  f'{name_val}_{x-1}'
+                                        new_ttc_node.resolve()
+                                        # add the updated node to the original node's parent .. we are a sibling node
+                                        s.parent.add( new_ttc_node )
+                                        new_ttc_node.resolve()
+                                        tree['/axi'].reorder_child(f'{new_ttc_node.abs_path}', f'{parent_node.abs_path}', after=True)
+                                        parent_node = new_ttc_node
+
+                          tree.sync()
+                          return True
+                      ";
+            };
+    };
+};


### PR DESCRIPTION
TTC IP in the ZynqMP and Versal has 3 counters, Baremetal ttc driver expects each counter as a separate driver but in SDT flow as per spec we have a single node for one IP, Add support for new additional nodes as per ttc BareMetal driver requirements.