### PR TITLE
lopper: assists: remove gtwiz_versal from the linux_ip_ignore list as…

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -257,7 +257,7 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
                             'psv_ocm', 'psv_pmc_aes', 'psv_pmc_bbram_ctrl', 'psv_pmc_cfi_cframe', 'psv_pmc_cfu_apb',
                             'psv_pmc_efuse_cache', 'psv_pmc_efuse_ctrl', 'psv_pmc_global', 'psv_pmc_ppu1_mdm',
                             'psv_pmc_ram_npi', 'psv_pmc_rsa', 'psv_pmc_sha', 'psv_pmc_slave_boot', 'psv_scntrs',
-                            'psv_pmc_slave_boot_stream', 'psv_pmc_trng', 'psv_psm_global_reg', 'psv_rpu', 'psv_scntr', 'gtwiz_versal']
+                            'psv_pmc_slave_boot_stream', 'psv_pmc_trng', 'psv_psm_global_reg', 'psv_rpu', 'psv_scntr']
 
     versal_gen2_linux_ignore_ip_list = ['mmi_10gbe', 'mmi_udh_pll', 'mmi_common', 'mmi_gpu', 'mmi_gtyp_cfg', 'mmi_pipe_gem_slcr',
                             'mmi_udh_pll', 'mmi_udh_slcr', 'mmi_usb2phy', 'mmi_usb3phy_crpara', 'mmi_usb3phy_tca', 'mmi_usb_cfg',

--- a/lopper/assists/yaml_bindings/xlnx,versal-gt.yaml
+++ b/lopper/assists/yaml_bindings/xlnx,versal-gt.yaml
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/phy/xlnx,gt-quad-base.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Xilinx DP GTQUAD PHY
+
+maintainers:
+  - Eachuri, Lakshmi Prasanna <lakshmi.prasanna.eachuri@amd.com>
+
+description: |
+  The Xilinx DP GTQUAD PHY Controller core is designed for enabling
+  connectivity with Xilinx DP RX and TX with xilinx versal devices.
+properties:
+  compatible:
+    items:
+      - enum:
+          - xlnx,gt-quad-base-1.1
+          - xlnx,gtwiz-versal-1.0
+
+  reg:
+    maxItems: 1
+
+  clocks:
+    description: List of clock specifiers
+    items:
+      - description: AXI Lite clock
+
+  "#phy-cells":
+    const: 0
+
+required:
+  - clocks
+  - clock-names
+  - compatible
+  - reg
+  - '#phy-cells'
+
+additionalProperties: false
+
+examples:
+  - |
+   gt_quad_gtwiz_versal_0: gtwiz_versal@a4040000 {
+           clocks = <&misc_clk_0>;
+           clock-names = "s_axi_lite_clk";
+           compatible = "xlnx,gt-quad-base-1.1", "xlnx,gtwiz-versal-1.0";
+           reg = <0xa4080000 0x10000>;
+           #phy-cells = <0>;
+   };


### PR DESCRIPTION
… it has a linux driver

Update the assist to generate the node for gtwiz_versal IP by reading the yaml properties.