### PR TITLE
lopper: assists: gen_domain_dts: Add MDM RISCV UART for Zephyr

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -413,6 +413,9 @@ def xlnx_generate_zephyr_domain_dts(tgt_node, sdt, options):
                             if node.propval('reg-shift') != ['2']:
                                node["reg-shift"] = LopperProp("reg-shift")
                                node["reg-shift"].value = 2
+                        # MDM RISCV DEBUG UARTLITE
+                        if "xlnx,mdm-riscv-1.0" in node["compatible"].value:
+                            node["compatible"].value = ["xlnx,xps-uartlite-1.00a"]
                         # UARTPS
                         if any(version in node["compatible"].value for version in ("xlnx,zynqmp-uart", "xlnx,xuartps")):
                             node["compatible"].value = ["xlnx,xuartps"]

--- a/lopper/assists/zephyr_supported_comp.yaml
+++ b/lopper/assists/zephyr_supported_comp.yaml
@@ -37,6 +37,13 @@ xlnx,xps-uartlite-1.00.a:
     - current-speed
     - clocks
 
+xlnx,mdm-riscv-1.0:
+  required:
+    - compatible
+    - reg
+    - interrupts
+    - interrupt-parent
+
 xlnx,axi-uart16550-2.0:
   required:
     - compatible


### PR DESCRIPTION
- Updated zephyr_supported_comp.yaml for MDM RISCV UART
- MDM RISCV UART uses UARTLITE driver
- Extended Zephyr DTS generation to support MDM RISCV UART node