### PR TITLE
lopper: assists: gen_domain_dts: delete unneeded nodes for zephyr MB-V

### DIFF
--- a/lopper/assists/zephyr_supported_comp.yaml
+++ b/lopper/assists/zephyr_supported_comp.yaml
@@ -1,0 +1,38 @@
+amd,mbv32:
+  required:
+    - compatible
+    - reg
+    - device_type
+    - riscv,isa
+    - i-cache-size
+    - d-cache-size
+    - clock-frequency
+
+xlnx,xps-intc-1.00.a:
+  required:
+    - compatible
+    - reg
+    - interrupt-controller
+    - interrupt-parent
+    - '#interrupt-cells'
+    - interrupts-extended
+    - xlnx,kind-of-intr
+    - xlnx,num-intr-inputs
+
+xlnx,xps-timer-1.00.a:
+  required:
+    - compatible
+    - reg
+    - interrupts
+    - interrupt-parent
+    - xlnx,one-timer-only 
+    - clocks
+
+xlnx,xps-uartlite-1.00.a:
+  required:
+    - compatible
+    - reg
+    - interrupts
+    - interrupt-parent
+    - current-speed
+    - clocks


### PR DESCRIPTION
Zephyr OS has strict device-tree node checking and property checking currently it support only timer, interrupt controller and uartlite IP's only for any given MB-V design keep only those nodes and update memory node and cpu node and alias nodes as per zephyr dts specificaion.

FIXME: file zephyr_supported_comp.yaml was added for the timebeing proper fix would be reading the yaml specification from zephyr binding docs.