### PR TITLE
assists: gen_domain_dts: Keep the nodes having no base address in linux dt

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -283,7 +283,7 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
                             'psv_pmc_slave_boot_stream', 'psv_pmc_trng', 'psv_psm_global_reg', 'psv_rpu', 'psv_scntr']
 
     versal_gen2_linux_ignore_ip_list = ['mmi_udh_pll', 'mmi_common', 'mmi_pipe_gem_slcr',
-                            'mmi_udh_pll', 'mmi_udh_slcr', 'mmi_usb2phy', 'mmi_usb3phy_crpara', 'mmi_usb3phy_tca', 'mmi_usb_cfg',
+                            'mmi_udh_pll', 'mmi_udh_slcr', 'mmi_usb2phy', 'mmi_usb3phy_crpara', 'mmi_usb3phy_tca',
                             'pmc_rsa', 'pmc_aes', 'pmc_sha2', 'pmc_sha3', "rpu", "apu", "pmc_ppu1_mdm", "pmc_xppu_npi", "pmc_xppu",
                             "pmc_xmpu", "pmc_slave_boot_stream", "pmc_slave_boot", "pmc_ram_npi", "pmc_global", "ocm", "ocm_xmpu",
                             "lpd_xppu", "lpd_systmr_read", "lpd_systmr_ctrl", "lpd_slcr_secure", "lpd_slcr", "lpd_iou_slcr",
@@ -322,7 +322,7 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
                 if "cpu" in node.propval('device_type', list)[0]:
                     continue
             if node.propval('status') != ['']:
-                if 'disabled' in node.propval('status', list)[0] and linux_dt:
+                if linux_dt and ('disabled' in node.propval('status', list)[0] or "@" not in node.name):
                     continue
                 elif "tcm" in node.propval('compatible', list)[0]:
                     continue


### PR DESCRIPTION
Linux supports virtual node as well, meaning the node is not having the base address but it can have its own child nodes and status. There is no register programming done for these nodes, but the driver can rely on them to take care of the platform related programming like enabling clocks, reset, phy config etc.

e.g node:

usb_mmi: mmi-usb {
    compatible = "xlnx,versal2-mmi-dwc3";
    status = "disabled";
    ranges;
    #address-cells = <2>;
    #size-cells = <2>;
    mmi_dwc3: usb@edec0000  {
            compatible = "snps,dwc3";
            status = "disabled";
            reg = <0x0 0xedec0000 0x0 0x10000>;
            interrupt-names = "host", "peripheral";
            interrupts = <0 191 4>, <0 191 4>;
            interrupt-parent = <&imux>;
            snps,dis_u2_susphy_quirk;
            snps,dis_u3_susphy_quirk;
            snps,quirk-frame-length-adjustment = <0x20>;
            snps,usb3_lpm_capable;
            dr_mode = "host";
    };
};


Update the logic to keep such virtual nodes in linux dt. As these nodes are not having any base address, these are not mapped in the processor address map. Due to this such nodes are getting removed along with its child node when they have "okay" status.