### PR TITLE
lopper: Support specific clock retrieval

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -255,7 +255,8 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
                         except KeyError:
                             pass
                     elif prop == "clocks":
-                        clkprop_val = bm_config.get_clock_prop(sdt, node[prop].value)
+                        tclk_offset = bm_config.get_clock_offset(node)
+                        clkprop_val = bm_config.get_clock_prop(sdt, node[prop].value, tclk_offset)
                         plat.buf(f'\n#define XPAR_{label_name}_{prop.upper()} {hex(clkprop_val)}')
                         canondef_dict.update({prop:hex(clkprop_val)})
                     elif prop == "child,required":


### PR DESCRIPTION
Updated get_clock_prop to accept an offset parameter, allowing retrieval of specified clocks.

For emacps we need the clock of the tx_clk. The clock returns the tx_clk clock id if found.
Else it returns the first clock in the array.