### PR TITLE
lopper: lops: lop-microblaze-riscv: Update multilib mapping when fpu …

### DIFF
--- a/lopper/lops/lop-microblaze-riscv.dts
+++ b/lopper/lops/lop-microblaze-riscv.dts
@@ -108,7 +108,7 @@
                                        'rv32ima' : 'rv32im',
                                        'rv32imaf' : 'rv32imf_zicsr',
                                        'rv32iac' : 'rv32ic',
-                                       'rv32imafc' : 'rv32imafc_zicsr',
+                                       'rv32imafc' : 'rv32imfc_zicsr',
                                        'rv32imfdc' : 'rv32imfdc_zicsr',
                                        'rv64imf' : 'rv64imf_zicsr',
                                        'rv64imfc' : 'rv64imfc_zicsr',
@@ -117,7 +117,8 @@
                                        'rv64imaf' : 'rv64imf_zicsr',
                                        'rv64iac' : 'rv64ic',
                                        'rv64imfdc' : 'rv64imfdc_zicsr',
-                                       'rv64imafc' : 'rv64imafc_zicsr'
+                                       'rv64imafc' : 'rv64imfc_zicsr',
+                                       'rv64imafd' : 'rv64imfd_zicsr'
 
                                    }
 


### PR DESCRIPTION
…is configured in the design case

--> Remove the "a" flag from the linker mapping in all the cases. --> Add new mapping entries when use-fpu is configured for 2 i.e rv64imafd.