### PR TITLE
lopper: Fix TTC instance exclusion and DTS split

### DIFF
--- a/lopper/assists/baremetal_gentestapp_xlnx.py
+++ b/lopper/assists/baremetal_gentestapp_xlnx.py
@@ -1,6 +1,6 @@
 #/*
 # * Copyright (c) 2021 Xilinx Inc. All rights reserved.
-# * Copyright (C) 2024 Advanced Micro Devices, Inc.  All rights reserved.
+# * Copyright (C) 2024 - 2025 Advanced Micro Devices, Inc.  All rights reserved.
 # *
 # * Author:
 # *       Appana Durga Kedareswara rao <appana.durga.rao@xilinx.com>
@@ -72,7 +72,7 @@ def xlnx_generate_testapp(tgt_node, sdt, options):
                     stdin_node = node
     match_cpunode = get_cpu_node(sdt, options)
     proc_ip_name = match_cpunode['xlnx,ip-name'].value
-    if proc_ip_name[0] in ["psu_cortexr5", "psv_cortexr5", "psx_cortexr52"] and ttc_node_list:
+    if proc_ip_name[0] in ["psu_cortexr5", "psv_cortexr5", "psx_cortexr52", "cortexr52"] and ttc_node_list:
         node_list.remove(ttc_node_list[-1])
         compatible_dict.pop(ttc_node_list[-1])
 

--- a/lopper/lops/lop-ttc-split.dts
+++ b/lopper/lops/lop-ttc-split.dts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Advanced Micro Devices, Inc. All Rights Reserved.
+ * Copyright (C) 2024 - 2025 Advanced Micro Devices, Inc. All Rights Reserved.
  *
  * Author:
  *     Appana Durga Kedareswara rao <appana.durga.kedareswara.rao@amd.com>
@@ -31,7 +31,7 @@
                           if __selected__:
                               for s in tree.__selected__:
                                   tree['/__symbols__'].delete(s.label)
-                                  val = s.label[-1]
+                                  val = int(''.join(filter(str.isdigit, s.label)))
                                   s.label = f'{s.label[:-1]}{int(val)*3}'
                                   try:
                                       name_val = s['xlnx,name'].value[0]
@@ -49,8 +49,9 @@
                                   for x in range(1, 3):
                                         new_ttc_node = s()
                                         new_ttc_node.name = f'{s.name[:-1]}{x*4}'
-                                        val = s.label[-1]
-                                        new_ttc_node.label = f'{s.label[:-1]}{int(val)+x}'
+                                        val = int(''.join(filter(str.isdigit, s.label)))
+                                        s_label = ''.join(filter(str.isalpha, s.label))
+                                        new_ttc_node.label = f'{s_label}{int(val)+x}'
                                         modify_reg = f'{hex(reg)[:-1]}{x*4}'
                                         modify_prop = [int(modify_reg, 16), size-(x*4)]
                                         modify_val = update_mem_node(s, modify_prop)


### PR DESCRIPTION
- Updated processor check to include cortexr52 for excluding the last TTC instance in Telluride and Palmyre.
- Fixed label handling to correctly split TTC instances.
- Updated copyright for 2025.