### PR TITLE
lopper: Enhancements in BareMetal flow

### DIFF
--- a/lopper/assists/baremetal_bspconfig_xlnx.py
+++ b/lopper/assists/baremetal_bspconfig_xlnx.py
@@ -102,5 +102,44 @@ def xlnx_generate_bm_bspconfig(tgt_node, sdt, options):
                            fd.write(",")
                            fd.write(f"  /* {prop} */") 
                    fd.write("\n};")
+               if name == "microblaze":
+                   outfile = os.path.join(sdt.outdir, "microblaze_exceptions_g.h")
+                   with open(outfile, 'w') as fd:
+                       fd.write('#ifndef MICROBLAZE_EXCEPTIONS_G_H /**< prevent circular inclusions */\n')
+                       fd.write('#define MICROBLAZE_EXCEPTIONS_G_H /**< by using protection macros */\n')
+                       is_exception_en = []
+                       for prop in prop_list[:10]:
+                           if prop == "xlnx,exceptions-in-delay-slots":
+                               if match_cpunode.propval(prop) != ['']:
+                                   val = match_cpunode.propval(prop, list)[0]
+                                   if val != 0:
+                                       fd.write("#define MICROBLAZE_CAN_HANDLE_EXCEPTIONS_IN_DELAY_SLOTS\n")
+                           elif prop == "xlnx,unaligned-exceptions":
+                               if match_cpunode.propval(prop) != ['']:
+                                   val = match_cpunode.propval(prop, list)[0]
+                                   if val == 0:
+                                       fd.write("#define NO_UNALIGNED_EXCEPTIONS 1\n")
+                                   else:
+                                       is_exception_en.append(True)
+                           elif prop == "xlnx,fpu-exception":
+                               if match_cpunode.propval(prop) != ['']:
+                                   val = match_cpunode.propval(prop, list)[0]
+                                   if val != 0:
+                                       fd.write("#define MICROBLAZE_FP_EXCEPTION_ENABLED 1\n")
+                                       is_exception_en.append(True)
+                           elif prop == "xlnx,predecode-fpu-exception":
+                               if match_cpunode.propval(prop) != ['']:
+                                   val = match_cpunode.propval(prop, list)[0]
+                                   if val != 0:
+                                       fd.write("#define MICROBLAZE_FP_EXCEPTION_DECODE 1\n")
+                                       is_exception_en.append(True)
+                           else:
+                               if match_cpunode.propval(prop) != ['']:
+                                   val = match_cpunode.propval(prop, list)[0]
+                                   if val != 0:
+                                       is_exception_en.append(True)
+                       if any(is_exception_en):
+                           fd.write('#define MICROBLAZE_EXCEPTIONS_ENABLED 1\n')
+                       fd.write('#endif /* end of protection macro */\n')
 
     return True

--- a/lopper/assists/baremetal_gentestapp_xlnx.py
+++ b/lopper/assists/baremetal_gentestapp_xlnx.py
@@ -90,12 +90,12 @@ def xlnx_generate_testapp(tgt_node, sdt, options):
     testapp_data = {}
     testapp_name = {}
     # Ensure that the interrupt controller example is the first example run in the peripheral tests sequence by updating the yaml_file_list.
-    gic_index = [index for index,yaml_file in enumerate(yaml_file_list) if re.sub(r"_v.*_.*$", "", os.path.basename(yaml_file)) == "scugic.yaml"]
     intc_index = [index for index,yaml_file in enumerate(yaml_file_list) if re.sub(r"_v.*_.*$", "", os.path.basename(yaml_file)) == "intc.yaml"]
-    if gic_index:
-        yaml_file_list.insert(0, yaml_file_list.pop(gic_index[0]))
     if intc_index:
         yaml_file_list.insert(0, yaml_file_list.pop(intc_index[0]))
+    gic_index = [index for index,yaml_file in enumerate(yaml_file_list) if re.sub(r"_v.*_.*$", "", os.path.basename(yaml_file)) == "scugic.yaml"]
+    if gic_index:
+        yaml_file_list.insert(0, yaml_file_list.pop(gic_index[0]))
     for yaml_file in yaml_file_list:
         schema = utils.load_yaml(yaml_file)
         driver_compatlist = compat_list(schema)

--- a/lopper/assists/baremetal_gentestapp_xlnx.py
+++ b/lopper/assists/baremetal_gentestapp_xlnx.py
@@ -36,6 +36,12 @@ def xlnx_generate_testapp(tgt_node, sdt, options):
     # and create a compatible_list from these nodes.
     symbol_node = ""
     chosen_node = ""
+    stdin = None
+    stdin_node = None
+    try:
+        stdin = options['args'][2]
+    except IndexError:
+        pass
     for node in root_sub_nodes:
         try:
             if node.name == "chosen":
