### PR TITLE
Generate properties only for QDMA and delete unnecessary properties for QDMA EP

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -324,7 +324,14 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
             if 'xlnx,usp-rf-data-converter-2.6' in node.propval('compatible'):
                 delete_child_nodes = True
             if is_prune_node:
+                if linux_dt and "qdma" in node.label:
+                    mode = node.propval('xlnx,device_port_type')
                 delete_unused_props( node, driver_proplist, delete_child_nodes)
+
+                if linux_dt and "qdma" in node.label:
+                    if mode == ['PCI_Express_Endpoint_device']:
+                        if "okay" in node.propval('status', list)[0]:
+                            node.propval('status', list)[0] = "disabled"
 
     # Remove symbol node referneces
     symbol_node = sdt.tree['/__symbols__']

--- a/lopper/assists/yaml_bindings/xlnx,xdma-host.yaml
+++ b/lopper/assists/yaml_bindings/xlnx,xdma-host.yaml
@@ -14,10 +14,21 @@ allOf:
 
 properties:
   compatible:
-    const: xlnx,xdma-host-3.00
+    enum:
+      - xlnx,xdma-host-3.00
+      - xlnx,qdma-host-3.00
 
   reg:
-    maxItems: 1
+    items:
+      - description: configuration region and XDMA bridge register.
+      - description: QDMA bridge register.
+    minItems: 1
+
+  reg-names:
+    items:
+      - const: cfg
+      - const: breg
+    minItems: 1
 
   ranges:
     maxItems: 2
@@ -76,6 +87,27 @@ required:
   - interrupt-names
   - "#interrupt-cells"
   - interrupt-controller
+
+if:
+  properties:
+    compatible:
+      contains:
+        enum:
+          - xlnx,qdma-host-3.00
+then:
+  properties:
+    reg:
+      minItems: 2
+    reg-names:
+      minItems: 2
+  required:
+    - reg-names
+else:
+  properties:
+    reg:
+      maxItems: 1
+    reg-names:
+      maxItems: 1
 
 unevaluatedProperties: false
 


### PR DESCRIPTION
Remove unwanted QDMA properties based on YAML definitions when the node status is "okay"
and its compatible matches the driver compatibility list.

If a QDMA node is configured as a PCIe Endpoint, update its status property to
"disabled" to ensure only the required properties are present and the
Endpoint status to disabled.
