### PR TITLE
lopper: assists: gen_domain_dts: Don't delete the xlnx,name property …

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -122,7 +122,9 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
                     sdt.tree.delete(node)
                     break
             if node.propval('xlnx,name') != ['']:
-                node.delete('xlnx,name')
+                if node.parent.propval('compatible') != ['']:
+                    if not "xlnx,versal-sysmon" in node.parent.propval('compatible'):
+                        node.delete('xlnx,name')
             if node.propval('xlnx,interconnect-s-axi-masters') != ['']:
                 node.delete('xlnx,interconnect-s-axi-masters')
             if node.propval('xlnx,rable') != ['']:


### PR DESCRIPTION
…for sysmon driver

Commit 08d1ac6f3568("lopper: assists: gen_domain_dts: Remove unneeded properties while generating linux device-tree") updated the code to remove unneeded properties but xlnx,name property is needed for sysmon child nodes updated the logic to don't delete this property from sysmon child nodes.