### PR TITLE
assists: gen_domain_dts: Add strict check while fetching cpu nodes from SDT

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -87,7 +87,7 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
         pass
 
     # Delete other CPU Cluster nodes
-    cpunode_list = sdt.tree.nodes('/cpu.*@.*')
+    cpunode_list = sdt.tree.nodes('/cpu.*@.*', strict=True)
     clustercpu_nodes = []
     for node in cpunode_list:
         if node.parent.phandle != match_cpunode.parent.phandle and node.phandle != match_cpunode.parent.phandle:


### PR DESCRIPTION
Some designs can have cpu_ as prefix in IPs names (sdt labels).

cpunode_list = sdt.tree.nodes('/cpu.@.')

was employed in gen_domain_dts assist to get all the cpu nodes from SDT and delete the cpu nodes (available in the root node) that are not supposed to be in that domain. In this case, the logic deleted all the IP nodes under axi bus starting with cpu_ as sdt.tree.nodes() does regex matching by default.

Employ the strict check (that was introduced a couple of weeks back in Lopper) to avoid the same.