### PR TITLE
lopper:__main__.py: Fixed file not exist in the binary flow

### DIFF
--- a/lopper/__main__.py
+++ b/lopper/__main__.py
@@ -19,8 +19,7 @@ from lopper import LopperSDT
 
 from lopper.log import _warning, _info, _error, _debug
 import logging
-
-lopper_directory = os.path.dirname(os.path.realpath(__file__))
+from lopper import lopper_directory
 
 global device_tree
 device_tree = None


### PR DESCRIPTION
PyInstaller extracts the bundled application to a temporary directory like /tmp/_MEIXXXX/. When importing a package (_init_.py file), Python treats it as a module and assigns it a path inside /tmp/_MEIXXXX/lopper/ (because it keeps packages in their directories). When running _main_.py, its path is just /tmp/_MEIXXXX/ because it’s the main entry point. Add condition to check the flow and read the lops files