### PR TITLE
lopper: assists: zephyr: Add Xilinx WWDT node for Zephyr

### DIFF
--- a/lopper/assists/zephyr_supported_comp.yaml
+++ b/lopper/assists/zephyr_supported_comp.yaml
@@ -175,3 +175,10 @@ xlnx,ocm-ram-11.0:
     - compatible
     - device_type
     - reg
+
+xlnx,versal-wwdt:
+  required:
+    - compatible
+    - reg
+    - timeout-sec
+    - clocks


### PR DESCRIPTION
Update zephyr_supported_comp.yaml to add Xilinx WWDT as supported component.
Extend Zephyr DTS generation to support Xilinx WWDT.