### PR TITLE
lops: lop-microblaze-riscv: Update multilib mappings

### DIFF
--- a/lopper/lops/lop-microblaze-riscv.dts
+++ b/lopper/lops/lop-microblaze-riscv.dts
@@ -102,19 +102,23 @@
                                    libpath.append('riscv64-unknown-elf/riscv32-xilinx-elf/usr/lib/')
                                    cflags_data = {}
                                    archflags_lib_map = {
-                                       'rv32if' : 'rv32if_zicsr',
                                        'rv32imf' : 'rv32imf_zicsr',
-                                       'rv32ifc' : 'rv32ifc_zicsr',
                                        'rv32imfc' : 'rv32imfc_zicsr',
                                        'rv32ia' : 'rv32i',
                                        'rv32ima' : 'rv32im',
-                                       'rv32iaf' : 'rv32if_zicsr',
                                        'rv32imaf' : 'rv32imf_zicsr',
                                        'rv32iac' : 'rv32ic',
-                                       'rv32imac' : 'rv32imc',
-                                       'rv32iafc' : 'rv32ifc_zicsr',
-                                       'rv32imafc' : 'rv32imfc_zicsr',
-                                       'rv32imfdc' : 'rv32imfdc_zicsr'
+                                       'rv32imafc' : 'rv32imafc_zicsr',
+                                       'rv32imfdc' : 'rv32imfdc_zicsr',
+                                       'rv64imf' : 'rv64imf_zicsr',
+                                       'rv64imfc' : 'rv64imfc_zicsr',
+                                       'rv64ia' : 'rv64i',
+                                       'rv64ima' : 'rv64im',
+                                       'rv64imaf' : 'rv64imf_zicsr',
+                                       'rv64iac' : 'rv64ic',
+                                       'rv64imfdc' : 'rv64imfdc_zicsr',
+                                       'rv64imafc' : 'rv64imafc_zicsr'
+
                                    }
 
                                    for property in proplist:


### PR DESCRIPTION
Updating multilib mappings based on multilib libraries installed in vitis 2024.2 version.

Also, include mappings for 64 bit variant.