### PR TITLE
lopper: Fix tx_clk index handling in clock property

### DIFF
--- a/lopper/assists/baremetalconfig_xlnx.py
+++ b/lopper/assists/baremetalconfig_xlnx.py
@@ -242,7 +242,8 @@ def get_clock_offset(node):
     if node.propval("clock-names") != ['']:
         clock_names = node["clock-names"].value
         try:
-            tclk_offset = clock_names.index("tx_clk") + 1
+            tclk_offset = clock_names.index("tx_clk")
+            tclk_offset = 2 * tclk_offset + 1
         except ValueError:
                 tclk_offset = 1
 


### PR DESCRIPTION
The clocks property in the device tree consists of tuples in the format: <phandle clock-id>. To correctly extract the clock ID associated with "tx_clk",
the offset needs to account for the two-cell structure.