### PR TITLE
lopper: assist: dt-binding: vphy: Fix the syntax error in vphy YAML binding

### DIFF
--- a/lopper/assists/yaml_bindings/xlnx,vphy.yaml
+++ b/lopper/assists/yaml_bindings/xlnx,vphy.yaml
@@ -157,7 +157,6 @@ properties:
       - $ref: /schemas/types.yaml#/definitions/uint32
       - enum: [0, 1]
 
- - xlnx,hdmi-connector
   xlnx,tx-buffer-bypass:
     description: Flag to indicate buffer bypass logic availability.
     allOf:


### PR DESCRIPTION
Commit 6515708cf697 (lopper: vphy: Add FMC connector property) had a copy paste error while adding the entry in the dt-binding YAML. Fix the YAML syntax error in the same.