### PR TITLE
openamp: xlnx: zynqmp: FreeRTOS IPI Vect ID can now be same as Versal…

### DIFF
--- a/lopper/assists/openamp_xlnx.py
+++ b/lopper/assists/openamp_xlnx.py
@@ -848,7 +848,6 @@ def xlnx_openamp_gen_outputs_only(sdt, machine, output_file, verbose = 0 ):
         ipi_irq_vect_id_rtos = hex(remote_vect_id-32)
 
         if platform == SOC_TYPE.ZYNQMP:
-            ipi_irq_vect_id_rtos = ipi_irq_vect_id
             host_bitmask = None
             for n in tree["/"].subnodes():
                 xlnx_ipi_id_pval = n.propval("xlnx,ipi-id")
@@ -970,7 +969,7 @@ def xlnx_openamp_gen_outputs(openamp_channel_info, channel_id, role, verbose = 0
                 soc_ipi_map[nobuf_ipi_key] = nobuf_ipi
 
         IPI_IRQ_VECT_ID = remote_ipi_irq_vect_id if role == 'remote' else host_ipi_irq_vect_id
-        IPI_IRQ_VECT_ID_FREERTOS = IPI_IRQ_VECT_ID if platform == SOC_TYPE.ZYNQMP else hex(int(IPI_IRQ_VECT_ID,16) - 32)
+        IPI_IRQ_VECT_ID_FREERTOS = hex(int(IPI_IRQ_VECT_ID,16) - 32)
 
         POLL_BASE_ADDR = remote_ipi_base if role == 'remote' else host_ipi_base
         # flip this as we are kicking other side with the bitmask value


### PR DESCRIPTION
… so let it match