### PR TITLE
lopper: assists: zephyr: Add interrupt-names to UARTPSV

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -459,6 +459,10 @@ def xlnx_remove_unsupported_nodes(tgt_node, sdt):
                     # UARTPSV
                     if any(version in node["compatible"].value for version in ("arm,pl011", "arm,sbsa-uart")):
                         node["compatible"].value = ["arm,sbsa-uart"]
+                        if node.propval('interrupt-names') == ['']:
+                            node["interrupt-names"] = LopperProp("interrupt-names")
+                            node["interrupt-names"].value = node.label
+                            node.add(node["interrupt-names"])
                     # AXI-IIC
                     if "xlnx,axi-iic-2.1" in node["compatible"].value:
                         node["compatible"].value = ["xlnx,xps-iic-2.1"]

--- a/lopper/assists/zephyr_supported_comp.yaml
+++ b/lopper/assists/zephyr_supported_comp.yaml
@@ -81,6 +81,7 @@ arm,pl011:
     - status
     - interrupts
     - interrupt-parent
+    - interrupt-names
 
 arm,sbsa-uart:
   required:
@@ -88,6 +89,7 @@ arm,sbsa-uart:
     - reg
     - interrupts
     - interrupt-parent
+    - interrupt-names
 
 xlnx,xps-iic-2.00.a:
   required:


### PR DESCRIPTION
Zephyr expects interrupt-names property to be generated for the UARTPSV nodes (arm,pl011 and arm,sbsa-uart)