### PR TITLE
lopper: assists: gen_domain_dts: Add gtwiz_versal IP to the linux_ign…

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -251,7 +251,7 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
                             'psv_ocm', 'psv_pmc_aes', 'psv_pmc_bbram_ctrl', 'psv_pmc_cfi_cframe', 'psv_pmc_cfu_apb',
                             'psv_pmc_efuse_cache', 'psv_pmc_efuse_ctrl', 'psv_pmc_global', 'psv_pmc_ppu1_mdm',
                             'psv_pmc_ram_npi', 'psv_pmc_rsa', 'psv_pmc_sha', 'psv_pmc_slave_boot', 'psv_scntrs',
-                            'psv_pmc_slave_boot_stream', 'psv_pmc_trng', 'psv_psm_global_reg', 'psv_rpu', 'psv_scntr']
+                            'psv_pmc_slave_boot_stream', 'psv_pmc_trng', 'psv_psm_global_reg', 'psv_rpu', 'psv_scntr', 'gtwiz_versal']
 
     versal_gen2_linux_ignore_ip_list = ['mmi_10gbe', 'mmi_udh_pll', 'mmi_common', 'mmi_gpu', 'mmi_gtyp_cfg', 'mmi_pipe_gem_slcr',
                             'mmi_udh_pll', 'mmi_udh_slcr', 'mmi_usb2phy', 'mmi_usb3phy_crpara', 'mmi_usb3phy_tca', 'mmi_usb_cfg',


### PR DESCRIPTION
…ore_ip_list

There is no Linux driver available for the gtwiz_versal IP, and it contains numerous unnecessary properties. To prevent final DTS size issues in relation to U-Boot, update the linux_ignore_ip_list to exclude it.