### PR TITLE
lopper: assists: zephyr: Add support to generate ADMA node

### DIFF
--- a/lopper/assists/zephyr_supported_comp.yaml
+++ b/lopper/assists/zephyr_supported_comp.yaml
@@ -228,6 +228,26 @@ xlnx,versal-net-emmc:
     - interrupts
     - clocks
 
+xlnx,zynqmp-dma-1.0:
+  required:
+    - compatible
+    - reg
+    - '#dma-cells'
+    - interrupts
+    - clocks
+    - clock-names
+    - xlnx,bus-width
+
+amd,versal2-dma-1.0:
+  required:
+    - compatible
+    - reg
+    - '#dma-cells'
+    - interrupts
+    - clocks
+    - clock-names
+    - xlnx,bus-width
+
 xlnx,versal-gpio-1.0:
   required:
     - compatible


### PR DESCRIPTION
Add support to generate adma node and pull in clk_main and clk_apb clocks for adma node in versalnet and versal gen2.

Add required properties of versalnet and versal gen2 in zephyr_supported_comp.yaml file