### PR TITLE
lopper: assists: zephyr: Add AXI-SPI node for zephyr

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -759,6 +759,28 @@ def xlnx_generate_zephyr_domain_dts(tgt_node, sdt, options):
                             if node.propval('#size-cells') != ['0']:
                                 node["#size-cells"] = LopperProp("#size-cells")
                                 node["#size-cells"].value = 0
+			#AXI-SPI
+                        if "xlnx,xps-spi-2.00.a" in node["compatible"].value:
+                            node["compatible"].value = ["xlnx,xps-spi-2.00.a"]
+                            if node.propval('#address-cells') != ['1']:
+                                node["#address-cells"] = LopperProp("#address-cells")
+                                node["#address-cells"].value = 1
+                            if node.propval('#size-cells') != ['0']:
+                                node["#size-cells"] = LopperProp("#size-cells")
+                                node["#size-cells"].value = 0
+                            new_node = LopperNode()
+                            new_node['compatible'] = "jedec,spi-nor"
+                            new_node.name = "flash@0"
+                            new_node['reg'] = 0
+                            new_node['spi-max-frequency'] = 8000000
+                            new_prop = LopperProp( "has-dpd" )
+                            new_node + new_prop
+                            flashid = "jedec-id = [20 bb 21]"
+                            new_node + LopperProp(flashid)
+                            new_node['size'] = 0x8000000
+                            new_node['t-enter-dpd'] = 10000
+                            new_node['t-exit-dpd'] = 35000
+                            node.add(new_node)
                         #AXI-GPIO
                         if "xlnx,xps-gpio-1.00.a" in node["compatible"].value:
                             node["compatible"].value = ["xlnx,xps-gpio-1.00.a"]

--- a/lopper/assists/zephyr_supported_comp.yaml
+++ b/lopper/assists/zephyr_supported_comp.yaml
@@ -234,3 +234,16 @@ xlnx,pmc-gpio-1.0:
     - interrupts
     - '#address-cells'
     - '#size-cells'
+
+xlnx,xps-spi-2.00.a:
+  required:
+    - compatible
+    - reg
+    - interrupts
+    - xlnx,num-ss-bits
+    - xlnx,num-transfer-bits
+    - fifo-size
+    - xlnx,startup-block
+    - interrupt-parent
+    - '#address-cells'
+    - '#size-cells'


### PR DESCRIPTION
Add support to generate AXI-SPI node with flash support for mbv32.