### PR TITLE
lopper: hdmi: Add HDCP1x Keymanagement property

### DIFF
--- a/lopper/assists/yaml_bindings/xlnx,v-dprxss.yaml
+++ b/lopper/assists/yaml_bindings/xlnx,v-dprxss.yaml
@@ -118,7 +118,7 @@ properties:
       - $ref: /schemas/types.yaml#/definitions/uint32
       - enum: [2, 3, 4, 5, 6, 7, 8]
 
-  xlnx,hdcp1x-keymgmt:
+  xlnx,hdcp1x_keymgmt:
     description:
       A phandle to a syscon device, used to access
       hdcp1x keymgmt registers.
@@ -177,6 +177,7 @@ required:
   - phy-names
   - xlnx,vidphy
   - xlnx,dp-retimer
+  - xlnx,hdcp1x_keymgmt
   - xlnx,mode
   - phys
   - ports

--- a/lopper/assists/yaml_bindings/xlnx,v-hdmi-rx-ss.yaml
+++ b/lopper/assists/yaml_bindings/xlnx,v-hdmi-rx-ss.yaml
@@ -117,6 +117,12 @@ properties:
       This denotes phandles for phy lanes registered for HDMI protocol.
       HDMI 1.4/2.0 always require 3 lanes
 
+  xlnx,hdcp1x_keymgmt:
+    description: |
+      A phandle to a syscon device, used to access
+      HDCP1x keymgmt registers.
+    $ref: /schemas/types.yaml#/definitions/phandle
+
   phy-names:
     items:
       - const: hdmi-phy0
@@ -166,6 +172,7 @@ required:
   - xlnx,snd-pcm
   - xlnx,include-hdcp-1-4
   - xlnx,include-hdcp-2-2
+  - xlnx,hdcp1x_keymgmt
   - phys
   - phy-names
   - ports

--- a/lopper/assists/yaml_bindings/xlnx,v-hdmi-rxss1.yaml
+++ b/lopper/assists/yaml_bindings/xlnx,v-hdmi-rxss1.yaml
@@ -101,7 +101,7 @@ properties:
     description: |
       Present when HDCP2x is enabled.
 
-  xlnx,hdcp1x-keymgmt:
+  xlnx,hdcp1x_keymgmt:
     description: |
       A phandle to a syscon device, used to access
       HDCP1x keymgmt registers.
@@ -180,6 +180,7 @@ required:
   - xlnx,frl-clk-freq-khz
   - xlnx,vid-clk-freq-khz
   - xlnx,input-pixels-per-clock
+  - xlnx,hdcp1x_keymgmt
   - phys
   - phy-names
   - ports

--- a/lopper/assists/yaml_bindings/xlnx,v-hdmi-tx-ss.yaml
+++ b/lopper/assists/yaml_bindings/xlnx,v-hdmi-tx-ss.yaml
@@ -134,6 +134,12 @@ properties:
       present, indicates optional audio core needed for audio usecase is
       included.
 
+  xlnx,hdcp1x-keymgmt:
+    description:
+      A phandle to a syscon device, used to access
+      hdcp1x keymgmt registers.
+    $ref: /schemas/types.yaml#/definitions/phandle
+
   xlnx,snd-pcm:
     description: |
       Reference to audio formatter block. Add this if, audio formatter
@@ -196,6 +202,7 @@ required:
   - xlnx,max-bits-per-component
   - xlnx,vid-interface
   - xlnx,xlnx-hdmi-acr-ctrl
+  - xlnx,hdcp1x-keymgmt
   - ports
 
 additionalProperties: false

--- a/lopper/assists/yaml_bindings/xlnx,v-hdmi-txss1.yaml
+++ b/lopper/assists/yaml_bindings/xlnx,v-hdmi-txss1.yaml
@@ -151,6 +151,7 @@ required:
   - phy-names
   - xlnx,input-pixels-per-clock
   - xlnx,max-bits-per-component
+  - xlnx,hdcp1x-keymgmt
   - xlnx,vid-interface
   - xlnx,max-frl-rate
   - ports


### PR DESCRIPTION
Add HDCP1x keymanagement property for DP and HDMI subsystems.