### PR TITLE
lopper: assists: gen_domain_dts: Add support for generating cortexA78 specific Zephyr device-tree

### DIFF
--- a/lopper/assists/zephyr_supported_comp.yaml
+++ b/lopper/assists/zephyr_supported_comp.yaml
@@ -166,9 +166,17 @@ cpus,cluster:
 arm,cortex-r52:
   required:
     - compatible
+    - device_type
+    - reg
+    - clock-frequency
+
+arm,cortex-a78:
+  required:
+    - compatible
     - device_type 
     - reg
     - clock-frequency
+    - enable-method
 
 arm,armv8-timer:
   required:


### PR DESCRIPTION
This change introduces support for generating a zephyr-compatible device tree tailored to the Cortex-A78 from the system-level device tree. It ensures that the A78-specific nodes and properties are correctly extracted and formatted for use in Zephyr builds.