### PR TITLE
lopper: assists: baremetalconfig_xlnx: Fix the issue of out-of-order …

### DIFF
--- a/lopper/assists/baremetalconfig_xlnx.py
+++ b/lopper/assists/baremetalconfig_xlnx.py
@@ -671,8 +671,8 @@ def xlnx_generate_bm_config(tgt_node, sdt, options):
     if driver_proplist == []:
         return True
     driver_nodes = []
-    for compat in driver_compatlist:
-        for node in node_list:
+    for node in node_list:
+        for compat in driver_compatlist:
            compat_string = node['compatible'].value
            for compa in compat_string:
                if compat in compa:


### PR DESCRIPTION
…config struct node generation by first

Fix the issue of out-of-order config struct node generation by first traversing the node.