### PR TITLE
lopper:assist: Preserve Individual Memory Regions in Memory Config to…

### DIFF
--- a/lopper/assists/baremetal_bspconfig_xlnx.py
+++ b/lopper/assists/baremetal_bspconfig_xlnx.py
@@ -36,7 +36,7 @@ def xlnx_generate_bm_bspconfig(tgt_node, sdt, options):
     root_sub_nodes = root_node.subnodes()
     if options.get('outdir', {}):
         sdt.outdir = options['outdir']
-   
+    options["args"].append("xparam")
     mem_ranges, _ = get_memranges(tgt_node, sdt, options)
     if not mem_ranges:
         _warning("No memory node is mapped to the processor. Moving ahead")

--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -432,7 +432,9 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
         plat.buf(f"\n#define XPS_BOARD_{board.upper()}\n")
     
     # Memory Node related defines
+    options["args"].append("xparam")
     mem_ranges, _ = get_memranges(tgt_node, sdt, options)
+
     for key, value in sorted(mem_ranges.items(), key=lambda e: e[1][1], reverse=True):
         start,size = value[0], value[1]
         suffix = "ADDRESS"

--- a/lopper/assists/baremetallinker_xlnx.py
+++ b/lopper/assists/baremetallinker_xlnx.py
@@ -60,6 +60,13 @@ def get_memranges(tgt_node, sdt, options):
     except:
         pass
 
+    xparam = False
+    try:
+        if "xparam" in options['args']:
+            xparam = True
+    except:
+        pass
+
     # Ensure that the region addresses are always in descending order of addresses
     # This order is necessary to employ the comparison while mapping the available regions.
     versal_noc_region_ranges =  {
@@ -173,9 +180,16 @@ def get_memranges(tgt_node, sdt, options):
                         linker_secname = key + str("_") + str(xlnx_memipname[key])
                         label_name_new = label_name + str("_") + str(xlnx_memipname[key])
                         xlnx_memipname[key] += 1
+
+                    if not xparam and (linker_secname in mem_ranges):
+                        index_val = str("_") + str(xlnx_memipname[key])
+                        linker_secname += index_val
+                        label_name_new += index_val
+                        xlnx_memipname[key] += 1
+
                     lable_names[linker_secname] = label_name_new
                     # Update the mem_ranges to account for multiple NoC memory segments within a given region.
-                    if is_valid_noc_ch and (linker_secname in mem_ranges):
+                    if is_valid_noc_ch and xparam and (linker_secname in mem_ranges):
                         start_addr, old_size = mem_ranges[linker_secname]
                         new_size = valid_range[0] + size - start_addr
                         mem_ranges.update({linker_secname: [start_addr, new_size]})


### PR DESCRIPTION
… Avoid Merging Holes

The get_mem_ranges logic merged multiple regions of a memory node into a single entry by taking the lowest base address and the highest end address. This approach caused issues when there were memory holes within the combined range, leading to hangs during memory tests. Add each memory region as a separate entry in the config, without merging. generate macros for each region as before, ensuring compatibility. allow memory holes to be naturally ignored by the test logic, preventing hangs. this change ensures that memory tests operate only on valid, contiguous regions as defined in the hardware,
improving reliability and correctness when memory holes are present.