### PR TITLE
lopper:assist: Add processor check for library validation

### DIFF
--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -224,19 +224,13 @@ def generate_hwtocmake_medata(sdt, node_list, src_path, repo_path_data, options,
     comp_type = schema.get('type',{})
     family =  sdt.tree['/'].propval('family')
     family = family[0] if family else ""
+    variant = sdt.tree['/'].propval('variant')
     if meta_dict.get("condition") and family:
         match_cpunode = bm_config.get_cpu_node(sdt, options)
         proc_ip_name = match_cpunode.propval('xlnx,ip-name')[0]
-        local_scope={
-            "proc":proc_ip_name,
-            "platform":family,
-            "depends":[]
-        }
-        try:
-            exec(meta_dict["condition"], {"__builtins__": {}}, local_scope)
-            meta_dict = {key: value for key, value in meta_dict.items() if key in local_scope["depends"]}
-        except Exception as e:
-            _warning("The condition in the {yaml_file} file has failed. -> {e}")
+        local_scope = utils.run_exec(meta_dict["condition"], proc_ip_name, family, variant, return_list="depends", yaml_file=yaml_file)
+        meta_dict = {key: value for key, value in meta_dict.items() if key in local_scope}
+
     meta_dict.pop("condition",None)
     lwip = re.search("lwip", name)
     standalone = re.search("standalone", name)

--- a/lopper/assists/common_utils.py
+++ b/lopper/assists/common_utils.py
@@ -15,6 +15,9 @@ import yaml
 from typing import Any, List, Optional, Dict, Union
 import shutil
 import logging
+from lopper.log import _init, _warning
+
+_init(__name__)
 
 def to_cmakelist(pylist):
     cmake_list = ';'.join(pylist)
@@ -157,4 +160,33 @@ def log_setup(options):
     #print(f"[LOG_SETUP] Verbose level = {verbose_level}, Final level = {level}")
     return level
 
+def run_exec(yaml_condition, proc_ip_name, family, variant=None, return_list="examples", yaml_file=""):
+    """
+    Executes a Python condition string in a restricted local scope and returns a specified list.
 
+    Args:
+        yaml_condition (str): Python code to execute, typically from a YAML file.
+        proc_ip_name (str): Name of the processor IP available in the local scope as 'proc'.
+        family (str): Platform family available in the local scope as 'platform'.
+        variant (str, optional): Variant available in the local scope as 'variant'.
+        return_list (str, optional): Name of the list to return from the local scope. Defaults to "examples".
+        yaml_file (str, optional): YAML file name for error reporting.
+
+    Returns:
+        list: The list named by `return_list` from the local scope after executing the condition.
+
+    Notes:
+        Any exceptions during execution are caught and logged as warnings.
+    """
+    local_scope = {
+        "proc": proc_ip_name,
+        "platform": family,
+        "variant": variant,
+        return_list: []
+    }
+    try:
+        exec(yaml_condition, {"__builtins__": {}}, local_scope)
+    except Exception as e:
+        _warning(f"The condition in the {yaml_file} file has failed. -> {e}")
+    finally:
+        return local_scope[return_list]


### PR DESCRIPTION
baremetal_getsupported_comp_xlnx: Add logic to filter the supported_processors list using dynamic conditions defined in the YAML file
common_utils: This refactoring brings all the condition checks based on processor, platform family, and variant into one place. It removes repeated logic from different assist scripts