### PR TITLE
lopper: assists: gen_domain_dts: Update memory node handling to consi…

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -163,6 +163,8 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
 
     # Update memory nodes as per address-map cluster mapping
     memnode_list = sdt.tree.nodes('/memory@.*')
+    # Iterate through memories where the device_type is set as "memory."
+    memnode_list = [node for node in memnode_list if node.propval('device_type') == ["memory"]]
     invalid_memnode = []
     for node in memnode_list:
         # Check whether the memory node is mapped to cpu cluster or not


### PR DESCRIPTION
…der device_type field

The current memory logic retrieves memory nodes by reading nodes named "memory@," which inadvertently leads to the deletion of reserved memory nodes with similar names. To prevent this, traverse only the memory nodes where device_type is explicitly set to "memory."