### PR TITLE
lopper: Exclude last TTC instance for RPU peripheral tests

### DIFF
--- a/lopper/assists/baremetal_gentestapp_xlnx.py
+++ b/lopper/assists/baremetal_gentestapp_xlnx.py
@@ -62,7 +62,7 @@ def xlnx_generate_testapp(tgt_node, sdt, options):
     if sdt.tree[tgt_node].propval('pruned-sdt') == ['']:
         node_list = get_mapped_nodes(sdt, node_list, options)
     for node in node_list:
-        if "cdns,ttc" in node["compatible"].value:
+        if "cdns,ttc" in node["compatible"].value and not node.props('lop-dynamic-ttc-node'):
             ttc_node_list += [node]
         compatible_dict.update({node: node["compatible"].value})
         if stdin:


### PR DESCRIPTION
Updated the baremetal_gentestapp_xlnx.py script to exclude the last TTC instance from peripheral testing for the RPU processor. This is achieved by adding a condition to filter out nodes marked with the lop-dynamic-ttc-node property.