### PR TITLE
lopper: assists: gen_domain_dts: Add mipi pipeline documentation

### DIFF
--- a/lopper/assists/yaml_bindings/xlnx,csi2rxss.yaml
+++ b/lopper/assists/yaml_bindings/xlnx,csi2rxss.yaml
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/media/xilinx/xlnx,csi2rxss.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Xilinx MIPI CSI-2 Receiver Subsystem
+
+maintainers:
+  - Vishal Sagar <vishal.sagar@xilinx.com>
+
+description: |
+  The Xilinx MIPI CSI-2 Receiver Subsystem is used to capture MIPI CSI-2
+  traffic from compliant camera sensors and send the output as AXI4 Stream
+  video data for image processing.
+  The subsystem consists of a MIPI D-PHY in slave mode which captures the
+  data packets. This is passed along the MIPI CSI-2 Rx IP which extracts the
+  packet data. The optional Video Format Bridge (VFB) converts this data to
+  AXI4 Stream video data.
+  For more details, please refer to PG232 Xilinx MIPI CSI-2 Receiver Subsystem.
+  Please note that this bindings includes only the MIPI CSI-2 Rx controller
+  and Video Format Bridge and not D-PHY.
+
+properties:
+  compatible:
+    items:
+      - enum:
+          - xlnx,mipi-csi2-rx-subsystem-5.0
+          - xlnx,mipi-csi2-rx-subsystem-6.0
+
+  reg:
+    maxItems: 1
+
+  interrupts:
+    maxItems: 1
+
+  clocks:
+    description: List of clock specifiers
+    items:
+      - description: AXI Lite clock
+      - description: Video clock
+
+  clock-names:
+    items:
+      - const: lite_aclk
+      - const: video_aclk
+
+  xlnx,csi-pxl-format:
+    description: |
+      This denotes the CSI Data type selected in hw design.
+      Packets other than this data type (except for RAW8 and
+      User defined data types) will be filtered out.
+      Possible values are as below -
+      0x18 - YUV4208B
+      0x1e - YUV4228B
+      0x1f - YUV42210B
+      0x20 - RGB444
+      0x21 - RGB555
+      0x22 - RGB565
+      0x23 - RGB666
+      0x24 - RGB888
+      0x28 - RAW6
+      0x29 - RAW7
+      0x2a - RAW8
+      0x2b - RAW10
+      0x2c - RAW12
+      0x2d - RAW14
+      0x2e - RAW16
+      0x2f - RAW20
+    $ref: /schemas/types.yaml#/definitions/uint32
+    oneOf:
+      - const: 0x18
+      - minimum: 0x1e
+        maximum: 0x24
+      - minimum: 0x28
+        maximum: 0x2f
+
+  xlnx,vfb:
+    type: boolean
+    description: Present when Video Format Bridge is enabled in IP configuration
+
+  xlnx,en-csi-v2-0:
+    type: boolean
+    description: Present if CSI v2 is enabled in IP configuration.
+
+  xlnx,en-vcx:
+    type: boolean
+    description: |
+      When present, there are maximum 16 virtual channels, else only 4.
+
+  xlnx,en-active-lanes:
+    type: boolean
+    description: |
+      Present if the number of active lanes can be re-configured at
+      runtime in the Protocol Configuration Register. Otherwise all lanes,
+      as set in IP configuration, are always active.
+
+  video-reset-gpios:
+    description: Optional specifier for a GPIO that asserts video_aresetn.
+    maxItems: 1
+
+  ports:
+    $ref: /schemas/graph.yaml#/properties/ports
+
+    properties:
+      port@0:
+        $ref: /schemas/graph.yaml#/$defs/port-base
+        description: |
+          Input / sink port node, single endpoint describing the
+          CSI-2 transmitter.
+
+        properties:
+          endpoint:
+            $ref: /schemas/media/video-interfaces.yaml#
+            unevaluatedProperties: false
+
+            properties:
+              data-lanes:
+                description: |
+                  This is required only in the sink port 0 endpoint which
+                  connects to MIPI CSI-2 source like sensor.
+                  The possible values are -
+                  1       - For 1 lane enabled in IP.
+                  1 2     - For 2 lanes enabled in IP.
+                  1 2 3   - For 3 lanes enabled in IP.
+                  1 2 3 4 - For 4 lanes enabled in IP.
+                items:
+                  - const: 1
+                  - const: 2
+                  - const: 3
+                  - const: 4
+
+            required:
+              - data-lanes
+
+        unevaluatedProperties: false
+
+      port@1:
+        $ref: /schemas/graph.yaml#/properties/port
+        description: |
+          Output / source port node, endpoint describing modules
+          connected the CSI-2 receiver.
+            
+required:
+  - compatible
+  - reg
+  - interrupts
+  - clocks
+  - clock-names
+  - xlnx,en-active-lanes
+  - xlnx,csi-pxl-format
+  - xlnx,en-vcx
+  - xlnx,vfb
+  - ports
+
+allOf:
+  - if:
+      required:
+        - xlnx,vfb
+    then:
+      required:
+        - xlnx,csi-pxl-format
+    else:
+      properties:
+        xlnx,csi-pxl-format: false
+
+  - if:
+      not:
+        required:
+          - xlnx,en-csi-v2-0
+    then:
+      properties:
+        xlnx,en-vcx: false
+
+additionalProperties: false
+
+examples:
+  - |
+    #include <dt-bindings/gpio/gpio.h>
+    xcsi2rxss_1: csi2rx@a0020000 {
+        compatible = "xlnx,mipi-csi2-rx-subsystem-6.0";
+        reg = <0xa0020000 0x10000>;
+        interrupt-parent = <&gic>;
+        interrupts = <0 95 4>;
+        xlnx,csi-pxl-format = <0x2a>;
+        xlnx,vfb;
+        xlnx,en-active-lanes;
+        xlnx,en-csi-v2-0;
+        xlnx,en-vcx;
+        clock-names = "lite_aclk", "video_aclk";
+        clocks = <&misc_clk_0>, <&misc_clk_1>;
+        video-reset-gpios = <&gpio 86 GPIO_ACTIVE_LOW>;
+
+        ports {
+            #address-cells = <1>;
+            #size-cells = <0>;
+
+            port@0 {
+                /* Sink port */
+                reg = <0>;
+                csiss_in: endpoint {
+                    data-lanes = <1 2 3 4>;
+                    /* MIPI CSI-2 Camera handle */
+                    remote-endpoint = <&camera_out>;
+                };
+            };
+            port@1 {
+                /* Source port */
+                reg = <1>;
+                csiss_out: endpoint {
+                    remote-endpoint = <&vproc_in>;
+                };
+            };
+        };
+    };
+...

