### PR TITLE
lopper: assists: gen_domain_dts: Add AXI GPIO node for Zephyr

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -435,6 +435,21 @@ def xlnx_generate_zephyr_domain_dts(tgt_node, sdt, options):
                             if node.propval('#size-cells') != ['0']:
                                 node["#size-cells"] = LopperProp("#size-cells")
                                 node["#size-cells"].value = 0
+                        #AXI-GPIO
+                        if "xlnx,xps-gpio-1.00.a" in node["compatible"].value:
+                            node["compatible"].value = ["xlnx,xps-gpio-1.00.a"]
+                            if node.propval('xlnx,is-dual') != ['']:
+                                val = node.propval('xlnx,is-dual')[0]
+                                if val == 1:
+                                    new_node = LopperNode()
+                                    new_node['compatible'] = "xlnx,xps-gpio-1.00.a-gpio2"
+                                    new_node.name = "gpio2"
+                                    new_prop = LopperProp( "gpio-controller" )
+                                    new_prop.value = ""
+                                    new_node + new_prop
+                                    new_node['#gpio-cells'] = 2
+                                    new_node.label_set(node.label)
+                                    node.add(new_node)
                         if is_supported_periph:
                             required_prop = is_supported_periph[0]["required"]
                             prop_list = list(node.__props__.keys())

--- a/lopper/assists/zephyr_supported_comp.yaml
+++ b/lopper/assists/zephyr_supported_comp.yaml
@@ -98,3 +98,23 @@ xlnx,axi-iic-2.1:
     - interrupt-parent
     - '#address-cells'
     - '#size-cells'
+
+xlnx,xps-gpio-1.00.a:
+  required:
+    - compatible
+    - reg
+    - interrupts
+    - interrupt-parent
+    - gpio-controller
+    - '#gpio-cells'
+    - xlnx,all-inputs
+    - xlnx,all-inputs-2
+    - xlnx,all-outputs
+    - xlnx,all-outputs-2
+    - xlnx,dout-default
+    - xlnx,dout-default-2
+    - xlnx,gpio-width
+    - xlnx,gpio2-width
+    - xlnx,is-dual
+    - xlnx,tri-default
+    - xlnx,tri-default-2


### PR DESCRIPTION
Update zephyr_supported_comp.yaml to add AXI GPIO as supported component.
Extended Zephyr DTS generation to support AXI GPIO node.