### PR TITLE
lopper: Add special handling for ttc baremetal use case

### DIFF
--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -241,6 +241,9 @@ def generate_hwtocmake_medata(sdt, node_list, src_path, repo_path_data, options,
 
             nodes = getmatch_nodes(sdt, node_list, drv_yamlpath, options)
             nodes = [node for node in nodes if node.props('xlnx,is-hierarchy') == []]
+            # Dynamically added TTC nodes should be excluded from the CMake metadata.
+            if drv == "ttcps":
+                nodes = [node for node in nodes if node.props('lop-dynamic-ttc-node') == []]
             name_list = []
             for node in nodes:
                 if node.propval('xlnx,name') != ['']:

--- a/lopper/lops/lop-ttc-split.dts
+++ b/lopper/lops/lop-ttc-split.dts
@@ -55,6 +55,7 @@
                                         modify_val = update_mem_node(s, modify_prop)
                                         new_ttc_node['reg'].value =  modify_val
                                         new_ttc_node['interrupts'].value =  s['interrupts'].value[x*inc:]
+                                        new_ttc_node['lop-dynamic-ttc-node'] =  1
                                         try:
                                             name_val = s['xlnx,name'].value[0]
                                             new_ttc_node['xlnx,name'].value[0] =  f'{name_val[:-1]}{int(val)+x}'


### PR DESCRIPTION
Dynamically added TTC nodes should be excluded from the CMake metadata. a new property, lop-dynamic-ttc-node, has been introduced, and the logic in bmcmake_metadata_xlnx has been updated to ensure these nodes are not included.