### PR TITLE
lopper: assists: domain_access: Traverse all domains to retrieve the …

### DIFF
--- a/lopper/assists/domain_access.py
+++ b/lopper/assists/domain_access.py
@@ -145,7 +145,8 @@ def core_domain_access( tgt_node, sdt, options ):
     if tgt_node.abs_path == "/":
         if sdt.target_domain:
             try:
-                tgt_node = sdt.tree[sdt.target_domain]
+                target_domain_path = [node.abs_path for node in sdt.tree['/'].subnodes() if node.label == sdt.target_domain or node.name == sdt.target_domain]
+                tgt_node = sdt.tree[target_domain_path[0]]
             except Exception as e:
                 print( f"[ERROR]: target domain {sdt.target_domain} cannot be found" )
                 sys.exit(1)


### PR DESCRIPTION
…absolute path of each domain

Domains can exist under the default system or at the top level, meaning the subsystem itself can be a domain. Update the logic to handle all possible cases by traversing all nodes and matching the node label or node name with the provided domain name.