--- a/lopper/assists/yaml_bindings/xlnx,dsi.yaml
+++ b/lopper/assists/yaml_bindings/xlnx,dsi.yaml
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/display/xlnx/xlnx,dsi.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Xilinx MIPI DSI Tx Subsystem
+
+maintainers:
+  - Kunal Rane <kunal.rane@amd.com>
+
+description: |
+  The Xilinx MIPI DSI Tx Subsystem is used to display MIPI DSI-2
+  traffic received in the form of AXI4 Stream video data.
+  The subsystem consists of a MIPI D-PHY in master mode which receives the
+  data packets from the MIPI DSI-2 Tx IP which encapsulates the
+  packet data.
+  For more details, please refer to PG238 Xilinx MIPI DSI-2 Tx Subsystem.
+
+properties:
+  compatible:
+      enum:
+        - xlnx,dsi
+        - xlnx,mipi-dsi-tx-subsystem-2.3
+
+  reg:
+    maxItems: 1
+
+  interrupts:
+    maxItems: 1
+
+  clocks:
+    description: List of clock specifiers
+    items:
+      - description: AXI Lite clock
+      - description: Video clock
+
+  clock-names:
+    items:
+      - const: dphy_clk_200M
+      - const: s_axis_aclk
+
+  xlnx,dsi-data-type:
+    $ref: /schemas/types.yaml#/definitions/uint32
+    description: |
+      This denotes the CSI Data type selected in hw design.
+      Packets other than this data type (except for RAW8 and
+      User defined data types) will be filtered out.
+      Possible values are as below -
+      0 : MIPI_DSI_FMT_RGB888
+      1 : MIPI_DSI_FMT_RGB666
+      2 : MIPI_DSI_FMT_RGB666_PACKED
+      3 : MIPI_DSI_FMT_RGB565
+    oneOf:
+      - const: 0
+      - minimum: 1
+        maximum: 3
+
+  xlnx,dsi-num-lanes:
+    $ref: /schemas/types.yaml#/definitions/uint32
+    description: |
+      Possible number of DSI lanes for the Tx controller.
+      Based on xlnx,dsi-num-lanes and line rate for the MIPI
+      D-PHY core in Mbps, the AXI4-stream received by MIPI DSI
+      Tx IP core adds markers as per DSI protocol and the packet
+      thus frame is convered to serial data by MIPI D-PHY core.
+      The possible values are -
+      1       - For 1 lane enabled in IP.
+      1 2     - For 2 lanes enabled in IP.
+      1 2 3   - For 3 lanes enabled in IP.
+      1 2 3 4 - For 4 lanes enabled in IP.
+      items:
+        - const: 1
+        - const: 2
+        - const: 3
+        - const: 4
+
+  "#address-cells":
+    const: 1
+
+  "#size-cells":
+    const: 0
+
+  port@0:
+    $ref: /schemas/graph.yaml#/properties/port
+    description: |
+      Input / sink port node, single endpoint describing the
+      DSI-2 TX IP receiver.
+
+      properties:
+        endpoint:
+          type: object
+
+          properties:
+            remote-endpoint: true
+
+          required:
+            - remote-endpoint
+
+          additional properties: false
+
+      required:
+        - endpoint
+
+      additionalProperties: false
+
+  simple-panel@0:
+    type: object
+    description: |
+      Panel node that's connected to DSI-2 TX.
+
+      properties:
+        compatible = "auo,b101uan01";
+ 
+required:
+  - compatible
+  - reg
+  - interrupts
+  - clocks
+  - clock-names
+  - xlnx,dsi-num-lanes
+  - xlnx,dsi-data-type
+  - port@0
+  - simple-panel@0
+
+additionalProperties: false
+
+examples:
+  - |
+    #include <dt-bindings/drm/mipi-dsi.h>
+        mipi_dsi_tx_subsystem@80000000 {
+          compatible = "xlnx,dsi";
+          reg = <0x80000000 0x10000>;
+          interrupts = <0 108 4>;
+          xlnx,dsi-num-lanes = <4>;
+          xlnx,dsi-data-type = <0>;
+          clock-names = "dphy_clk_200M", "s_axis_aclk";
+          clocks = <&misc_clk_0>, <&misc_clk_1>;
+          #address-cells = <1>;
+          #size-cells = <0>;
+
+          simple_panel: simple-panel@0 {
+            compatible = "auo,b101uan01";
+            reg = <0>;
+          };
+          port@0 {
+            reg = <0>;
+            dsi_encoder: endpoint {
+              remote-endpoint = <&xyz_port>;
+            };
+          };
+        };

