### PR TITLE
lopper: assists: gen_domain_dts: Add Ignore IP entries for Versal Gen2 linux domain

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -242,6 +242,18 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
                             'psv_pmc_ram_npi', 'psv_pmc_rsa', 'psv_pmc_sha', 'psv_pmc_slave_boot', 'psv_scntrs',
                             'psv_pmc_slave_boot_stream', 'psv_pmc_trng', 'psv_psm_global_reg', 'psv_rpu', 'psv_scntr']
 
+    versal_gen2_linux_ignore_ip_list = ['mmi_10gbe', 'mmi_udh_pll', 'mmi_common', 'mmi_gpu', 'mmi_gtyp_cfg', 'mmi_pipe_gem_slcr',
+                            'mmi_udh_pll', 'mmi_udh_slcr', 'mmi_usb2phy', 'mmi_usb3phy_crpara', 'mmi_usb3phy_tca', 'mmi_usb_cfg',
+                            'pmc_rsa', 'pmc_aes', 'pmc_sha2', 'pmc_sha3', "rpu", "apu", "pmc_ppu1_mdm", "pmc_xppu_npi", "pmc_xppu",
+                            "pmc_xmpu", "pmc_slave_boot_stream", "pmc_slave_boot", "pmc_ram_npi", "pmc_global", "ocm", "ocm_xmpu",
+                            "lpd_xppu", "lpd_systmr_read", "lpd_systmr_ctrl", "lpd_slcr_secure", "lpd_slcr", "lpd_iou_slcr",
+                            "lpd_iou_secure_slcr", "lpd_afi", "fpd_systmr_read", "fpd_systmr_ctrl", "fpd_slv_asild_xmpu",
+                            "fpd_slv_asilb_xmpu", "fpd_slcr_secure", "fpd_slcr", "fpd_cmn", "fpd_afi", "pmc_efuse_ctrl",
+                            "pmc_efuse_cache", "crp", "crf", "crl", "coresight_lpd_atm", "coresight_fpd_stm", "pmc_bbram_ctrl",
+                            "pmc_cfi_cframe", "pmc_cfu_apb", "ipi"]
+
+    linux_ignore_ip_list += versal_gen2_linux_ignore_ip_list
+
     if linux_dt:
         binding_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "yaml_bindings")
         yaml_prune_list = utils.find_files("*.yaml", binding_dir)


### PR DESCRIPTION
IP Names have been updated from Versal Gen2 family onwards. There will no longer be any psu/psv/psx suffixes in the IP Names for Versal Gen2 family. Add Versal Gen2 specific IP Name entries in the ignore list to avoid un-needed IPs in linux domain and keep the linux domain device tree size in check.