### PR TITLE
lopper: assists: baremetal_xparameters_xlnx: Fix the issue of out-of-…

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -132,8 +132,8 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
                 else:
                     driver_proplist = schema.get('additionalProperties',{})
             match_nodes = []
-            for comp in driver_compatlist:
-                for node,compatible_list in node_dict.items():
+            for node,compatible_list in node_dict.items():
+                for comp in driver_compatlist:
                    match = [x for x in compatible_list if comp == x]
                    if match:
                        node1 = [x for x in node_list if (x.abs_path == node)]


### PR DESCRIPTION
…order node entries in xparameters.h file

commit d671bd3c0d1b("lopper: assists: baremetalconfig_xlnx: Fix the issue of out-of-order config struct node generation by first") fixed the issue of out-of-order node entries in config struct similar changed needed in the baremetal_xparameters_xlnx assist as well, update the code for the same.