### PR TITLE
Openamp xlnx fixes feb5 2025

### DIFF
--- a/lopper/assists/openamp_xlnx.py
+++ b/lopper/assists/openamp_xlnx.py
@@ -1056,6 +1056,13 @@ def xlnx_rpmsg_parse(tree, node, openamp_channel_info, options, xlnx_options = N
 
         # rpmsg native?
         native = node.propval("openamp-xlnx-native")
+
+        # no rpmsg userspace support in v2
+        if openamp_channel_info[REMOTEPROC_D_TO_D_v2]:
+            native = []
+            for j in remote_nodes:
+                native.append(False)
+
         if native == [] or len(native) != len(remote_nodes):
             print("ERROR: malformed openamp-xlnx-native property.")
             return False

--- a/lopper/tree.py
+++ b/lopper/tree.py
@@ -437,6 +437,8 @@ class LopperProp():
                     constructed_condition = "{0} re.search(r\"{1}\",'{2}')".format(invert_check,lop_compare_value,tgt_node_compare_value)
                 elif other_prop.ptype == LopperFmt.UINT32: # type(lop_compare_value) == int:
                     constructed_condition = "{0} {1} == {2}".format(invert_check,lop_compare_value,tgt_node_compare_value)
+                else:
+                    constructed_condition = "False"
 
                 if self.__dbg__ > 2:
                     lopper.log._debug( f"    single:single. Condition: {constructed_condition}" )


### PR DESCRIPTION
@zeddii  this also fixes upstream error:

[ERROR] 

Traceback (most recent call last):
  File "/scratch/pm_team/blevinsk/build/tmp/work/x86_64-linux/esw-conf-native/2025.1+git/recipe-sysroot-native/usr/bin/lopper", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/scratch/pm_team/blevinsk/build/tmp/work/x86_64-linux/esw-conf-native/2025.1+git/recipe-sysroot-native/usr/lib/python3.12/site-packages/lopper/__main__.py", line 417, in main
    device_tree.perform_lops()
  File "/scratch/pm_team/blevinsk/build/tmp/work/x86_64-linux/esw-conf-native/2025.1+git/recipe-sysroot-native/usr/lib/python3.12/site-packages/lopper/__init__.py", line 2268, in perform_lops
    result = self.exec_lop( f, fdt_tree )
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/scratch/pm_team/blevinsk/build/tmp/work/x86_64-linux/esw-conf-native/2025.1+git/recipe-sysroot-native/usr/lib/python3.12/site-packages/lopper/__init__.py", line 1123, in exec_lop
    are_they_equal = test_prop.compare( sl_prop )
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/scratch/pm_team/blevinsk/build/tmp/work/x86_64-linux/esw-conf-native/2025.1+git/recipe-sysroot-native/usr/lib/python3.12/site-packages/lopper/tree.py", line 444, in compare
    constructed_check = eval(constructed_condition)
                             ^^^^^^^^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'constructed_condition' where it is not associated with a value


