### PR TITLE
lopper: lops: Update the lops to use outdir option

### DIFF
--- a/lopper/lops/lop-cpulist.dts
+++ b/lopper/lops/lop-cpulist.dts
@@ -22,6 +22,7 @@
                               inherit = "lopper_lib";
                               code = "
                                      import yaml
+                                     import os
                                      cpu_output = {}
                                      for c in __selected__:
                                          for c_node in c.subnodes( children_only = True ):
@@ -37,7 +38,7 @@
                                                  cpu_node = None
                                              if cpu_node:
                                              	 cpu_output[cpu_node] = ip_name[0]
-                                     with open('cpulist.yaml', 'w') as fd:
+                                     with open(os.path.join(outdir, 'cpulist.yaml'), 'w') as fd:
                                          fd.write(yaml.dump(cpu_output, indent = 4))
                                      ";
                       };

--- a/lopper/lops/lop-microblaze-riscv.dts
+++ b/lopper/lops/lop-microblaze-riscv.dts
@@ -93,6 +93,7 @@
                            compatible = "system-device-tree-v1,lop,code-v1";
                            code = "
                                import yaml
+                               import os
 
                                for n in tree.__selected__:
                                    proplist= ['xlnx,data-size', 'xlnx,use-muldiv', 'xlnx,use-atomic', 'xlnx,use-fpu', 'xlnx,use-compression']
@@ -196,7 +197,7 @@
                                    cflags_data['libpath'] = libdir 
                                    cflags_data['linkflags'] = bsp_linkflags
 
-                                   with open('cflags.yaml', 'w') as fd:
+                                   with open(os.path.join(outdir, 'cflags.yaml'), 'w') as fd:
                                          fd.write(yaml.dump(cflags_data, indent = 4))
                                ";
                       };

--- a/lopper/lops/lop-microblaze.dts
+++ b/lopper/lops/lop-microblaze.dts
@@ -170,6 +170,7 @@
                            compatible = "system-device-tree-v1,lop,code-v1";
                            code = "
                                import yaml
+                               import os
                                for n in tree.__selected__:
                                    proplist= ['xlnx,use-barrel', 'xlnx,endianness', 'xlnx,data-size', 'xlnx,use-pcmp-instr', 'xlnx,use-reorder-instr', 'xlnx,area-optimized', 'xlnx,use-hw-mul', 'xlnx,use-div', 'xlnx,use-fpu', 'model']
 
@@ -207,7 +208,7 @@
                                    cflags_data['cflags'] = cflags
                                    cflags_data['libpath'] = libdir
 
-                                   with open('cflags.yaml', 'w') as fd:
+                                   with open(os.path.join(outdir, 'cflags.yaml'), 'w') as fd:
                                          fd.write(yaml.dump(cflags_data, indent = 4))
                                ";
                       };


### PR DESCRIPTION
If the user provides the -O option, generate the artifacts in the specified output directory.