### PR TITLE
lopper/assists/README: Add --firmware-name option documentation for x…

### DIFF
--- a/lopper/assists/README
+++ b/lopper/assists/README
@@ -88,6 +88,19 @@ lopper -O <output_dir> -f --enhanced <system-top.dts> <lopper-gen DT> -- xlnx_ov
 |-----------------------------------------------------------------------------------|
 | <PL DTSI>              | SDT-generated pl.dtsi file                               |
 |-----------------------------------------------------------------------------------|
+|--firmware-name         | optional:                                                |
+|                        |         Overrides the firmware-name property in the      |
+|                        |         generated overlay.                               |
+|-----------------------------------------------------------------------------------|
 
 ##Example:
 lopper -O <output_dir>/ -f --enhanced <path_to_system_top>/system-top.dts <path_to_lopper_gen_dt>/lopper-gen.dts -- xlnx_overlay_pl_dt <machine> <config> <path_to_pl_dtsi>/pl.dtsi
+
+##Example:
+--firmware-name=<custom_name>
+The --firmware-name argument is optional and allows you to override the default firmware-name property in the generated pl.dtsi.
+This is especially useful when:
+-->The bitstream is managed or named externally.
+-->You want to embed a custom bitstream name in the overlay.
+Usage Example:
+lopper -O <output_dir>/ -f --enhanced <path_to_system_top>/system-top.dts <path_to_lopper_gen_dt>/lopper-gen.dts -- xlnx_overlay_pl_dt <machine> <config> <path_to_pl_dtsi>/pl.dtsi --firmware-name=<my_custom.bit>


### PR DESCRIPTION
…lnx_overlay_pl_dt.py

Updates documentation for the new optional --firmware-name argument in the xlnx_overlay_pl_dt.py assist. This option allows users to override the default firmware-name property in the generated pl.dtsi overlay file, which is useful when managing bitstreams externally or requiring a custom bitstream filename. The README was updated to include a clear description of this feature along with a usage example.