### PR TITLE
xlnx_overlay_dt.py: Use re.match instead of re.search for clock patte…

### DIFF
--- a/lopper/assists/xlnx_overlay_dt.py
+++ b/lopper/assists/xlnx_overlay_dt.py
@@ -284,7 +284,7 @@ def xlnx_generate_overlay_dt(tgt_node, sdt, options):
                                 phandle_prop = str(p).replace('"', '')
                         if phandle_prop:
                             plat.buf('%s' % phandle_prop)
-                        elif re.search("clocks =", str(p)):
+                        elif re.match("clocks =", str(p)):
                             plat.buf('%s' % node['clocks'])
                         elif p.name == "interrupt-parent":
                             if gic_node and imux_node:


### PR DESCRIPTION
…rn matching

Switch from re.search to re.match for checking the "clocks =" pattern. re.match ensures the pattern is matched only at the beginning of the string, improving accuracy when parsing clock definitions.