### PR TITLE
Bug fixes in the peripheral test app

### DIFF
--- a/lopper/assists/baremetal_gentestapp_xlnx.py
+++ b/lopper/assists/baremetal_gentestapp_xlnx.py
@@ -184,6 +184,8 @@ def xlnx_generate_testapp(tgt_node, sdt, options):
 
             for compat in driver_compatlist:
                 for node in node_list:
+                    if "xlnx,tmr-sem-1.0" in node["compatible"].value:
+                        continue
                     if sdt.tree[node].propval('reg') != ['']:
                         val, size = scan_reg_size(node, node['reg'].value, 0)
                         if stdin_addr == val:

--- a/lopper/assists/common_utils.py
+++ b/lopper/assists/common_utils.py
@@ -121,6 +121,7 @@ def copy_file(src: str, dest: str, follow_symlinks: bool = False, silent_discard
     """
     is_file(src, silent_discard)
     shutil.copy2(src, dest, follow_symlinks=follow_symlinks)
+    os.chmod(dest, 0o644)
 
 def find_files(search_pattern, search_path):
     """


### PR DESCRIPTION
This pull request does the below
lopper: assists: common_utils: Add support for read-only embeddedsw usecase
lopper: assists: baremetal_gentestapp_xlnx: Exclude pulling uartlite examples for tmr-sem