--- a/lopper/assists/yaml_bindings/xlnx,frmbuf-rd-wr.yaml
+++ b/lopper/assists/yaml_bindings/xlnx,frmbuf-rd-wr.yaml
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/dma/xilinx/xlnx,frmbuf-rd-wr.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Xilinx framebuffer read and write ip
+
+maintainers:
+  - Kunal Rane <kunal.rane@amd.com>
+
+description: |
+  The Xilinx framebuffer DMA engine supports two soft IP blocks, one IP
+  block is used for reading video frame data from memory (FB Read) to the device
+  and the other IP block is used for writing video frame data from the device
+  to memory (FB Write). Both the FB Read/Write IP blocks are aware of the
+  format of the data being written to or read from memory including RGB and
+  YUV in packed, planar, and semi-planar formats.  Because the FB Read/Write
+  is format aware, only one buffer pointer is needed by the IP blocks even
+  when planar or semi-planar format are used.
+
+allOf:
+  - $ref: "../dma-controller.yaml#"
+
+properties: 
+  "#dma-cells":
+    const: 1
+    description: |
+      The cell is the DMA channel ID.
+
+  compatible:
+    enum:
+      - xlnx,axi-frmbuf-wr-v2.1
+      - xlnx,axi-frmbuf-wr-v2.2
+      - xlnx,axi-frmbuf-rd-v2.1
+      - xlnx,axi-frmbuf-rd-v2.2
+
+  reg:
+    maxItems: 1
+
+  clocks:
+    description: Reference to the AXI Streaming clock.
+    maxItems: 1
+
+  clock-names:
+    items:
+      - const: ap_clk
+
+  interrupt-names:
+    items:
+      - const: interrupt
+
+  interrupts:
+    maxItems: 1
+
+  reset-gpios:
+    maxItems: 1
+    description: Should contain GPIO reset phandle
+
+  xlnx,dma-addr-width:
+    description: Size of dma address pointer in IP (either 32 or 64)
+    $ref: /schemas/types.yaml#/definitions/uint8
+    enum: [ 32, 64 ]
+
+  xlnx,vid-formats:
+    description: |
+      A list of strings indicating what video memory
+      formats the IP has been configured to support.
+      The following table describes the legal string values to be used for
+      the xlnx,vid-formats property.  To the left is the string value and the
+      two columns to the right describe how this is mapped to an equivalent V4L2
+      and DRM fourcc code---respectively---by the driver.
+
+      IP FORMAT	    DTS String	     V4L2 Fourcc	    DRM Fourcc
+      -------------|----------------|----------------------|-------------------
+      RGB8		bgr888		V4L2_PIX_FMT_RGB24	DRM_FORMAT_BGR888
+      BGR8		rgb888		V4L2_PIX_FMT_BGR24	DRM_FORMAT_RGB888
+      RGBX8		xbgr8888	V4L2_PIX_FMT_BGRX32	DRM_FORMAT_XBGR8888
+      RGBA8		abgr8888	<not supported>		DRM_FORMAT_ABGR8888
+      BGRA8		argb8888	<not supported>		DRM_FORMAT_ARGB8888
+      BGRX8		xrgb8888	V4L2_PIX_FMT_XBGR32	DRM_FORMAT_XRGB8888
+      RGBX10		xbgr2101010	V4L2_PIX_FMT_XBGR30	DRM_FORMAT_XBGR2101010
+      RGBX12		xbgr2121212	V4L2_PIX_FMT_XBGR40	<not supported>
+      RGBX16		rgb16		V4L2_PIX_FMT_BGR40	<not supported>
+      YUV8		vuy888		V4L2_PIX_FMT_VUY24	DRM_FORMAT_VUY888
+      YUVX8		xvuy8888	V4L2_PIX_FMT_XVUY32	DRM_FORMAT_XVUY8888
+      Y_U_V8		y_u_v8		V4L2_PIX_FMT_YUV444P	DRM_FORMAT_YUV444
+      Y_U_V8		y_u_v8		V4L2_PIX_FMT_YUV444M	DRM_FORMAT_YUV444
+      Y_U_V10		y_u_v10		V4L2_PIX_FMT_X403	DRM_FORMAT_X403
+      YUYV8		yuyv		V4L2_PIX_FMT_YUYV	DRM_FORMAT_YUYV
+      UYVY8		uyvy		V4L2_PIX_FMT_UYVY	DRM_FORMAT_UYVY
+      YUVA8		avuy8888	<not supported>		DRM_FORMAT_AVUY
+      YUVX10		yuvx2101010	V4L2_PIX_FMT_XVUY10	DRM_FORMAT_XVUY2101010
+      Y8		y8		V4L2_PIX_FMT_GREY	DRM_FORMAT_Y8
+      Y10		y10		V4L2_PIX_FMT_XY10	DRM_FORMAT_Y10
+      Y_UV8		nv16		V4L2_PIX_FMT_NV16	DRM_FORMAT_NV16
+      Y_UV8		nv16		V4L2_PIX_FMT_NV16M	DRM_FORMAT_NV16
+      Y_UV8_420	        nv12		V4L2_PIX_FMT_NV12	DRM_FORMAT_NV12
+      Y_UV8_420	        nv12		V4L2_PIX_FMT_NV12M	DRM_FORMAT_NV12
+      Y_UV10		xv20		V4L2_PIX_FMT_XV20M	DRM_FORMAT_XV20
+      Y_UV10		xv20		V4L2_PIX_FMT_XV20	<not supported>
+      Y_UV10_420	xv15		V4L2_PIX_FMT_XV15M	DRM_FORMAT_XV15
+      Y_UV10_420	xv15		V4L2_PIX_FMT_XV20	<not supported>
+      
+    $ref: /schemas/types.yaml#/definitions/string
+    minItems: 1
+    maxItems: 27
+
+  xlnx,pixels-per-clock:
+    description: Pixels per clock set in IP
+    allOf:
+      - $ref: /schemas/types.yaml#/definitions/uint32
+      - enum: [1, 2, 4, 8] 
+    
+  xlnx,dma-align:
+    description: |
+      DMA alignment required in bytes.
+      If absent then dma alignment is calculated as
+      pixels per clock * 8.
+      If present it should be power of 2 and at least
+      pixels per clock * 8.
+      Minimum is 8, 16, 32 when pixels-per-clock is
+      1, 2 or 4.  
+    allOf:
+      - $ref: /schemas/types.yaml#/definitions/uint32
+      - enum: [8, 16, 32] 
+
+  xlnx,max-height:
+    $ref: /schemas/types.yaml#/definitions/uint16
+    description: Maximum number of lines.
+    minimum: 64
+    maximum: 8640
+
+  xlnx,max-width:
+    $ref: /schemas/types.yaml#/definitions/uint16
+    description: Maximum number pixels in a line.
+    minimum: 64
+    maximum: 15360
+
+  xlnx,s-axi-ctrl-addr-width:
+    description: |
+      AXI lite bus address width
+    $ref: /schemas/types.yaml#/definitions/uint32
+
+  xlnx,s-axi-ctrl-data-width:
+    description: |
+      AXI lite bus data width
+    $ref: /schemas/types.yaml#/definitions/uint32
+
+  xlnx,video-width:
+    description: |
+      data width
+    $ref: /schemas/types.yaml#/definitions/uint8
+
+required:
+  - "#dma-cells"
+  - compatible
+  - reg
+  - clocks
+  - clock-names
+  - interrupt-names
+  - interrupts
+  - reset-gpios
+  - xlnx,dma-addr-width
+  - xlnx,vid-formats
+  - xlnx,pixels-per-clock
+  - xlnx,dma-align
+  - xlnx,max-height
+  - xlnx,max-width
+  - xlnx,s-axi-ctrl-addr-width
+  - xlnx,s-axi-ctrl-data-width
+  - xlnx,video-width
+
+additionalProperties: false
+
+examples: 
+  - |
+    #include <dt-bindings/phy/phy.h>
+    #include <dt-bindings/reset/xlnx-zynqmp-resets.h>
+
+    v_frmbuf_rd@a0060000 {
+        #dma-cells = <1>;
+        compatible = "xlnx,v-frmbuf-rd-2.4", "xlnx,axi-frmbuf-rd-v2.2";
+        reg = <0x0 0xa0060000 0x0 0x10000>;
+        clocks = <&misc_clk_2>;
+        clock-names = "ap_clk";
+        interrupt-names = "interrupt";
+        interrupts = <0 106 4>;
+        interrupt-parent = <&gic>;
+        reset-gpios = <&psng0_axi_gpio_rst 5 1>;
+        xlnx,dma-addr-width = <32>;
+        xlnx,vid-formats = "bgr888";
+        xlnx,pixels-per-clock = <2>;
+        xlnx,dma-align = <16>;
+        xlnx,max-height = <2160>;
+        xlnx,max-width = <3840>;
+        xlnx,s-axi-ctrl-addr-width = <0x7>;
+        xlnx,s-axi-ctrl-data-width = <0x20>;
+        xlnx,video-width = <8>;
+    };
+
+    v_frmbuf_wr@a0070000 {
+        #dma-cells = <1>;
+        compatible = "xlnx,v-frmbuf-wr-2.4", "xlnx,axi-frmbuf-wr-v2.2";
+        reg = <0x0 0xa0070000 0x0 0x10000>;
+        clocks = <&misc_clk_2>;
+        clock-names = "ap_clk";
+        interrupt-names = "interrupt";
+        interrupts = <0 107 4>;
+        interrupt-parent = <&gic>;
+        reset-gpios = <&psng0_axi_gpio_rst 4 1>;
+        xlnx,dma-addr-width = <32>;
+        xlnx,vid-formats = "bgr888";
+        xlnx,pixels-per-clock = <2>;
+        xlnx,dma-align = <16>;
+        xlnx,max-height = <2160>;
+        xlnx,max-width = <3840>;
+        xlnx,s-axi-ctrl-addr-width = <0x7>;
+        xlnx,s-axi-ctrl-data-width = <0x20>;
+        xlnx,video-width = <8>;
+    };

