### PR TITLE
lopper: assists: zephyr: Add current-speed to UARTNS550

### DIFF
--- a/lopper/assists/zephyr_supported_comp.yaml
+++ b/lopper/assists/zephyr_supported_comp.yaml
@@ -50,6 +50,7 @@ xlnx,axi-uart16550-2.0:
     - reg
     - interrupts
     - interrupt-parent
+    - current-speed
     - clock-frequency
     - reg-shift
 


### PR DESCRIPTION
- Add 'current-speed' property to UARTNS550 configuration in zephyr_supported_comp.yaml