### PR TITLE
lopper: assists: zephyr: Add AXI TIMEBASE WATCHDOG node for Zephyr

### DIFF
--- a/lopper/assists/zephyr_supported_comp.yaml
+++ b/lopper/assists/zephyr_supported_comp.yaml
@@ -126,3 +126,11 @@ xlnx,xps-gpio-1.00.a:
     - xlnx,is-dual
     - xlnx,tri-default
     - xlnx,tri-default-2
+
+xlnx,xps-timebase-wdt-1.00.a:
+  required:
+    - compatible
+    - reg
+    - clocks
+    - xlnx,wdt-interval
+    - xlnx,wdt-enable-once


### PR DESCRIPTION
Update zephyr_supported_comp.yaml to add AXI TIMEBASE WATCHDOG as supported component.
Extend Zephyr DTS generation to support AXI TIMEBASE WATCHDOG node.