@@ -54,6 +60,11 @@ def xlnx_generate_testapp(tgt_node, sdt, options):
         if "cdns,ttc" in node["compatible"].value:
             ttc_node_list += [node]
         compatible_dict.update({node: node["compatible"].value})
+        if stdin:
+            if node.propval('xlnx,name') != ['']:
+                node_name = node.propval('xlnx,name', list)[0]
+                if node_name == stdin:
+                    stdin_node = node
     match_cpunode = get_cpu_node(sdt, options)
     proc_ip_name = match_cpunode['xlnx,ip-name'].value
     if proc_ip_name[0] in ["psu_cortexr5", "psv_cortexr5", "psx_cortexr52"] and ttc_node_list:
@@ -118,7 +129,10 @@ def xlnx_generate_testapp(tgt_node, sdt, options):
             drv_config_name = drv_name
 
         stdin_addr = None
-        if chosen_node:
+        if stdin_node:
+            val, size = scan_reg_size(stdin_node, stdin_node['reg'].value, 0)
+            stdin_addr = val
+        elif chosen_node:
             stdin_node = get_stdin(sdt, chosen_node, node_list)
             if stdin_node:
                 val, size = scan_reg_size(stdin_node, stdin_node['reg'].value, 0)

--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -476,14 +476,6 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
         pss_ref = match_cpunode.propval('xlnx,pss-ref-clk-freq', list)[0]
         plat.buf(f'#define XPAR_PSU_PSS_REF_CLK_FREQ_HZ {pss_ref}\n')
 
-    #Defines for STDOUT and STDIN Baseaddress
-    if chosen_node:
-        stdin_node = bm_config.get_stdin(sdt, chosen_node, total_nodes)
-        if stdin_node:
-            val, size = bm_config.scan_reg_size(stdin_node, stdin_node['reg'].value, 0)
-            plat.buf(f"\n#define STDOUT_BASEADDRESS {hex(val)}")
-            plat.buf(f"\n#define STDIN_BASEADDRESS {hex(val)}\n")
-
     #Define for NUMBER_OF_SLRS
     if sdt.tree[tgt_node].propval('slrcount') != ['']:
         val = sdt.tree[tgt_node].propval('slrcount', list)[0]

--- a/lopper/lops/lop-ttc-split.dts
+++ b/lopper/lops/lop-ttc-split.dts
@@ -30,7 +30,16 @@
                           from baremetalconfig_xlnx import scan_reg_size
                           if __selected__:
                               for s in tree.__selected__:
-
+                                  tree['/__symbols__'].delete(s.label)
+                                  val = s.label[-1]
+                                  s.label = f'{s.label[:-1]}{int(val)*3}'
+                                  try:
+                                      name_val = s['xlnx,name'].value[0]
+                                      s['xlnx,name'].value[0] =  f'{name_val[:-1]}{int(val)*3}'
+                                  except:
+                                      pass
+                              tree.sync()
+                              for s in tree.__selected__:
                                   reg, size = scan_reg_size(s, s['reg'].value, 0)
                                   inp = s['interrupt-parent'].value[0]
                                   intr_parent = [s for s in tree['/'].subnodes() if s.phandle == inp]
@@ -39,14 +48,18 @@
                                   for x in range(1, 3):
                                         new_ttc_node = s()
                                         new_ttc_node.name = f'{s.name[:-1]}{x*4}'
-                                        new_ttc_node.label = f'{s.label}_{x-1}'
+                                        val = s.label[-1]
+                                        new_ttc_node.label = f'{s.label[:-1]}{int(val)+x}'
                                         modify_reg = f'{hex(reg)[:-1]}{x*4}'
                                         modify_prop = [int(modify_reg, 16), size-(x*4)]
                                         modify_val = update_mem_node(s, modify_prop)
                                         new_ttc_node['reg'].value =  modify_val
                                         new_ttc_node['interrupts'].value =  s['interrupts'].value[x*inc:]
-                                        name_val = s['xlnx,name'].value[0]
-                                        new_ttc_node['xlnx,name'].value[0] =  f'{name_val}_{x-1}'
+                                        try:
+                                            name_val = s['xlnx,name'].value[0]
+                                            new_ttc_node['xlnx,name'].value[0] =  f'{name_val[:-1]}{int(val)+x}'
+                                        except:
+                                            pass
                                         new_ttc_node.resolve()
                                         # add the updated node to the original node's parent .. we are a sibling node
                                         s.parent.add( new_ttc_node )


### PR DESCRIPTION
Pull request does the below
lopper: assists: baremetal_bspconfig_xlnx: Add support for generating microblaze_exceptions_g.h header
lopper: assists: baremetal_gentestapp_xlnx: Fix race condition while making the Interrupt Controller example as the primary example
lopper: assists: baremetal_gentestapp_xlnx: Add support for override stdin configuration
lopper: assists: baremetal_xparameters_xlnx: remove references to duplicate SDT* defines
lopper: lops: lop-ttc-split: Rename the label names to inline with old tool