### PR TITLE
Revert "lopper/assists: Move non-address-mapped subnodes from '/amba_…

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -127,23 +127,6 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
         all_phandles.append(address_map[tmp])
         tmp = tmp + cells + na + 1
 
-    # Access the '/amba_pl' node
-    if linux_dt:
-        try:
-            amba_pl_node = sdt.tree['/amba_pl']
-        except KeyError:
-            amba_pl_node = None
-
-        if amba_pl_node:
-            # Iterate over each subnode of '/amba_pl'
-            for subnode in amba_pl_node.subnodes():
-                has_reg = subnode.propval('reg') != ['']
-                has_ranges = subnode.propval('ranges') != ['']
-
-                if not has_reg and not has_ranges:
-                    subnode.abs_path = subnode.abs_path.replace("/amba_pl/", "/")
-                    sdt.tree.add(subnode)
-
     node_list = []
     for node in root_sub_nodes:
         if linux_dt:


### PR DESCRIPTION
…pl' to root"

This reverts commit ae7c0f91b1a2bed6668c3862287f02223fe5356e.

The original change moved non-address-mapped subnodes from /amba_pl to the root node in the Linux device tree, aiming to improve structure and avoid device link failures. However, this resulted in issues with video-related designs such as HDMI, SDI, and DP. The final dtb/dts output after lopper processing showed inconsistencies where subsystem nodes and their corresponding ports were split across different parent nodes. This broke endpoint associations and led to an incorrect device tree structure.

Reverting this change ensures the nodes remain correctly grouped, preserving expected hierarchy