### PR TITLE
fdt: generate __symbols__ when compile

### DIFF
--- a/lopper/fdt.py
+++ b/lopper/fdt.py
@@ -1876,7 +1876,7 @@ class LopperFDT(lopper.base.lopper_base):
             dtcargs += ["-i", i]
 
         dtcargs += ["-o", "{0}/{1}".format(outdir,output_dtb)]
-        dtcargs += ["-I", "dts", "-O", "dtb", preprocessed_name ]
+        dtcargs += ["-@", "-I", "dts", "-O", "dtb", preprocessed_name ]
         if verbose:
             print( "[INFO]: compiling dtb: %s" % dtcargs )
 


### PR DESCRIPTION
It seems to me that many lops under `lopper/lops/` requires a `__symbols__` node to run. However, the `dtc` on my machine only generates the `__symbols__` node when `-@` is passed