### PR TITLE
Align generated Kconfig files and device tree for mbv32 zephyr with zephyr-amd repository

### DIFF
--- a/lopper/base.py
+++ b/lopper/base.py
@@ -474,6 +474,7 @@ class lopper_base:
                     "address-map" : [ '#ranges-address-cells phandle #ranges-address-cells #ranges-size-cells', 0 ],
                     "secure-address-map" : [ '#ranges-address-cells phandle ^:#address-cells #ranges-size-cells', 0 ],
                     "interrupt-parent" : [ 'phandle', 0 ],
+                    "interrupts-extended" : [ 'phandle field' ],
                     "iommus" : [ 'phandle field' ],
                     "interrupt-map" : [ '#address-cells #interrupt-cells phandle:#interrupt-cells' ],
                     "access" : [ 'phandle flags' ],

--- a/lopper/lops/lop-mbv-zephyr-intc.dts
+++ b/lopper/lops/lop-mbv-zephyr-intc.dts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Author:
+ *       Mubin Sayyed <mubin.sayyed@amd.com>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/dts-v1/;
+
+/ {
+        compatible = "system-device-tree-v1,lop";
+        lops {
+                compatible = "system-device-tree-v1,lop";
+                
+		lop_0 {
+                        compatible = "system-device-tree-v1,lop,select-v1";
+                        select_1;
+                        select_2 = "/soc/interrupt-controller*::";
+
+                };
+
+                lop_1 {
+                        compatible = "system-device-tree-v1,lop,modify";
+                        modify = ":interrupt-parent:&cpu_intc";
+
+                };
+
+
+		lop_2 {
+                        compatible = "system-device-tree-v1,lop,modify";
+                        modify = ":interrupts-extended:&cpu_intc";
+			lop_2_1 {
+				compatible = "system-device-tree-v1,lop,code-v1";
+				code = "
+					for n in __selected__:
+						val = n['interrupts-extended'].value
+						val.append('11')
+						n.resolve()
+					tree.resolve()
+				";
+
+                	};
+                };
+
+		lop_3 {
+			select_1;
+			compatible = "system-device-tree-v1,lop,modify";
+			modify = "/__symbols__::";
+		};
+        };
+};


### PR DESCRIPTION
zephyr-amd repository has been updated with zephyr upstream
version 3.7. It has few changes related to Kconfig files,
kcofigs  related to HW extensions are moved from soc/mbv32/kconfig.soc
to soc/mbv32/Kconfig. Also, interrupt controller wiring is modified. 