--- a/lopper/assists/yaml_bindings/xlnx,v-demosaic.yaml
+++ b/lopper/assists/yaml_bindings/xlnx,v-demosaic.yaml
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/media/xilinx/xlnx,v-demosaic.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Xilinx Demosaic IP.
+
+maintainers:
+  - Kunal Rane <kunal.rane@amd.com>
+
+description: |
+  The Xilinx Video Demosaic IP is used to interface to a Bayer video source.
+  The driver set default Sink Pad media bus format to RGGB.
+  The IP and driver only support RGB as its Source Pad media format.
+
+properties:
+  compatible:
+    items:
+      - enum:
+          - xlnx,v-demosaic-1.1
+
+  reg:
+    maxItems: 1
+
+  clocks:
+    description: Reference to the AXI streaming clock feeding the Demosaic
+                 ap_clk.
+    maxItems: 1
+
+  clock-names:
+    items:
+      - const: ap_clk
+
+  xlnx,max-height:
+    $ref: /schemas/types.yaml#/definitions/uint16
+    description: Maximum number of lines.
+    minimum: 64
+    maximum: 4320
+
+  xlnx,max-width:
+    $ref: /schemas/types.yaml#/definitions/uint16
+    description: Maximum number of pixels in a line.
+    minimum: 64
+    maximum: 8192
+
+  reset-gpios:
+    maxItems: 1
+    description: Should contain GPIO reset phandle
+
+  ports:
+    type: object
+
+    properties:
+      "#address-cells":
+        const: 1
+
+      "#size-cells":
+        const: 0
+
+      port@0:
+        type: object
+        description: |
+          Input/sink port node, describing module connected to the
+          input of Demosaic IP.
+
+        properties:
+          reg:
+            description: |
+              Input/sink port number.
+            const: 0
+
+          endpoint:
+            type: object
+
+            properties:
+              remote-endpoint: true
+
+            required:
+              - remote-endpoint
+
+            additionalProperties: false
+
+        required:
+            - reg
+            - endpoint
+
+        additionalProperties: false
+
+      "port@1":
+        type: object
+        description: |
+          Output/source port node, describing module connected to the
+          output.
+
+        properties:
+          reg:
+            description: |
+              Output/source port number.
+            const: 1
+
+          endpoint:
+            type: object
+
+            properties:
+              remote-endpoint: true
+
+            required:
+              - remote-endpoint
+
+            additionalProperties: false
+
+        required:
+          - reg
+          - endpoint
+
+        additionalProperties: false
+
+    required:
+      - "#address-cells"
+      - "#size-cells"
+      - port@0
+      - port@1
+
+    additionalProperties: false
+
+required:
+  - compatible
+  - reg
+  - clocks
+  - clock-names
+  - xlnx,max-height
+  - xlnx,max-width
+  - reset-gpios
+  - ports
+  - remote-endpoint
+
+additionalProperties: false
+
+examples:
+  - |
+   psng0_dm0: v_demosaic@a0010000 {
+        clock-names = "ap_clk";
+        clocks = <&misc_clk_2>;
+        compatible = "xlnx,v-demosaic-1.1";
+        reg = <0xa0010000 0x10000>;
+        reset-gpios = <&psng0_axi_gpio_rst 0 1>;
+        xlnx,max-height = /bits/ 16 <2160>;
+        xlnx,max-width = /bits/ 16 <3840>;
+
+        ports {
+            #address-cells = <1>;
+            #size-cells = <0>;
+
+            port@0 {
+                /* For cfa-pattern=rggb user needs to fill as per BAYER format */
+                reg = <0>;
+                psng0_dm0csirx_0: endpoint {
+                    remote-endpoint = <&mipi_csirx_outcsirx_0>;
+                };
+
+            };
+            port@1 {
+                /* For cfa-pattern=rggb user needs to fill as per BAYER format */
+                reg = <1>;
+                demo_outpsng0_dm0: endpoint {
+                    remote-endpoint = <&psng0_vg0psng0_dm0>;
+                };
+
+            };
+        };
+    };

