### PR TITLE
baremetal_xparameters_xlnx: Add macros DDRMC5 device type

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -520,6 +520,16 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
         plat.buf(f"\n/* Device ID */")
         plat.buf(f'\n#define XPAR_DEVICE_ID "{val}"\n')
 
+    #Define for DDRMC5_DEVICE_TYPE
+    if sdt.tree[tgt_node].propval('xlnx,ddrmc5-device-type') != ['']:
+        val = sdt.tree[tgt_node].propval('xlnx,ddrmc5-device-type', list)[0]
+        plat.buf(f"\n#define NOC_MC_DDR5\n")
+        plat.buf(f"\n/* DDRMC5_DEVICE_TYPE */")
+        if val == "RDIMMs":
+            plat.buf(f"\n#define DDRMC5_DEVICE_TYPE_RDIMM\n")
+        elif val == "UDIMMs":
+            plat.buf(f"\n#define DDRMC5_DEVICE_TYPE_UDIMM\n")
+
     #Define for XSEM_CFRSCAN_EN
     if sdt.tree[tgt_node].propval('semmem-scan') != ['']:
         val = sdt.tree[tgt_node].propval('semmem-scan', list)[0]


### PR DESCRIPTION
When the 'xlnx,ddrmc5-device-type' property is present in the device tree, define a new macro 'NOC_MC_DDR5' to indicate the presence of the DDRMC5 controller, and generate a specific define for the memory type:
- 'DDRMC5_DEVICE_TYPE_RDIMM' if the device type is RDIMMs
- 'DDRMC5_DEVICE_TYPE_UDIMM' if the device type is UDIMMs