### PR TITLE
lopper: assists: gen_domain_dts: Add UART and AXI-IIC nodes for Zephyr

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -393,6 +393,37 @@ def xlnx_generate_zephyr_domain_dts(tgt_node, sdt, options):
                         is_supported_periph = [value for key,value in schema.items() if key in node["compatible"].value]
                         if "xlnx,xps-timer-1.00.a" in node["compatible"].value:
                             node["compatible"].value = ["amd,xps-timer-1.00.a"]
+                        # UARTNS550
+                        if "xlnx,axi-uart16550-2.0" in node["compatible"].value:
+                            node["compatible"].value = ["ns16550"]
+                            if node.propval('clock-frequency') == [''] and node.propval('xlnx,clock-freq') != ['']:
+                                node["clock-frequency"] = LopperProp("clock-frequency")
+                                node["clock-frequency"].value = node["xlnx,clock-freq"].value
+                            if node.propval('reg-shift') != ['2']:
+                               node["reg-shift"] = LopperProp("reg-shift")
+                               node["reg-shift"].value = 2
+                        # UARTPS
+                        if any(version in node["compatible"].value for version in ("xlnx,zynqmp-uart", "xlnx,xuartps")):
+                            node["compatible"].value = ["xlnx,xuartps"]
+                            if node.propval('clock-frequency') == [''] and node.propval('xlnx,clock-freq') != ['']:
+                                node["clock-frequency"] = LopperProp("clock-frequency")
+                                node["clock-frequency"].value = node["xlnx,clock-freq"].value
+                            if node.propval('current-speed') == [''] and node.propval('xlnx,baudrate') != ['']:
+                                node["current-speed"] = LopperProp("current-speed")
+                                node["current-speed"].value = node["xlnx,baudrate"].value
+                        # UARTPSV
+                        if any(version in node["compatible"].value for version in ("arm,pl011", "arm,sbsa-uart")):
+                            node["compatible"].value = ["arm,sbsa-uart"]
+                        # AXI-IIC
+                        if "xlnx,axi-iic-2.1" in node["compatible"].value:
+                            node["compatible"].value = ["xlnx,xps-iic-2.1"]
+                        if any(version in node["compatible"].value for version in ("xlnx,xps-iic-2.00.a", "xlnx,xps-iic-2.1")):
+                            if node.propval('#address-cells') != ['1']:
+                                node["#address-cells"] = LopperProp("#address-cells")
+                                node["#address-cells"].value = 1
+                            if node.propval('#size-cells') != ['0']:
+                                node["#size-cells"] = LopperProp("#size-cells")
+                                node["#size-cells"].value = 0
                         if is_supported_periph:
                             required_prop = is_supported_periph[0]["required"]
                             prop_list = list(node.__props__.keys())

--- a/lopper/assists/zephyr_supported_comp.yaml
+++ b/lopper/assists/zephyr_supported_comp.yaml
@@ -36,3 +36,65 @@ xlnx,xps-uartlite-1.00.a:
     - interrupt-parent
     - current-speed
     - clocks
+
+xlnx,axi-uart16550-2.0:
+  required:
+    - compatible
+    - reg
+    - interrupts
+    - interrupt-parent
+    - clock-frequency
+    - reg-shift
+
+xlnx,zynqmp-uart:
+  required:
+    - compatible
+    - reg
+    - interrupts
+    - interrupt-parent
+    - current-speed
+    - clock-frequency
+    - pinctrl-0
+    - pinctrl-names
+
+xlnx,xuartps:
+    - compatible
+    - reg
+    - interrupts
+    - interrupt-parent
+    - current-speed
+    - clock-frequency
+    - pinctrl-0
+    - pinctrl-names
+
+arm,pl011:
+  required:
+    - compatible
+    - reg
+    - interrupts
+    - interrupt-parent
+
+arm,sbsa-uart:
+  required:
+    - compatible
+    - reg
+    - interrupts
+    - interrupt-parent
+
+xlnx,xps-iic-2.00.a:
+  required:
+    - compatible
+    - reg
+    - interrupts
+    - interrupt-parent
+    - '#address-cells'
+    - '#size-cells'
+
+xlnx,axi-iic-2.1:
+  required:
+    - compatible
+    - reg
+    - interrupts
+    - interrupt-parent
+    - '#address-cells'
+    - '#size-cells'


### PR DESCRIPTION
This pull request updates the Zephyr support in the Lopper project to include additional UART and AXI-IIC node support in the DTS generation.

### Changes:
- Updated the `zephyr_supported_comp.yaml` file to add UART and AXI-IIC components.
- Extended the Zephyr DTS generation script to support:
  - `UARTNS550`
  - `UARTPS`
  - `UARTPSV`
  - `AXI-IIC` nodes.

### Signed-off-by:
Ajay Neeli <ajay.neeli@amd.com>