--- a/lopper/assists/yaml_bindings/xlnx,v-gamma-lut.yaml
+++ b/lopper/assists/yaml_bindings/xlnx,v-gamma-lut.yaml
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/media/xilinx/xlnx,v-gamma-lut.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Xilinx Gamma LUT IP.
+
+maintainers:
+  - Kunal Rane <kunal.rane@amd.com>
+
+description: |
+  The Xilinx Gamma LUT IP is used to provide RGB Gamma correction.
+  The IP provides a look up table for each R,G and B components.
+
+properties:
+  compatible:
+    items:
+      - enum:
+          - xlnx,v-gamma-lut
+
+  reg:
+    maxItems: 1
+
+  clocks:
+    description: Reference to the AXI streaming clock feeding the Demosaic
+                 ap_clk.
+    maxItems: 1
+
+  clock-names:
+    items:
+      - const: ap_clk
+
+  xlnx,max-height:
+    $ref: /schemas/types.yaml#/definitions/uint16
+    description: Maximum number of lines.
+    minimum: 64
+    maximum: 4320
+
+  xlnx,max-width:
+    $ref: /schemas/types.yaml#/definitions/uint16
+    description: Maximum number of pixels in a line.
+    minimum: 64
+    maximum: 8192
+
+  reset-gpios:
+    maxItems: 1
+    description: Should contain GPIO reset phandle
+
+
+
+  ports:
+    type: object
+
+    properties:
+      "#address-cells":
+        const: 1
+
+      "#size-cells":
+        const: 0
+
+      port@0:
+        type: object
+        description: |
+          Input/sink port node, describing module connected to the
+          input of Gamma LUT IP.
+
+        properties:
+          reg:
+            description: |
+              Input/sink port number.
+            const: 0
+
+          xlnx,video-width:
+            description: Number of bits per color.
+            allOf:
+              - $ref: /schemas/types.yaml#/definitions/uint32
+              - enum: [8, 16]
+
+          endpoint:
+            type: object
+
+            properties:
+              remote-endpoint: true
+
+            required:
+              - remote-endpoint
+
+            additionalProperties: false
+
+        required:
+            - reg
+            - xlnx,video-width
+            - endpoint
+
+        additionalProperties: false
+
+      "port@1":
+        type: object
+        description: |
+          Output/source port node, describing module connected to the
+          output.
+
+        properties:
+          reg:
+            description: |
+              Output/source port number.
+            const: 1
+
+          xlnx,video-width:
+            description: Number of bits per color.
+            allOf:
+              - $ref: /schemas/types.yaml#/definitions/uint32
+              - enum: [8, 16]
+
+          endpoint:
+            type: object
+
+            properties:
+              remote-endpoint: true
+
+            required:
+              - remote-endpoint
+
+            additionalProperties: false
+
+        required:
+            - reg
+            - xlnx,video-width
+            - endpoint
+
+        additionalProperties: false
+
+    required:
+      - "#address-cells"
+      - "#size-cells"
+      - port@0
+      - port@1
+
+    additionalProperties: false
+
+required:
+  - compatible
+  - reg
+  - clocks
+  - xlnx,max-height
+  - xlnx,max-width
+  - reset-gpios
+  - ports
+
+additionalProperties: false
+
+examples:
+  - |
+   gamma_lut_1: gamma_lut_1@a0080000 {
+        compatible = "xlnx,v-gamma-lut";
+        reg = <0xa0080000 0x10000>;
+        clocks = <&vid_stream_clk>;
+        reset-gpios = <&gpio 83 1>;
+        xlnx,max-height = /bits/ 16 <2160>;
+        xlnx,max-width = /bits/ 16 <3840>;
+
+        ports {
+            #address-cells = <1>;
+            #size-cells = <0>;
+
+            port@0 {
+                reg = <0>;
+                xlnx,video-width = <8>;
+
+                gamma_in: endpoint {
+                    remote-endpoint = <&demosaic_out>;
+                };
+            };
+
+            port@1 {
+                reg = <1>;
+                xlnx,video-width = <8>;
+
+                gamma_out: endpoint {
+                    remote-endpoint = <&csc_in>;
+                };
+            };
+        };
+    };

