### PR TITLE
lopper:assist: Define FRL enable macro based on HDMI mode

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -425,6 +425,13 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
         except KeyError:
             pass
 
+    for node in sdt.tree['/'].subnodes():
+        if node.propval('xlnx,ip-name') == ['v_hdmi_rxss1'] and node.propval('xlnx,hdmi-mode') != ['']:
+            hdmi_mode = int(str(node.propval('xlnx,hdmi-mode', list)[0]) or "0", 0)
+            if hdmi_mode > 0:
+                plat.buf("\n#define XPAR_XV_HDMI_RX_FRL_ENABLE \n")
+                break
+
     # Define for Board
     if sdt.tree[tgt_node].propval('board') != ['']:
         board = sdt.tree[tgt_node].propval('board', list)[0]

--- a/lopper/assists/yaml_bindings/xlnx,v-hdmi-phy1.yaml
+++ b/lopper/assists/yaml_bindings/xlnx,v-hdmi-phy1.yaml
@@ -182,17 +182,25 @@ properties:
 
   xlnx,rx-clk-primitive:
     description: |
-      Rx clock primitive type that IP is configured with.
+      Rx clock primitive type that IP is configured with. Possible values
+      are as below.
+      0 - MMCM
+      1 - PLL
+      2 - DPLL
     allOf:
       - $ref: /schemas/types.yaml#/definitions/uint32
-      - enum: [0, 1]
+      - enum: [0, 1, 2]
 
   xlnx,tx-clk-primitive:
     description: |
-      Tx clock primitive type that IP is configured with.
+      Tx clock primitive type that IP is configured with. Possible values
+      are as below.
+      0 - MMCM
+      1 - PLL
+      2 - DPLL
     allOf:
       - $ref: /schemas/types.yaml#/definitions/uint32
-      - enum: [0, 1]
+      - enum: [0, 1, 2]
 
   xlnx,hdmi-connector:
     description: |


### PR DESCRIPTION
Define a macro to enable or exclude FRL-related logic in the driver, based on the HDMI mode configured in the HDMI 2.1 Rx subsystem IP.