### PR TITLE
lopper: assists: Add special handling for zynq nand

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -287,6 +287,14 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
                                     plat.buf(f'\n#define XPAR_{label_name}_{prop.upper()}_BASEADDR_{i} {prop_val}')
                                     cannon_prop = prop + str("_") + str("BASEADDR") + str("_") + str(i)
                                     canondef_dict.update({cannon_prop:prop_val})
+                        # Add special handling for Zynq NAND
+                        elif "arm,pl353-smc-r2p1" in node.propval('compatible'):
+                            val = node[prop].value[2]
+                            size = node[prop].value[3]
+                            plat.buf(f'\n#define XPAR_{label_name}_BASEADDR {hex(val)}')
+                            plat.buf(f'\n#define XPAR_{label_name}_HIGHADDR {hex(val + size -1)}')
+                            canondef_dict.update({"BASEADDR":hex(val)})
+                            canondef_dict.update({"HIGHADDR":hex(val + size - 1)})
                     else:
                         try:
                             prop_val = node[prop].value

--- a/lopper/assists/baremetalconfig_xlnx.py
+++ b/lopper/assists/baremetalconfig_xlnx.py
@@ -521,6 +521,11 @@ def xlnx_generate_prop(sdt, node, prop, drvprop_list, plat, pad, phandle_prop):
                 if j != (len(prop_vallist) - 1):
                     plat.buf(',')
                 drvprop_list.append(prop_val)
+        # Add special handling for Zynq NAND
+        elif "arm,pl353-smc-r2p1" in node.propval('compatible'):
+            plat.buf('\n\t\t%s' % hex(node[prop].value[2]))
+            drvprop_list.append(hex(node[prop].value[2]))
+
     elif prop == "Handler-table":
         # In the driver config structure this property is of type struct
         # to avoid Missing braces around initializer warning add braces


### PR DESCRIPTION
For Zynq Nand controller the baseaddress of the IP is part of the ranges property instead of reg property updated the assits to handle this use case.