--- a/lopper/assists/yaml_bindings/xlnx,v-vpss-csc.yaml
+++ b/lopper/assists/yaml_bindings/xlnx,v-vpss-csc.yaml
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/media/xilinx/xlnx,v-vpss-csc.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Xilinx VPROC_SS IP.
+
+maintainers:
+  - Kunal Rane <kunal.rane@amd.com>
+
+description: |  
+  The Xilinx VPSS Color Space Converter (CSC) is a Video IP that supports
+  color space conversion from RGB or YUV(444, 422, 420)input to RGB or
+  YUV(444, 422, 420) output.
+
+properties:
+  compatible:
+    items:
+      - enum:
+          - xlnx,v-proc-ss-2.3
+          - xlnx,v-vpss-csc
+          - xlnx,vpss-csc
+  reg:
+    maxItems: 1
+
+  clocks:
+    description: Reference to the AXI streaming clock feeding the Demosaic
+                 ap_clk.
+    maxItems: 1
+
+  clock-names:
+    items:
+      - const: ap_clk
+
+  xlnx,max-height:
+    $ref: /schemas/types.yaml#/definitions/uint16
+    description: Maximum number of lines.
+    minimum: 64
+    maximum: 4320
+
+  xlnx,max-width:
+    $ref: /schemas/types.yaml#/definitions/uint16
+    description: Maximum number of pixels in a line.
+    minimum: 64
+    maximum: 8192
+
+  reset-gpios:
+    maxItems: 1
+    description: Should contain GPIO reset phandle
+
+  ports:
+    type: object
+
+    properties:
+      "#address-cells":
+        const: 1
+
+      "#size-cells":
+        const: 0
+
+      port@0:
+        type: object
+        description: |
+          Input/sink port node, describing module connected to the
+          input of Demosaic IP.
+
+        properties:
+          reg:
+            description: |
+              Input/sink port number.
+            const: 0
+
+          xlnx,video-format:
+            $ref: /schemas/types.yaml#/definitions/uint16
+            description: |
+              Video format details for input and output port.
+              The possible values are -
+              0 - RGB
+              1 - YUV444
+              2 - YUV422
+              3 - YUV420
+            anyOf:
+              - enum: [0, 1, 2, 3] 
+
+          xlnx,video-width:
+            $ref: /schemas/types.yaml#/definitions/uint16
+            description: |
+              The video with to which input and output pads
+              of the VPSS IP are set.
+            anyOf:
+              - enum: [8, 10, 12, 16] 
+
+          endpoint:
+            type: object
+
+            properties:
+              remote-endpoint: true
+
+            required:
+              - remote-endpoint
+
+            additionalProperties: false
+
+        required:
+            - reg
+            - xlnx,video-format
+            - xlnx,video-width   
+            - endpoint
+
+        additionalProperties: false
+
+      "port@1":
+        type: object
+        description: |
+          Output/source port node, describing module connected to the
+          output.
+
+        properties:
+          reg:
+            description: |
+              Output/source port number.
+            const: 1
+
+          xlnx,video-format:
+            $ref: /schemas/types.yaml#/definitions/uint16
+            description: |
+              Video format details for input and output port.
+              The possible values are 
+              0 - RGB
+              1 - YUV444
+              2 - YUV422
+              3 - YUV420
+            anyOf:
+              - enum: [0, 1, 2, 3] 
+  
+
+          xlnx,video-width:
+            $ref: /schemas/types.yaml#/definitions/uint16
+            description: |
+              The video with to which input and output pads
+              of the VPSS IP are set.
+            anyOf:
+              - enum: [8, 10, 12, 16] 
+
+          endpoint:
+            type: object
+
+            properties:
+              remote-endpoint: true
+
+            required:
+              - remote-endpoint
+
+            additionalProperties: false
+
+        required:
+          - reg
+          - xlnx,video-format
+          - xlnx,video-width   
+          - endpoint
+
+        additionalProperties: false
+
+    required:
+      - "#address-cells"
+      - "#size-cells"
+      - port@0
+      - port@1
+
+    additionalProperties: false
+
+required:
+  - compatible
+  - reg
+  - clocks
+  - clock-names
+  - xlnx,max-height
+  - xlnx,max-width
+  - reset-gpios
+  - ports
+
+additionalProperties: false
+
+examples:
+  - |
+   csc_1:csc@a0040000 {
+        clock-names = "ap_clk";
+        clocks = <&misc_clk_2>;
+        compatible = "xlnx,v-vpss-csc";
+        reg = <0xa0040000 0x10000>;
+        reset-gpios = <&gpio 0 1>;
+        xlnx,max-height = /bits/ 16 <2160>;
+        xlnx,max-width = /bits/ 16 <3840>;
+
+        ports {
+            #address-cells = <1>;
+            #size-cells = <0>;
+            port@0 {
+                reg = <0>;
+                xlnx,video-format = /bits/ 16 <0>;
+                xlnx,video-width = /bits/ 16 <8>;
+                csc_in: endpoint {
+                    remote-endpoint = <&gamma_out>;
+                };
+
+            };
+            port@1 {
+                reg = <1>;
+                xlnx,video-format = /bits/ 16 <3>;
+                xlnx,video-width = /bits/ 16 <8>;
+                csc_out: endpoint {
+                    remote-endpoint = <&scaler_in>;
+                };
+
+            };
+        };
+    };

