### PR TITLE
lopper: assists: gen_domain_dts: Remove TTC0 for Versal-based SOCs

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -160,6 +160,8 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
         if node.propval('device_type') != ['']:
             if "memory" in node.propval('device_type', list)[0]:
                 node_list.append(node)
+        if node.propval('xlnx,ip-name') != [''] and node.propval('xlnx,ip-name')[0] == "psv_ttc" and node.label == "ttc0":
+            sdt.tree.delete(node)
 
     mapped_nodelist = get_mapped_nodes(sdt, node_list, options)
     mapped_nodelist.append(symbol_node)


### PR DESCRIPTION
TTC0 is used for RPU scheduler and so in AMP solutions this IP being present can cause issue for such usage.