### PR TITLE
lopper: assists: baremetallinker_xlnx: Eliminated unnecessary code bl…

### DIFF
--- a/lopper/assists/baremetal_bspconfig_xlnx.py
+++ b/lopper/assists/baremetal_bspconfig_xlnx.py
@@ -37,7 +37,7 @@ def xlnx_generate_bm_bspconfig(tgt_node, sdt, options):
     if options.get('outdir', {}):
         sdt.outdir = options['outdir']
    
-    mem_ranges, lable_names = get_memranges(tgt_node, sdt, options)
+    mem_ranges, _ = get_memranges(tgt_node, sdt, options)
     if not mem_ranges:
         return
     # Generate Memconfig cmake meta-data file.

--- a/lopper/assists/baremetal_bspconfig_xlnx.py
+++ b/lopper/assists/baremetal_bspconfig_xlnx.py
@@ -37,7 +37,7 @@ def xlnx_generate_bm_bspconfig(tgt_node, sdt, options):
     if options.get('outdir', {}):
         sdt.outdir = options['outdir']
    
-    mem_ranges = get_memranges(tgt_node, sdt, options)
+    mem_ranges, lable_names = get_memranges(tgt_node, sdt, options)
     if not mem_ranges:
         return
     # Generate Memconfig cmake meta-data file.

--- a/lopper/assists/baremetal_gentestapp_xlnx.py
+++ b/lopper/assists/baremetal_gentestapp_xlnx.py
@@ -206,7 +206,7 @@ def xlnx_generate_testapp(tgt_node, sdt, options):
                             valid_ex = 0
                             match_list = []
                             if drv_config_name == 'XAxiCdma':
-                                mem_ranges, lable_names = get_memranges(tgt_node, sdt, options)
+                                mem_ranges, _ = get_memranges(tgt_node, sdt, options)
                                 for mem in list_of_mem_list:
                                     if any(mem in mem_name for mem_name in mem_ranges.keys()):
                                         match_list.append(True)

--- a/lopper/assists/baremetal_gentestapp_xlnx.py
+++ b/lopper/assists/baremetal_gentestapp_xlnx.py
@@ -206,7 +206,7 @@ def xlnx_generate_testapp(tgt_node, sdt, options):
                             valid_ex = 0
                             match_list = []
                             if drv_config_name == 'XAxiCdma':
-                                mem_ranges = get_memranges(tgt_node, sdt, options)
+                                mem_ranges, lable_names = get_memranges(tgt_node, sdt, options)
                                 for mem in list_of_mem_list:
                                     if any(mem in mem_name for mem_name in mem_ranges.keys()):
                                         match_list.append(True)

--- a/lopper/assists/baremetal_validate_comp_xlnx.py
+++ b/lopper/assists/baremetal_validate_comp_xlnx.py
@@ -49,7 +49,7 @@ def check_for_mem(sdt, options, mem_type, required_mem):
     if required_mem.get("size", {}):
         required_mem_size = required_mem["size"]
 
-    mem_ranges = get_memranges(sdt.tree['/'], sdt, options)
+    mem_ranges, lable_names = get_memranges(sdt.tree['/'], sdt, options)
     for key, value in sorted(mem_ranges.items(), key=lambda e: e[1][1], reverse=True):
         start,size = value[0], value[1]
         if mem_type == "any" or re.search(mem_type, key):

--- a/lopper/assists/baremetal_validate_comp_xlnx.py
+++ b/lopper/assists/baremetal_validate_comp_xlnx.py
@@ -49,7 +49,7 @@ def check_for_mem(sdt, options, mem_type, required_mem):
     if required_mem.get("size", {}):
         required_mem_size = required_mem["size"]
 
-    mem_ranges, lable_names = get_memranges(sdt.tree['/'], sdt, options)
+    mem_ranges, _ = get_memranges(sdt.tree['/'], sdt, options)
     for key, value in sorted(mem_ranges.items(), key=lambda e: e[1][1], reverse=True):
         start,size = value[0], value[1]
         if mem_type == "any" or re.search(mem_type, key):

--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -429,7 +429,7 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
         plat.buf(f"\n#define XPS_BOARD_{board.upper()}\n")
     
     # Memory Node related defines
-    mem_ranges = get_memranges(tgt_node, sdt, options)
+    mem_ranges, lable_names = get_memranges(tgt_node, sdt, options)
     for key, value in sorted(mem_ranges.items(), key=lambda e: e[1][1], reverse=True):
         start,size = value[0], value[1]
         suffix = "ADDRESS"

--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -429,7 +429,7 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
         plat.buf(f"\n#define XPS_BOARD_{board.upper()}\n")
     
     # Memory Node related defines
-    mem_ranges, lable_names = get_memranges(tgt_node, sdt, options)
+    mem_ranges, _ = get_memranges(tgt_node, sdt, options)
     for key, value in sorted(mem_ranges.items(), key=lambda e: e[1][1], reverse=True):
         start,size = value[0], value[1]
         suffix = "ADDRESS"

--- a/lopper/assists/petalinuxconfig_xlnx.py
+++ b/lopper/assists/petalinuxconfig_xlnx.py
@@ -96,7 +96,7 @@ def xlnx_generate_petalinux_config(tgt_node, sdt, options):
                     device_type_dict['processor'][label_name].update({"slaves_strings": " ".join(nodename_list)})
             elif re.search("memory", dev_type):
                 ### Memory Handling
-                mem_ranges = get_memranges(tgt_node, sdt, options)
+                mem_ranges, _ = get_memranges(tgt_node, sdt, options)
                 index = 0
                 memnode_list = sdt.tree.nodes('/memory@.*')
                 for mem_name,mem in mem_ranges.items():


### PR DESCRIPTION
…ocks that were no longer needed.

- Separated the 'xlnx_generate_bm_linker' code into the following functions to improve code flow:
   - **generate_mem_config**: Generates the memory configuration.
   - **get_ddr_address**: Retrieves the default DDR address value.
   - **generate_linker_script**: Contains the generic code for the linker script.
- Add the full names of the memory sections to the linker script to ensure proper alignment with Vitis Classic. 
- lopper: assists: Integrated label names within the 'get_memranges' function, which returns both the memory ranges and label names as part of adding the full names of the memory sections.