### PR TITLE
lopper: assists: gen_domain_dts: Don't generate PMP related configura…

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -916,7 +916,7 @@ def xlnx_generate_zephyr_domain_dts(tgt_node, sdt, options):
                     defconfig_kconfig.write("  default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)")
 
                     val = node.propval('xlnx,pmp-entries', list)[0]
-                    if val % 8 == 0:
+                    if val % 8 == 0 and val != 0:
                         soc_kconfig = open(soc_kconfig_file, 'a')
                         soc_kconfig.write("  select RISCV_PMP\n")
                         soc_kconfig.close()


### PR DESCRIPTION
…tion incase of pmp-entries is zero

Skip generating PMP-related configuration when the number of PMP entries is set to zero in the hardware design.