### PR TITLE
lopper:__main__.py:Unify lopper_directory path handling across module

### DIFF
--- a/lopper/__main__.py
+++ b/lopper/__main__.py
@@ -19,8 +19,7 @@ from lopper import LopperSDT
 
 from lopper.log import _warning, _info, _error, _debug
 import logging
-
-lopper_directory = os.path.dirname(os.path.realpath(__file__))
+from lopper import lopper_directory
 
 global device_tree
 device_tree = None


### PR DESCRIPTION
The os.path.dirname(os.path.realpath(__file__)) call returns the same path in both main.py and __init__.py during normal execution. However, when bundled with PyInstaller, the application is extracted to a temporary directory (e.g., /tmp/_MEIXXXX/). In this case, main.py's path becomes just /tmp/_MEIXXXX/ (as the main entry point), while __init__.py has a different path, creating inconsistency. To maintain a unified lopper_directory path across the module, import the lopper_directory variable directly from the lopper module in main.py instead of calculating it separately. This ensures consistent path handling regardless of execution context.