### PR TITLE
openamp: xlnx: updates for latest driver

### DIFF
--- a/lopper/assists/openamp_xlnx.py
+++ b/lopper/assists/openamp_xlnx.py
@@ -1083,16 +1083,18 @@ def xlnx_rpmsg_parse(tree, node, openamp_channel_info, options, xlnx_options = N
         openamp_channel_info["carveouts_"+channel_id] = channel_carveouts_nodes
 
         # rpmsg native?
-        native = node.propval("openamp-xlnx-native")
+        native = []
 
         # no rpmsg userspace support in v2
         if openamp_channel_info[REMOTEPROC_D_TO_D_v2]:
             native = []
             for j in remote_nodes:
                 native.append(False)
-
-        if native == [] or len(native) != len(remote_nodes):
-            print("ERROR: malformed openamp-xlnx-native property.")
+        else:
+            # keep parsing of the property for backward compatibility
+            native = node.propval("openamp-xlnx-native")
+            if native == [] or len(native) != len(remote_nodes):
+                print("ERROR: malformed openamp-xlnx-native property.")
             return False
 
         native = native[i]
@@ -1808,11 +1810,6 @@ def xlnx_remoteproc_parse(tree, node, openamp_channel_info, verbose = 0 ):
             channel_elfload_nodes.append ( elfloadnode )
 
         if platform in [SOC_TYPE.ZYNQMP, SOC_TYPE.VERSAL, SOC_TYPE.VERSAL_NET, SOC_TYPE.VERSAL2]:
-            cpu_config = determine_cpus_config(remote_node)
-            if cpu_config ==  CPU_CONFIG.RPU_SPLIT and len(remote_nodes) == 1:
-                print("ERROR: CPU config is split but only 1 remote node", remote_node, "has been provided.")
-                return False
-
             ret = xlnx_remoteproc_rpu_parse(tree, node, openamp_channel_info, remote_node, channel_elfload_nodes, verbose)
             if not ret:
                 return ret


### PR DESCRIPTION
Remove parsing of openamp-xlnx-native for remoteproc-v2 cases

Allow user to define one core in cluster for single core use in split mode