### PR TITLE
Bug fixes in Linux device-tree generation

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -108,6 +108,8 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
                 sdt.tree.delete(node)
             if node.propval('memory_type', list) == ['linear_flash']:
                 sdt.tree.delete(node)
+            if node.label == "amba_xppu" or node.label == "amba_xmpu":
+                sdt.tree.delete(node)
             for entry in node.propval('compatible', list):
                 pl_memory_compatible_list = ["xlnx,ddr4","xlnx,mig-7series","xlnx,lmb-bram","xlnx,axi-bram"]
                 if any(entry.startswith(compatible_prefix) for compatible_prefix in pl_memory_compatible_list):
@@ -205,7 +207,18 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
                             'psu_pmu_global_0', 'psu_qspi_linear_0', 'psu_rpu', 'psu_rsa', 'psu_siou', 'psu_ipi',
                             'psx_PSM_PPU', 'psx_ram_instr_cntlr', 'psx_rpu', 'psx_fpd_gpv', 'ddr4', 'ps7_ram', 'ps7_afi',
                             'ps7_pmu', 'ps7_ocmc', 'ps7_scuc', 'ps7_iop_bus_config', 'ps7_gpv', 'psu_ocm_ram_0', 'psv_ocm_ram_0',
-                            'psx_ocm_ram', 'ocm_ram', 'psx_ocm_ram_0', 'ocm_ram_0']
+                            'psx_ocm_ram', 'ocm_ram', 'psx_ocm_ram_0', 'ocm_ram_0', 'gt_quad_base', 'psv_coresight_apu_cti',
+                            'psv_coresight_cpm_cti2d', 'psv_coresight_cpm_ela2a', 'psv_coresight_cpm_ela2b',
+                            'psv_coresight_cpm_ela2c', 'psv_coresight_cpm_ela2d', 'psv_coresight_cpm_fun',
+                            'psv_coresight_cpm_rom', 'psv_coresight_fpd_atm', 'psv_coresight_fpd_stm',
+                            'psv_coresight_lpd_atm', 'psv_crf', 'psv_crl',  'psv_crp', 'psv_fpd_afi',
+                            'psv_fpd_cci', 'psv_fpd_gpv', 'psv_fpd_slcr', 'psv_fpd_slcr_secure', 'psv_fpd_smmu',
+                            'psv_lpd_afi', 'psv_lpd_iou_secure_slcr', 'psv_lpd_iou_slcr', 'psv_lpd_slcr',
+                            'psv_lpd_slcr_secure', 'psv_noc_pcie_0', 'psv_noc_pcie_1', 'psv_noc_pcie_2',
+                            'psv_ocm', 'psv_pmc_aes', 'psv_pmc_bbram_ctrl', 'psv_pmc_cfi_cframe', 'psv_pmc_cfu_apb',
+                            'psv_pmc_efuse_cache', 'psv_pmc_efuse_ctrl', 'psv_pmc_global', 'psv_pmc_ppu1_mdm',
+                            'psv_pmc_ram_npi', 'psv_pmc_rsa', 'psv_pmc_sha', 'psv_pmc_slave_boot', 'psv_scntrs',
+                            'psv_pmc_slave_boot_stream', 'psv_pmc_trng', 'psv_psm_global_reg', 'psv_rpu', 'psv_scntr']
 
     if linux_dt:
         binding_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "yaml_bindings")

--- a/lopper/assists/xlnx_overlay_dt.py
+++ b/lopper/assists/xlnx_overlay_dt.py
@@ -84,7 +84,6 @@ def xlnx_generate_overlay_dt(tgt_node, sdt, options):
     except:
         pass
     outfile = os.path.join(sdt.outdir, 'pl.dtsi')
-    plat = DtbtoCStruct(outfile)
     for node in root_sub_nodes:
         try:
             if node.name == "__symbols__":
@@ -102,9 +101,9 @@ def xlnx_generate_overlay_dt(tgt_node, sdt, options):
     for node in root_sub_nodes:
         try:
             label_name = get_label(sdt, symbol_node, node)
-            if platform == "cortexa53-zynqmp" and label_name == "gic_a53":
+            if (platform == "cortexa53-zynqmp" or platform == "psu_cortexa53_0") and label_name == "gic_a53":
                 gic_node = node
-            elif platform == "cortexa72-versal" and label_name == "gic_a72":
+            elif (platform == "cortexa72-versal" or platform == "psv_cortexa72_0") and label_name == "gic_a72":
                 gic_node = node
             elif platform == "psx_cortexa78_0" and label_name == "gic_a78":
                 gic_node = node
@@ -145,6 +144,7 @@ def xlnx_generate_overlay_dt(tgt_node, sdt, options):
 
     for node in root_sub_nodes:
         if node.name == "amba_pl":
+            pl_node = node
             get_sub_node = node.subnodes()
             for node in get_sub_node:
                 if node.propval('reg') != ['']:
@@ -153,9 +153,10 @@ def xlnx_generate_overlay_dt(tgt_node, sdt, options):
         if has_valid_pl:
             break
 
+    if pl_node:
+        plat = DtbtoCStruct(outfile)
+
     for node in root_sub_nodes:
-        if node.name == "amba_pl":
-            pl_node = node
         set_ignore = 0
 
         try:
@@ -313,8 +314,8 @@ def xlnx_generate_overlay_dt(tgt_node, sdt, options):
         plat.buf('};')
     if has_pl:
         plat.buf('\n};')
-    plat.out(''.join(plat.get_buf()))
     if pl_node:
+        plat.out(''.join(plat.get_buf()))
         sdt.tree.delete(pl_node)
         remove_node_ref(sdt, tgt_node, sdt.tree['/__symbols__'])
         remove_node_ref(sdt, tgt_node, sdt.tree['/aliases'])


### PR DESCRIPTION
lopper: assist: gen_domain_dts: Update the linux device-tree to delete unneeded nodes
lopper: assists: xlnx_overlay_dt: Improvments in the assist
Update the assist for the below use cases
--> Don't generate pl.dtsi in case of no amba_pl node in the system
device-tree
--> Add support for passing processor name as input instead of hardcoded
machine name.