### PR TITLE
lopper: assists: Add AMD-VERSAL-GEN2 UFS for Zephyr

### DIFF
--- a/lopper/assists/zephyr_supported_comp.yaml
+++ b/lopper/assists/zephyr_supported_comp.yaml
@@ -275,3 +275,13 @@ xlnx,versal-ipi-dest-mailbox:
     - reg-names
     - xlnx,ipi-id
     - '#mbox-cells'
+
+amd,versal2-ufs:
+  required:
+    - compatible
+    - status
+    - reg
+    - interrupts
+    - interrupt-parent
+    - clocks
+    - clock-names


### PR DESCRIPTION
- Update zephyr_supported_comp.yaml for AMD-VERSAL-GEN2 UFS
- Extend Zephyr DTS generation to support AMD-VERSAL-GEN2 UFS node
- Add ufs0 alias support for testing ufs ztests