### PR TITLE
base: fix phandle resolution for vendor-prefixed DTS properties

### DIFF
--- a/lopper/base.py
+++ b/lopper/base.py
@@ -1000,7 +1000,7 @@ class lopper_base:
 
             # Check for property definitions with phandles
             # Handle both single-line and multi-line properties
-            prop_match = re.match(r'^([a-zA-Z0-9_-]+)\s*=\s*(.*)', line)
+            prop_match = re.match(r'^([a-zA-Z0-9_,-]+)\s*=\s*(.*)', line)
             if prop_match and current_path:
                 prop_name = prop_match.group(1)
                 prop_value = prop_match.group(2)


### PR DESCRIPTION
DTS property names using a vendor prefix follow the convention <vendor>,<property> (e.g., xlnx,hdmi-connector and xlnx,xlnx-hdmi-acr-ctrl). The regex pattern used to detect property definitions during phandle resolution was restricted to the character class [a-zA-Z0-9_-], which excludes the comma character. As a result, any property whose name contains a vendor prefix was silently skipped, leaving its phandle references unresolved in the Lopper-generated pl.dtsi.

Extend the character class to [a-zA-Z0-9_,-] to include the comma, allowing vendor-prefixed property names to be matched. This restores correct phandle resolution for properties such as xlnx,hdmi-connector and xlnx,xlnx-hdmi-acr-ctrl generated by SDT for HDMI-related PL IP blocks (e.g., xfmc and audio_ss_0_hdmi_acr_ctrl), bringing the Lopper output in line with the reference SDT-generated pl.dtsi.