### PR TITLE
lops:lop-cpu-oslist Add a new lops file to get ai_engine as cpu

### DIFF
--- a/lopper/lops/lop-cpu-oslist.dts
+++ b/lopper/lops/lop-cpu-oslist.dts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2024 Advanced Micro Devices, Inc.  All rights reserved.
+ *
+ * Author:
+ *     Dhriti Sree Rompicharla <DhritiSree.Rompicharla@amd.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+*/
+
+/dts-v1/;
+
+/ {
+        compatible = "system-device-tree-v1,lop";
+        lops {
+                compatible = "system-device-tree-v1,lop";
+                lop_0 {
+                      compatible = "system-device-tree-v1,lop,select-v1";
+                      select_1;
+                      select_2 = "/.*:device_type:cpu";
+                      lop_0_1 {
+                              compatible = "system-device-tree-v1,lop,code-v1";
+                              code = "
+                                     import yaml
+                                     yaml_dict = {}
+                                     for node in __selected__:
+                                        cpu_ip_name =  node.propval('xlnx,ip-name')[0]
+                                        yaml_dict[node.label] = {'ip_name' : '','supported_os' : []}
+                                        yaml_dict[node.label]['ip_name'] = cpu_ip_name
+                                        if 'cortex' in cpu_ip_name or cpu_ip_name == 'microblaze':
+                                            yaml_dict[node.label]['supported_os'] = ['standalone','freertos']
+                                        else:
+                                            yaml_dict[node.label]['supported_os'] = ['standalone']
+                                     with open('cpulist.yaml', 'w') as fd:
+                                         fd.write(yaml.dump(yaml_dict, indent = 4))
+                                     ";
+                      };
+                };
+                lop_1 {
+                       compatible = "system-device-tree-v1,lop,select-v1";
+                       select_1;
+                       select_2 = "/.*:xlnx,ip-name:ai_engine";
+                       lop_1_1 {
+                               compatible = "system-device-tree-v1,lop,code-v1";
+                               code = "
+                                      import yaml
+                                      with open('cpulist.yaml', 'r') as fd:
+                                        yaml_data = yaml.safe_load(fd)
+                                      for node in __selected__:
+                                         yaml_data[node.label] = {'ip_name' : 'ai_engine','supported_os' : ['aie_runtime']}
+                                      with open('cpulist.yaml', 'w') as fd:
+                                          fd.write(yaml.dump(yaml_data, indent = 4))
+                                      ";
+                               };
+                };
+        };
+};


### PR DESCRIPTION
Add a new lops file that can generate ai_engine as a cpu. Update the earlier cpulist.yaml with supported os data as well.