--- a/lopper/assists/yaml_bindings/xlnx,v-vpss-scaler.yaml
+++ b/lopper/assists/yaml_bindings/xlnx,v-vpss-scaler.yaml
@@ -1,0 +1,329 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/media/xilinx/xlnx,v-vpss-scaler.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Xilinx VPROC_SS IP.
+
+maintainers:
+  - Kunal Rane <kunal.rane@amd.com>
+
+description: |  
+  The Xilinx VPSS Scaler IP is a Video IP that supports up and down
+  scaling as well as color space conversion from RGB or YUV(444, 422, 420)
+  input to RGB or YUV(444, 422, 420) output.
+
+properties:
+  compatible:
+    items:
+      - enum:
+          - xlnx,v-proc-ss-2.3
+          - xlnx,v-vpss-scaler-1.0
+
+  reg:
+    maxItems: 1
+
+  clocks:
+    description: Reference to the AXI streaming clock feeding the Demosaic
+                 ap_clk.
+    maxItems: 1
+
+  clock-names:
+    items:
+      - const: ap_clk
+
+  xlnx,max-height:
+    $ref: /schemas/types.yaml#/definitions/uint16
+    description: Maximum number of lines.
+    minimum: 64
+    maximum: 4320
+
+  xlnx,max-width:
+    $ref: /schemas/types.yaml#/definitions/uint16
+    description: Maximum number of pixels in a line.
+    minimum: 64
+    maximum: 8192
+
+  reset-gpios:
+    maxItems: 1
+    description: Should contain GPIO reset phandle
+
+  xlnx,num-hori-taps:
+    $ref: /schemas/types.yaml#/definitions/uint16
+    description: The number of horizontal taps for scaling filter.
+      A value of 2 represents bilinear filters.
+      A value of 4 represents bicubic. Values 6,8,10,12 represent
+      polyphase filters.
+    oneOf:
+      - enum: [2, 4, 6, 8, 10, 12]
+
+  xlnx,num-vert-taps:
+    $ref: /schemas/types.yaml#/definitions/uint16
+    description: The number of vertical taps for scaling filter.
+      A value of 2 represents bilinear filters.
+      A value of 4 represents bicubic. Values 6,8,10,12 represent
+      polyphase filters.
+    allOf:
+      - enum: [2, 4, 6, 8, 10, 12]
+
+  xlnx,pix-per-clk:
+    $ref: /schemas/types.yaml#/definitions/uint16
+    description: The pixels per clock property of the IP.
+    allOf:
+      - enum: [1, 2, 4, 8]
+
+  xlnx,colorspace-support:
+    $ref: /schemas/types.yaml#/definitions/uint16
+    description: The colorspace property selected in the IP.
+    const: 0
+    
+  xlnx,csc-enable-window:
+    type: boolean
+    description: If csc window is enabled or not.
+
+  xlnx,enable-csc:
+    type: boolean
+    description: If csc is enabled or not.
+     
+  xlnx,h-scaler-phases:
+    $ref: /schemas/types.yaml#/definitions/uint16
+    description: defines hscaler phase value for
+       polyphase algorithm.
+    const: 64
+
+  xlnx,h-scaler-taps:
+    $ref: /schemas/types.yaml#/definitions/uint16
+    description: no of taps for h-scaler.
+    allOf:
+      - enum: [6, 8, 10, 12]
+
+  xlnx,samples-per-clk:
+    $ref: /schemas/types.yaml#/definitions/uint16
+    description: samples per clock set in the IP.
+    allOf:
+      - enum: [1, 2, 4, 8]
+
+  xlnx,scaler-algorithm:
+    $ref: /schemas/types.yaml#/definitions/uint16
+    description: Algorithm selected in the IP for scaling.
+    allOf:
+      - enum: [0, 1, 2]
+
+  xlnx,topology:
+    $ref: /schemas/types.yaml#/definitions/uint16
+    description: Mode of operation selected for the IP.
+    allOf:
+      - enum: [0, 1, 2, 3, 4, 5]
+
+  xlnx,use-uram:
+    type: boolean
+    description: use uram or not selected in the IP.
+
+  xlnx,v-scaler-phases:
+    $ref: /schemas/types.yaml#/definitions/uint16
+    description: Defines vscale phase value for the
+        polyphase algorithm.
+    const: 64
+
+  xlnx,v-scaler-taps:
+    $ref: /schemas/types.yaml#/definitions/uint16
+    description: No of taps for vscaler.
+    allOf:
+      - enum: [6, 8, 10, 12]
+      
+
+  ports:
+    type: object
+
+    properties:
+      "#address-cells":
+        const: 1
+
+      "#size-cells":
+        const: 0
+
+      port@0:
+        type: object
+        description: |
+          Input/sink port node, describing module connected to the
+          input of Demosaic IP.
+
+        properties:
+          reg:
+            description: |
+              Input/sink port number.
+            const: 0
+
+          xlnx,video-format:
+            $ref: /schemas/types.yaml#/definitions/uint16
+            description: |
+              Video format details for input and output port.
+              The possible values are -
+              0 - RGB
+              1 - YUV444
+              2 - YUV422
+              3 - YUV420
+            anyOf:
+              - enum: [0, 1, 2, 3] 
+
+          xlnx,video-width:
+            $ref: /schemas/types.yaml#/definitions/uint16
+            description: |
+              The video with to which input and output pads
+              of the VPSS IP are set.
+            anyOf:
+              - enum: [8, 10, 12, 16] 
+
+          endpoint:
+            type: object
+
+            properties:
+              remote-endpoint: true
+
+            required:
+              - remote-endpoint
+
+            additionalProperties: false
+
+        required:
+            - reg
+            - xlnx,video-format
+            - xlnx,video-width   
+            - endpoint
+
+        additionalProperties: false
+
+      "port@1":
+        type: object
+        description: |
+          Output/source port node, describing module connected to the
+          output.
+
+        properties:
+          reg:
+            description: |
+              Output/source port number.
+            const: 1
+
+          xlnx,video-format:
+            $ref: /schemas/types.yaml#/definitions/uint16
+            description: |
+              Video format details for input and output port.
+              The possible values are 
+              0 - RGB
+              1 - YUV444
+              2 - YUV422
+              3 - YUV420
+            anyOf:
+              - enum: [0, 1, 2, 3] 
+  
+
+          xlnx,video-width:
+            $ref: /schemas/types.yaml#/definitions/uint16
+            description: |
+              The video with to which input and output pads
+              of the VPSS IP are set.
+            anyOf:
+              - enum: [8, 10, 12, 16] 
+
+          endpoint:
+            type: object
+
+            properties:
+              remote-endpoint: true
+
+            required:
+              - remote-endpoint
+
+            additionalProperties: false
+
+        required:
+          - reg
+          - xlnx,video-format
+          - xlnx,video-width   
+          - endpoint
+
+        additionalProperties: false
+
+    required:
+      - "#address-cells"
+      - "#size-cells"
+      - port@0
+      - port@1
+
+    additionalProperties: false
+
+required:
+  - compatible
+  - reg
+  - clocks
+  - clock-names
+  - xlnx,max-height
+  - xlnx,max-width
+  - reset-gpios
+  - ports
+  - xlnx,num-hori-taps
+  - xlnx,num-vert-taps
+  - xlnx,pix-per-clk
+  - xlnx,colorspace-support
+  - xlnx,csc-enable-window
+  - xlnx,enable-csc
+  - xlnx,h-scaler-phases
+  - xlnx,h-scaler-taps
+  - xlnx,samples-per-clk
+  - xlnx,scaler-algorithm
+  - xlnx,topology
+  - xlnx,use-uram
+  - xlnx,v-scaler-phases
+  - xlnx,v-scaler-taps
+
+additionalProperties: false
+
+examples:
+  - |
+   csc_1:csc@a0040000 {
+        compatible = "xlnx,v-vpss-scaler-1.0";
+        reg = <0xa0040000 0x10000>;
+        clocks = <&misc_clk_2>;
+        clock-names = "ap_clk";
+        xlnx,max-height = /bits/ 16 <2160>;
+        xlnx,max-width = /bits/ 16 <3840>;
+        reset-gpios = <&gpio 0 1>;
+        xlnx,num-hori-taps = /bits/ 16 <8>;
+        xlnx,num-vert-taps = /bits/ 16 <8>;
+        xlnx,pix-per-clk = /bits/ 16 <2>;
+        xlnx,colorspace-support = /bits/ 16 <0>;
+        xlnx,csc-enable-window;
+        xlnx,enable-csc;
+        xlnx,h-scaler-phases = /bits/ 16 <64>;
+        xlnx,h-scaler-taps = /bits/ 16 <8>;
+        xlnx,samples-per-clk = /bits/ 16 <2>;
+        xlnx,scaler-algorithm = /bits/ 16  <2>;
+        xlnx,topology = /bits/ 16  <0>;
+        xlnx,use-uram;
+        xlnx,v-scaler-phases = /bits/ 16 <64>;
+        xlnx,v-scaler-taps = /bits/ 16 <8>;
+        ports {
+            #address-cells = <1>;
+            #size-cells = <0>;
+            port@0 {
+                reg = <0>;
+                xlnx,video-format = /bits/ 16 <0>;
+                xlnx,video-width = /bits/ 16 <8>;
+                csc_in: endpoint {
+                    remote-endpoint = <&gamma_out>;
+                };
+
+            };
+            port@1 {
+                reg = <1>;
+                xlnx,video-format = /bits/ 16 <3>;
+                xlnx,video-width = /bits/ 16 <8>;
+                csc_out: endpoint {
+                    remote-endpoint = <&scaler_in>;
+                };
+
+            };
+        };
+    };


### PR DESCRIPTION
Add following list of yaml documentation to support MIPI linux solution:
1. MIPI CSI2 RX SS
2. MIPI DSI TX SS
3. Demosaic
4. Gamma Lut
5. VPSS CSC and Scaler
6. Framebuffer RD/WR