### PR TITLE
lopper: assists: baremetallinker: Fix the bram start address when bas…

### DIFF
--- a/lopper/assists/baremetallinker_xlnx.py
+++ b/lopper/assists/baremetallinker_xlnx.py
@@ -369,6 +369,10 @@ def generate_linker_script(mem_ranges,yaml_file,cfd,cpu_ip_name,machine,openamp_
             size -= start
             if size <= 0x2000:
                 heap_size = 0x400
+        elif cpu_ip_name == "microblaze" and "lmb_bram" in key :
+            start += 80
+            size -= 80
+
         """
         For R5 PSU DDR initial 1MB is reserved for tcm
         Adjust the size and start address accordingly.


### PR DESCRIPTION
…e vectors start address is non-zero

commit b57956118b72("lopper: assists: baremetallinker_xlnx: Enable the generation of the BASE_VECTOR cmake variable for the MicroBlaze processor") Added support for BASE_VECTOR cmake variable generation for the MicroBlaze processor by retrieving the value from the xlnx,base-vectors property but when the start address is non-zero bram start address is not being adjusted due to which memory overlap errors are coming fix the same.