### PR TITLE
assists: baremetallinker: Add DDR_PL NOC specific address ranges

### DIFF
--- a/lopper/assists/baremetallinker_xlnx.py
+++ b/lopper/assists/baremetallinker_xlnx.py
@@ -64,7 +64,7 @@ def get_memranges(tgt_node, sdt, options):
     # This order is necessary to employ the comparison while mapping the available regions.
     versal_noc_region_ranges =  {
         "0x70000000000": "DDR_CH_3", "0x60000000000": "DDR_CH_2", "0x50000000000": "DDR_CH_1",
-        "0x10000000000": "DDR_LOW_3", "0xC000000000": "DDR_LOW_2",
+        "0x20000000000": "DDR_PL_NOC", "0x10000000000": "DDR_LOW_3", "0xC000000000": "DDR_LOW_2",
         "0x47C0000000": "HBM15_PC1", "0x4780000000": "HBM15_PC0", "0x4740000000": "HBM14_PC1", "0x4700000000": "HBM14_PC0",
         "0x46C0000000": "HBM13_PC1", "0x4680000000": "HBM13_PC0", "0x4640000000": "HBM12_PC1", "0x4600000000": "HBM12_PC0",
         "0x45C0000000": "HBM11_PC1", "0x4580000000": "HBM11_PC0", "0x4540000000": "HBM10_PC1", "0x4500000000": "HBM10_PC0",


### PR DESCRIPTION
This fix aligns the address with the expected value used in Classic platform definitions and avoids negative address mapping issues.