### PR TITLE
lopper: assists: gen_domain_dts: Enable RPU domain support for OpenAMP

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -94,12 +94,16 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
         pass
 
     openamp_present = xlnx_openamp_find_channels(sdt)
+    openamp_host = machine in openamp_linux_hosts and linux_dt == 1
+    openamp_remote = machine in openamp_roles.keys() and linux_dt != 1 and machine not in openamp_linux_hosts
+    openamp_role = "host" if openamp_host else "remote"
 
-    if openamp_present and linux_dt == 1 and machine in openamp_linux_hosts:
-        # Currently this plugin is only invoked for Linux. So for now just consider linux case
+    if openamp_present and (openamp_host or openamp_remote):
         xlnx_options = { "openamp_host":   openamp_roles[machine],
                          "openamp_remote": openamp_roles[machine],
-                         "openamp_role":   "host" }
+                         "openamp_role":   openamp_role }
+        if "--openamp_no_header" in options['args']:
+            xlnx_options["openamp_no_header"] = True
         xlnx_openamp_parse(sdt, options, xlnx_options, verbose = 0 )
 
     # Delete other CPU Cluster nodes

--- a/lopper/assists/openamp_xlnx.py
+++ b/lopper/assists/openamp_xlnx.py
@@ -1088,7 +1088,7 @@ def xlnx_rpmsg_parse(tree, node, openamp_channel_info, options, xlnx_options = N
     try:
         args = options['args']
     except:
-        print("No arguments passed for OpenAMP Module. Need role property")
+        print("No arguments passed for OpenAMP Module.")
         return False
 
     # Here try for key value pair arguments
@@ -1105,6 +1105,8 @@ def xlnx_rpmsg_parse(tree, node, openamp_channel_info, options, xlnx_options = N
         role = xlnx_options["openamp_role"]
         arg_host = xlnx_options["openamp_host"]
         arg_remote = xlnx_options["openamp_remote"]
+        if "openamp_no_header" in xlnx_options.keys():
+            no_header = True
     else:
         for o,a in opts:
             if o in ('-l', "--openamp_role"):


### PR DESCRIPTION
If Gen Domain plugin is invoked for RPU Domain and OpenAMP Conditions are met, then invoke openamp parse routine

Also because there can exist case where the header for OpenAMP Remote is not required, add option to specify no header.