### PR TITLE
lopper: assists: Add AMD-Xilinx IPI for Zephyr

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -613,6 +613,10 @@ def xlnx_remove_unsupported_nodes(tgt_node, sdt):
                     # Mailbox
                     if any(version in node["compatible"].value for version in ("vnd,mbox-consumer", "xlnx,mbox-versal-ipi-mailbox", "xlnx,mbox-versal-ipi-dest-mailbox")):
                         continue
+                    if "xlnx,versal-ipi-mailbox" in node["compatible"].value:
+                        node["compatible"].value = ["xlnx,mbox-versal-ipi-mailbox"]
+                    elif "xlnx,versal-ipi-dest-mailbox" in node["compatible"].value:
+                        node["compatible"].value = ["xlnx,mbox-versal-ipi-dest-mailbox"]
                     # PS-IIC
                     if "cdns,i2c-r1p14" in node["compatible"].value:
                         node["compatible"].value = ["cdns,i2c"]

--- a/lopper/assists/zephyr_supported_comp.yaml
+++ b/lopper/assists/zephyr_supported_comp.yaml
@@ -256,3 +256,22 @@ xlnx,xps-spi-2.00.a:
     - interrupt-parent
     - '#address-cells'
     - '#size-cells'
+
+xlnx,versal-ipi-mailbox:
+  required:
+    - compatible
+    - reg
+    - reg-names
+    - interrupts
+    - interrupt-parent
+    - xlnx,ipi-id
+    - '#address-cells'
+    - '#size-cells'
+
+xlnx,versal-ipi-dest-mailbox:
+  required:
+    - compatible
+    - reg
+    - reg-names
+    - xlnx,ipi-id
+    - '#mbox-cells'


### PR DESCRIPTION
- Updated zephyr_supported_comp.yaml for AMD-Xilinx IPI Mailbox
- Extended Zephyr DTS generation to support AMD-Xilinx IPI Mailbox node