### PR TITLE
assists: zephyr_supported_comp: Remove timeout-sec property from wwdt

### DIFF
--- a/lopper/assists/zephyr_supported_comp.yaml
+++ b/lopper/assists/zephyr_supported_comp.yaml
@@ -205,7 +205,6 @@ xlnx,versal-wwdt:
   required:
     - compatible
     - reg
-    - timeout-sec
     - clocks
 
 fixed-clock:


### PR DESCRIPTION
Remove timeout-sec property from WWDT node to sync with upstream DT bindings.