### PR TITLE
lopper: Fix tx_clk index handling in clock property

### DIFF
--- a/lopper/__init__.py
+++ b/lopper/__init__.py
@@ -1929,6 +1929,13 @@ class LopperSDT:
                     if opt_key:
                         options[opt_key] = opt_val
 
+            # arrange for the system device tree's output directory to
+            # be visible in the executed code environment
+            try:
+                output = options['output']
+            except:
+                options['outdir'] = self.outdir
+
             try:
                 start_node = options['start_node']
             except:

--- a/lopper/assists/baremetal_gentestapp_xlnx.py
+++ b/lopper/assists/baremetal_gentestapp_xlnx.py
@@ -55,6 +55,8 @@ def xlnx_generate_testapp(tgt_node, sdt, options):
                 symbol_node = node
             status = node["status"].value
             if "okay" in status:
+                if "cdns,ttc" in node["compatible"].value and node.props('lop-dynamic-ttc-node'):
+                    continue
                 node_list.append(node)
         except:
            pass
@@ -62,7 +64,7 @@ def xlnx_generate_testapp(tgt_node, sdt, options):
     if sdt.tree[tgt_node].propval('pruned-sdt') == ['']:
         node_list = get_mapped_nodes(sdt, node_list, options)
     for node in node_list:
-        if "cdns,ttc" in node["compatible"].value and not node.props('lop-dynamic-ttc-node'):
+        if "cdns,ttc" in node["compatible"].value:
             ttc_node_list += [node]
         compatible_dict.update({node: node["compatible"].value})
         if stdin:

--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -255,7 +255,8 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
                         except KeyError:
                             pass
                     elif prop == "clocks":
-                        clkprop_val = bm_config.get_clock_prop(sdt, node[prop].value)
+                        tclk_offset = bm_config.get_clock_offset(node)
+                        clkprop_val = bm_config.get_clock_prop(sdt, node[prop].value, tclk_offset)
                         plat.buf(f'\n#define XPAR_{label_name}_{prop.upper()} {hex(clkprop_val)}')
                         canondef_dict.update({prop:hex(clkprop_val)})
                     elif prop == "child,required":

--- a/lopper/assists/baremetalconfig_xlnx.py
+++ b/lopper/assists/baremetalconfig_xlnx.py
@@ -242,7 +242,8 @@ def get_clock_offset(node):
     if node.propval("clock-names") != ['']:
         clock_names = node["clock-names"].value
         try:
-            tclk_offset = clock_names.index("tx_clk") + 1
+            tclk_offset = clock_names.index("tx_clk")
+            tclk_offset = 2 * tclk_offset + 1
         except ValueError:
                 tclk_offset = 1
 

--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -916,7 +916,7 @@ def xlnx_generate_zephyr_domain_dts(tgt_node, sdt, options):
                     defconfig_kconfig.write("  default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency)")
 
                     val = node.propval('xlnx,pmp-entries', list)[0]
-                    if val % 8 == 0:
+                    if val % 8 == 0 and val != 0:
                         soc_kconfig = open(soc_kconfig_file, 'a')
                         soc_kconfig.write("  select RISCV_PMP\n")
                         soc_kconfig.close()

--- a/lopper/assists/generate_config_object.py
+++ b/lopper/assists/generate_config_object.py
@@ -221,7 +221,9 @@ def get_power_domain_perm_mask_txt(pwr_domain, sdtinfo_obj):
                 continue
             macro_list.append(get_ipi_mask_txt(master, sdtinfo_obj))
     if (pwr_domain == "NODE_FPD" or pwr_domain == "NODE_APU") and (len(macro_list) == 0):
-        macro_list.append("psu_cortexa53_0")
+        hardcode_mask = get_ipi_mask_txt("psu_cortexr5_0", sdtinfo_obj)
+        if hardcode_mask != "":
+            macro_list.append(hardcode_mask)
     if len(macro_list) > 0:
         return " | ".join(macro_list)
     else:

--- a/lopper/tree.py
+++ b/lopper/tree.py
@@ -4394,13 +4394,13 @@ class LopperTree:
         return matches
 
 
-    def deref( self, phandle_or_label ):
+    def deref( self, phandle_or_label_or_alias ):
         """Find a node by a phandle or label
 
         dereferences a phandle or label to find the target node.
 
         Args:
-           phandle_or_label (int or string)
+           phandle_or_label_or_alias (int or string)
 
         Returns:
            LopperNode: the matching node if found, None otherwise
@@ -4413,16 +4413,22 @@ class LopperTree:
                 try:
                     if tgn:
                         break
-                    tgn = t.pnode( phandle_or_label )
+                    tgn = t.pnode( phandle_or_label_or_alias )
                     if tgn == None:
                         # if we couldn't find the target, maybe it is in
                         # as a string. So let's check that way.
-                        tgn2 = t.nodes( phandle_or_label )
+                        tgn2 = t.nodes( phandle_or_label_or_alias )
                         if not tgn2:
-                            tgn2 = t.lnodes( re.escape(phandle_or_label) )
+                            tgn2 = t.lnodes( re.escape(phandle_or_label_or_alias) )
 
                         if tgn2:
                             tgn = tgn2[0]
+
+                        if not tgn:
+                            tgn2 = t.alias_node( phandle_or_label_or_alias )
+                            if tgn2:
+                                print( f'debug: deref by alias worked: orig: {tgn} alias: {tgn2}')
+                                tgn = tgn2
                 except:
                     pass
         except Exception as e:


### PR DESCRIPTION
The clocks property in the device tree consists of tuples in the format:
    <phandle clock-id>. To correctly extract the clock ID associated with
    "tx_clk",
    the offset needs to account for the two-cell structure.

    Signed-off-by: Shubhrajyoti Datta <shubhrajyoti.datta@amd.com>
