### PR TITLE
lopper: don't check the existence of cpp when LOPPER_CPP is set

### DIFF
--- a/lopper/__init__.py
+++ b/lopper/__init__.py
@@ -122,9 +122,9 @@ class LopperSDT:
 
         # check for required support applications
         if libfdt:
-            support_bins = [ "dtc", "cpp" ]
+            support_bins = [ os.environ.get("LOPPER_DTC", "dtc"), os.environ.get("LOPPER_CPP", "cpp") ]
         else:
-            support_bins = [ "cpp" ]
+            support_bins = [ os.environ.get("LOPPER_CPP", "cpp") ]
 
         for s in support_bins:
             lopper.log._info( f"checking for support binary: {s}" )

--- a/lopper/base.py
+++ b/lopper/base.py
@@ -112,7 +112,7 @@ class lopper_base:
 
         # try pcpp first
         ppargs = (os.environ.get('LOPPER_CPP') or shutil.which("pcpp") or "").split()
-        if ppargs:
+        if ppargs and os.path.basename(ppargs[0]) == "pcpp":
             ppargs += "--passthru-comments".split()
         else:
             ppargs = (os.environ.get('LOPPER_CPP') or shutil.which("cpp") or "").split()


### PR DESCRIPTION
When LOPPER_CPP is set to other C preprocessors, e.g. aarch64-none-elf-cpp in a cross compilation environment, lopper still checks the existence of `cpp` and refuses to run if not exists.

Also fixed lopper passing an unrecognized argument `--passthru-comments` when LOPPER_CPP is set to C processors other than `pcpp`.