### PR TITLE
lopper: assists: baremetalconfig_xlnx: Add special handling for pciep…

### DIFF
--- a/lopper/assists/baremetalconfig_xlnx.py
+++ b/lopper/assists/baremetalconfig_xlnx.py
@@ -350,7 +350,7 @@ def get_mapped_nodes(sdt, node_list, options):
     valid_nodes = [node for node in node_list for handle in all_phandles if handle == node.phandle]
     return valid_nodes
 
-def xlnx_generate_config_struct(sdt, node, drvprop_list, plat, driver_proplist, is_subnode):
+def xlnx_generate_config_struct(sdt, node, drvprop_list, plat, driver_proplist, is_subnode, options):
     for i, prop in enumerate(driver_proplist):
         pad = 0
         phandle_prop = 0
@@ -384,7 +384,7 @@ def xlnx_generate_config_struct(sdt, node, drvprop_list, plat, driver_proplist, 
             plat.buf('\n\t{')
 
         if not subnode_gen:
-            xlnx_generate_prop(sdt, node, prop, drvprop_list, plat, pad, phandle_prop)
+            xlnx_generate_prop(sdt, node, prop, drvprop_list, plat, pad, phandle_prop, options)
         else:
             # Get the sub node
             dummy_struct = None
@@ -406,7 +406,7 @@ def xlnx_generate_config_struct(sdt, node, drvprop_list, plat, driver_proplist, 
                         plat.buf(',')
             else:
                 sub_node = [node for node in sdt.tree['/'].subnodes() if node.phandle == phandle_value]
-                xlnx_generate_config_struct(sdt, sub_node[0], drvprop_list, plat, subnode_prop_list, 1)
+                xlnx_generate_config_struct(sdt, sub_node[0], drvprop_list, plat, subnode_prop_list, 1, options)
     
         if i == len(driver_proplist)-1:
             if "subnode_phandle" not in prop:
@@ -420,7 +420,7 @@ def xlnx_generate_config_struct(sdt, node, drvprop_list, plat, driver_proplist, 
             if "subnode_phandle" not in prop:
                 plat.buf(' /* %s */' % prop)
 
-def xlnx_generate_prop(sdt, node, prop, drvprop_list, plat, pad, phandle_prop):
+def xlnx_generate_prop(sdt, node, prop, drvprop_list, plat, pad, phandle_prop, options):
     nosub = 0
     if prop == "reg":
         val, size = scan_reg_size(node, node[prop].value, 0)
@@ -521,7 +521,7 @@ def xlnx_generate_prop(sdt, node, prop, drvprop_list, plat, pad, phandle_prop):
                         numsplits = len(splitidxs);
                         continue
                     pv = list(p.values())
-                    xlnx_generate_prop(sdt, child[1], prop, drvprop_list, plat, pv[0], phandle_prop)
+                    xlnx_generate_prop(sdt, child[1], prop, drvprop_list, plat, pv[0], phandle_prop, options)
                 else:
                     try:
                         plat.buf('\n\t\t\t\t%s' % str(child[1][p].value[0]))
@@ -562,6 +562,11 @@ def xlnx_generate_prop(sdt, node, prop, drvprop_list, plat, pad, phandle_prop):
             _warning(f"Get device type failed for {node.name}, adding default value as {0}")
             device_ispci = 0
         if device_ispci:
+            match_cpunode = get_cpu_node(sdt, options)
+            if match_cpunode.propval('xlnx,ip-name') != ['']:
+                ip_name = match_cpunode.propval('xlnx,ip-name', list)[0]
+                if ip_name in ["psu_cortexr5", "psv_cortexr5", "psx_cortexr52", "cortexr52"]:
+                    pad = 1
             prop_vallist = get_pci_ranges(node, node[prop].value, pad)
             for j, prop_val in enumerate(prop_vallist):
                 plat.buf('\n\t\t%s' % prop_val)
@@ -730,7 +735,7 @@ def xlnx_generate_bm_config(tgt_node, sdt, options):
         if index == 0:
             plat.buf('#include "%s.h"\n' % drvname)
             plat.buf('\n%s %s __attribute__ ((section (".drvcfg_sec"))) = {\n' % (config_struct, config_struct + str("Table[]")))
-        xlnx_generate_config_struct(sdt, node, drvprop_list, plat, driver_proplist, 0)
+        xlnx_generate_config_struct(sdt, node, drvprop_list, plat, driver_proplist, 0, options)
         if index == len(driver_nodes)-1:
             plat.buf('\n\t {\n\t\t NULL\n\t}')
             plat.buf('\n};')


### PR DESCRIPTION
…su driver

pciepsu driver is expecting only two entries in the _g.c from ranges property when processor is r5 updated the checks for the same.