### PR TITLE
Lopper: Assists: Allow application creation when required memory is e…

### DIFF
--- a/lopper/assists/baremetal_validate_comp_xlnx.py
+++ b/lopper/assists/baremetal_validate_comp_xlnx.py
@@ -56,7 +56,7 @@ def check_for_mem(sdt, options, mem_type, required_mem):
             if required_mem_start != 0x0:
                 if (required_mem_start == start) and (size <= required_mem_size):
                     return False, mem_type, required_mem_size
-            if size > required_mem_size:
+            if size >= required_mem_size:
                 return True, mem_type, required_mem_size
 
     return False, mem_type, required_mem_size, required_mem_start


### PR DESCRIPTION
…xactly matched

Updated the memory validation logic in check_for_mem to allow application creation when the available memory size is equal to the required size. Earlier, the validation passed only if available memory was greater than the required size. This caused memory_tests to fail even when exactly 0x2000 bytes were allocated, as defined in the YAML. Changed the condition from greater than to greater than or equal to, so that exact matches are also accepted.