### PR TITLE
lopper/tree: add get() for LopperTree class

### DIFF
--- a/lopper/tree.py
+++ b/lopper/tree.py
@@ -3291,6 +3291,33 @@ class LopperTree:
         # not currently supported
         pass
 
+    def get(self, key, default = None):
+        """mocks the builtin dictionary get() function for Lopper tree object:
+
+            <Lopper Tree Object>.get(<node path>)
+
+        Returns the same output as that of __getitem__ described above when the passed
+        key matches with some node inside the tree object.
+
+        Returns the default value when the node is not valid for the tree and avoids
+        the standard KeyError exception.
+
+        Args:
+            key: string, int or LopperNode
+            default: any valid data type
+
+        Returns:
+           LopperNode object if the key is found in the object
+           default value when key is absent.
+
+        """
+
+        try:
+            return self.__getitem__(key)
+        except KeyError:
+            return default
+
+
     def phandles( self ):
         """Utility function to get the active phandles in the tree
 


### PR DESCRIPTION
Add a new function get() for LopperTree class to mock the builtin dictionary get() function. This function helps in avoiding the KeyError while accessing any node from the tree. This feature already exists for LopperNode (propval()) and LopperProp (__getitem__), but it is missing for LopperTree.