### PR TITLE
__init__: Give priority to user defined paths for assists and lops paths search

### DIFF
--- a/lopper/__init__.py
+++ b/lopper/__init__.py
@@ -388,7 +388,7 @@ class LopperSDT:
         self.support_files = support_files
 
         if self.verbose:
-            search_paths = [ lopper_directory ] + [ lopper_directory + "/assists/" ] + self.load_paths
+            search_paths = self.load_paths + [ lopper_directory ] + [ lopper_directory + "/assists/" ]
             print( "" )
             print( "Lopper summary:")
             print( f"   system device tree: {sdt_files}" )
@@ -684,8 +684,8 @@ class LopperSDT:
             # check the path from which lopper is running, that
             # directory + lops, and paths specified on the command line
             input_file_abs = ""
-            search_paths =  [ lopper_directory ] + [ lopper_directory + "/assists/" ] + \
-                            [ lopper_directory + "/lops/" ] + local_search_paths + self.load_paths
+            search_paths =  self.load_paths + [ lopper_directory ] + [ lopper_directory + "/assists/" ] + \
+                            [ lopper_directory + "/lops/" ] + local_search_paths
             for s in search_paths:
                 # the first found file is the one we return
                 if input_file_abs:

--- a/lopper/assists/baremetal_gentestapp_xlnx.py
+++ b/lopper/assists/baremetal_gentestapp_xlnx.py
@@ -96,7 +96,7 @@ def xlnx_generate_testapp(tgt_node, sdt, options):
                 drv_path_in_yaml = drv_data[entries]['path'][0]
             drv_name_in_yaml = os.path.basename(drv_path_in_yaml)
             # Incase of versioned component strip the version info
-            drv_name_in_yaml = re.split("_v(\d+)_(\d+)", drv_name_in_yaml)[0]
+            drv_name_in_yaml = re.split(r"_v(\d+)_(\d+)", drv_name_in_yaml)[0]
             yaml_file_list += [os.path.join(drv_path_in_yaml, 'data', f"{drv_name_in_yaml}.yaml")]
     else:
         drv_dir = os.path.join(repo_path_data, "XilinxProcessorIPLib", "drivers")

--- a/lopper/assists/baremetal_getsupported_comp_xlnx.py
+++ b/lopper/assists/baremetal_getsupported_comp_xlnx.py
@@ -62,7 +62,7 @@ def xlnx_baremetal_getsupported_comp(tgt_node, sdt, options):
         for entries in files:
             dir_path = utils.get_dir_path(utils.get_dir_path(entries))
             comp_name = utils.get_base_name(dir_path)
-            comp_name = re.split("_v(\d+)_(\d+)", comp_name)[0]
+            comp_name = re.split(r"_v(\d+)_(\d+)", comp_name)[0]
             yaml_data = utils.load_yaml(entries)
             version = yaml_data.get('version','vless')
 

--- a/lopper/assists/baremetal_validate_comp_xlnx.py
+++ b/lopper/assists/baremetal_validate_comp_xlnx.py
@@ -98,7 +98,7 @@ def xlnx_baremetal_validate_comp(tgt_node, sdt, options):
     src_path = src_path.rstrip(os.path.sep)
     name = utils.get_base_name(utils.get_dir_path(src_path))
     # Incase of versioned component strip the version info
-    name = re.split("_v(\d+)_(\d+)", name)[0]
+    name = re.split(r"_v(\d+)_(\d+)", name)[0]
     yaml_file = os.path.join(utils.get_dir_path(src_path), "data", f"{name}.yaml")
     if not utils.is_file(yaml_file):
         print(f"{name} Comp doesn't have yaml file")

--- a/lopper/assists/baremetalconfig_xlnx.py
+++ b/lopper/assists/baremetalconfig_xlnx.py
@@ -653,7 +653,7 @@ def xlnx_generate_bm_config(tgt_node, sdt, options):
     drvpath = utils.get_dir_path(src_dir.rstrip(os.sep))
     drvname = utils.get_base_name(drvpath)
     # Incase of versioned driver strip the version info
-    drvname = re.split("_v(\d+)_(\d+)", drvname)[0]
+    drvname = re.split(r"_v(\d+)_(\d+)", drvname)[0]
     yaml_file = os.path.join(drvpath, f"data/{drvname}.yaml")
     if not utils.is_file(yaml_file):
         print(f"{drvname} Driver doesn't have yaml file")

--- a/lopper/assists/baremetaldrvlist_xlnx.py
+++ b/lopper/assists/baremetaldrvlist_xlnx.py
@@ -69,7 +69,7 @@ def xlnx_generate_bm_drvlist(tgt_node, sdt, options):
                 drv_path = drv_data[entries]['path'][0]
             drv_name = os.path.basename(drv_path)
             # Incase of versioned driver strip the version info
-            drv_name = re.split("_v(\d+)_(\d+)", drv_name)[0]
+            drv_name = re.split(r"_v(\d+)_(\d+)", drv_name)[0]
             yaml_file_list += [os.path.join(drv_path, 'data', f"{drv_name}.yaml")]
         has_drivers = [dir_name for dir_name in os.listdir(utils.get_dir_path(sdt.dts)) if "drivers" in dir_name]
         if has_drivers:

--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -39,7 +39,7 @@ def generate_drvcmake_metadata(sdt, node_list, src_dir, options):
     driver_compatlist = []
     drvname = utils.get_base_name(utils.get_dir_path(src_dir))
     # Incase of versioned component strip the version info
-    drvname = re.split("_v(\d+)_(\d+)", drvname)[0]
+    drvname = re.split(r"_v(\d+)_(\d+)", drvname)[0]
     yaml_file = os.path.join(utils.get_dir_path(src_dir), "data", f"{drvname}.yaml")
     if not utils.is_file(yaml_file):
         print(f"{drvname} Driver doesn't have yaml file")
@@ -208,7 +208,7 @@ def generate_hwtocmake_medata(sdt, node_list, src_path, repo_path_data, options,
     src_path = src_path.rstrip(os.path.sep)
     name = utils.get_base_name(utils.get_dir_path(src_path))
     # Incase of versioned component strip the version info
-    name = re.split("_v(\d+)_(\d+)", name)[0]
+    name = re.split(r"_v(\d+)_(\d+)", name)[0]
     yaml_file = os.path.join(utils.get_dir_path(src_path), "data", f"{name}.yaml")
 
     if not utils.is_file(yaml_file):


### PR DESCRIPTION
If a user is explicitly passing directories using -I command line option or by setting LOPPER_INPUT_DIRS environment variable, that directory should be given the highest priority over the default lops and assists paths. Otherwise, the purpose of these options get defeated.