### PR TITLE
assists: baremetallinker_xlnx.py: Add missing memory region for NoC_C…

### DIFF
--- a/lopper/assists/baremetallinker_xlnx.py
+++ b/lopper/assists/baremetallinker_xlnx.py
@@ -89,6 +89,7 @@ def get_memranges(tgt_node, sdt, options):
         "0x50000000000" : "DDR_CH_1",
         "0x10000000000" : "DDR_LOW_3",
         "0xC000000000" : "DDR_LOW_2",
+        "0xA00000000" : "DDR_LOW_1A",
         "0x800000000" : "DDR_LOW_1",
         "0x0" : "DDR_LOW_0"
     }


### PR DESCRIPTION
…2_C3

The base address 0xA00000000 used by the NoC_C2_C3 memory region was not present in the valid memory regions list within the baremetallinker assist. Due to this, the linker was incorrectly assigning the region to an adjacent block (e.g., DDR_LOW_1), resulting in incorrect memory address and size calculations.

This patch adds the missing entry "0xA00000000": "DDR_LOW_1A" to the memory map, ensuring the correct association of the NoC_C2_C3 region during linker script generation.