### PR TITLE
openamp: xlnx: Enable gen_domain to invoke openamp processing

### DIFF
--- a/lopper/assists/openamp.py
+++ b/lopper/assists/openamp.py
@@ -187,7 +187,7 @@ def openamp_parse(root_node, tree, options ):
 
     for i in root_node["compatible"].value:
         if "xlnx" in i:
-            return xlnx_openamp_parse(tree, options, verbose)
+            return xlnx_openamp_parse(tree, options, None, verbose)
 
     return False
 

--- a/lopper/assists/openamp_xlnx_common.py
+++ b/lopper/assists/openamp_xlnx_common.py
@@ -30,6 +30,19 @@ versal_ipi_to_irq_vect_id = {
     0xFF380000 : 67,
 }
 
+openamp_linux_hosts = [ "psv_cortexa72_0", "psx_cortexa78_0", "psu_cortexa53_0" ]
+openamp_roles = { openamp_linux_hosts[0] : "a72_0",
+                  openamp_linux_hosts[1] : "a78_0",
+                  openamp_linux_hosts[2] : "a53_0",
+                  "psx_cortexr52_0" : "r52_0",
+                  "psx_cortexr52_1" : "r52_1",
+                  "psx_cortexr52_2" : "r52_2",
+                  "psx_cortexr52_3" : "r52_3",
+                  "psu_cortexr5_0" : "r5_0",
+                  "psu_cortexr5_1" : "r5_1",
+                  "psv_cortexr5_1" : "r5_1",
+                  "psv_cortexr5_0" : "r5_0" }
+
 class SOC_TYPE:
     UNINITIALIZED = -1
     VERSAL = 0


### PR DESCRIPTION
For gen_domain_dts.py plugin, if the openamp domains are present then have this processing occur at the start.

Additionally if the openamp processing ocurred then keep TCM nodes.

For OpenAMP to enable this do the following:
1. If OpenAMP processing occurs then at the end remove the OpenAMP nodes
2. Only output the OpenAMP Configuration header for non-Linux targets
3. Add some OpenAMP lookup tables to aid the gen_domain_dts.py in OpenAMP info lookup

This way the following use cases are still preserved
1. Non-Linux OpenAMP runs
2. If a user keeps the OpenAMP plugin args in a Linux domain Lopper run