### PR TITLE
lopper: assists: baremetalconfig_xlnx: Add support for 'mdioproducer-baseaddr' property

### DIFF
--- a/lopper/assists/baremetalconfig_xlnx.py
+++ b/lopper/assists/baremetalconfig_xlnx.py
@@ -473,6 +473,26 @@ def xlnx_generate_prop(sdt, node, prop, drvprop_list, plat, pad, phandle_prop):
         clkprop_val = get_clock_prop(sdt, node[prop].value)
         plat.buf('\n\t\t%s' % hex(clkprop_val))
         drvprop_list.append(hex(clkprop_val))
+    elif prop == "mdioproducer-baseaddr":
+        if node.propval('phy-handle') == ['']:
+            drvprop_list.append(hex(0))
+            plat.buf('\n\t\t%s' % hex(0))
+        else:
+            # two possible scenarios phy-handle property is part of mac node or part of mdio node handle both the cases
+            parent_node = [node1.parent for node1 in sdt.tree['/'].subnodes() if node1.phandle == node['phy-handle'].value[0]]
+            if parent_node:
+                # if parent node has reg property it's mac node other wise its mdio node
+                if parent_node[0].propval('reg') != ['']:
+                    reg, size = scan_reg_size(parent_node[0], parent_node[0]['reg'].value, 0)
+                    drvprop_list.append(hex(reg))
+                    plat.buf('\n\t\t%s' % hex(reg))
+                elif parent_node[0].parent.propval('reg') != ['']:
+                    reg, size = scan_reg_size(parent_node[0].parent, parent_node[0].parent['reg'].value, 0)
+                    drvprop_list.append(hex(reg))
+                    plat.buf('\n\t\t%s' % hex(reg))
+            else:
+                drvprop_list.append(hex(0))
+                plat.buf('\n\t\t%s' % hex(0))
     elif prop == "child,required":
         plat.buf('\n\t\t{')
         numsplits = 0


### PR DESCRIPTION
This patch adds support for generating the `mdioproducer-baseaddr`

if the `phy-handle` property is absent, default to `0x0` as the base address.

if PHY handle under MAC node,if the parent node has a `reg` property, it is considered a MAC node. Extract the base address from its register.

if PHY handle under MDIO node,if the parent node lacks a `reg` property but its grandparent has one, treat it as an MDIO node and extract the base address from the grandparent.