### PR TITLE
gen_domain_dts: Extend mapped_nodelist to include bus children nodes

### DIFF
--- a/lopper/__init__.py
+++ b/lopper/__init__.py
@@ -482,19 +482,24 @@ class LopperSDT:
 
         tagged_count = 0
 
-        def tag_subtree(node, source_tag):
+        def tag_subtree(node, overlay_layer):
             """Recursively tag all properties on node and all descendants."""
             count = 0
+            # Mark entire node as overlay-originated
+            node._origin_layer = overlay_layer
             for prop_name in list(node.__props__.keys()):
-                node.__props__[prop_name]._source = source_tag
+                prop = node.__props__[prop_name]
+                # Record overlay layer value (current merged value IS the overlay value)
+                prop._set_layer_value(overlay_layer, prop.__dict__.get('value', []), priority=500)
                 count += 1
-                lopper.log._debug(f"Tagged {node.abs_path}.{prop_name} from {source_tag}")
+                lopper.log._debug(f"Tagged {node.abs_path}.{prop_name} with layer '{overlay_layer}'")
             for child in node.child_nodes.values():
-                count += tag_subtree(child, source_tag)
+                count += tag_subtree(child, overlay_layer)
             return count
 
         for overlay_name, targets in self._overlay_targets.items():
-            source_tag = f"overlay:{overlay_name}"
+            # Layer name is just the overlay filename without extension, e.g. 'pl_overlay'
+            overlay_layer = os.path.splitext(overlay_name)[0]
 
             for label, target_info in targets.items():
                 # Support both old list format and new dict format
@@ -516,7 +521,9 @@ class LopperSDT:
                 # Tag direct properties on the target node
                 for prop_name in prop_names:
                     if prop_name in node.__props__:
-                        node.__props__[prop_name]._source = source_tag
+                        prop = node.__props__[prop_name]
+                        # Record overlay layer value
+                        prop._set_layer_value(overlay_layer, prop.__dict__.get('value', []), priority=500)
                         tagged_count += 1
                         lopper.log._debug(f"Tagged {node.abs_path}.{prop_name} from {overlay_name}")
 
@@ -525,7 +532,7 @@ class LopperSDT:
                     child_path = node.abs_path.rstrip('/') + '/' + child_name
                     if child_path in self.tree.__nodes__:
                         child_node = self.tree.__nodes__[child_path]
-                        tagged_count += tag_subtree(child_node, source_tag)
+                        tagged_count += tag_subtree(child_node, overlay_layer)
                     else:
                         lopper.log._debug(f"Overlay child node '{child_path}' not found in merged tree")
 

--- a/lopper/__init__.py
+++ b/lopper/__init__.py
@@ -87,6 +87,322 @@ class LopperAssist:
         # holds specific key,value properties
         self.properties = properties_dict
 
+
+def is_overlay_file(filepath):
+    """Check if a DTS file contains overlay syntax (&label { }).
+
+    Overlay files modify existing nodes using label references like
+    &mmi_dc { status = "okay"; }. This function detects such patterns
+    to identify files that should be tracked for source tagging.
+
+    Args:
+        filepath: Path to the DTS/DTSI file to check
+
+    Returns:
+        bool: True if file contains overlay syntax, False otherwise
+    """
+    try:
+        with open(filepath, 'r') as f:
+            content = f.read()
+            # Look for &label { pattern indicating overlay modification
+            # Must have & followed by identifier and opening brace
+            return bool(re.search(r'&\w+\s*\{', content))
+    except Exception:
+        return False
+
+
+def _extract_overlay_targets_regex(filepath):
+    """Extract overlay targets using a brace-counting parser (fallback method).
+
+    Used when compiled tree analysis is not possible (e.g., during early
+    setup before full SDT is loaded, or when dtc is unavailable).
+
+    Handles arbitrarily nested child nodes inside &label { } blocks by
+    counting braces rather than using a fixed-depth regex.
+
+    Args:
+        filepath: Path to the overlay DTS/DTSI file
+
+    Returns:
+        dict: Mapping of label names to a dict with keys:
+              'props'    - list of direct property names on the overlay target
+              'children' - list of direct child node names added by the overlay
+              Example: {'mmi_dc': {'props': ['status', 'clocks'],
+                                   'children': ['ports']}}
+    """
+    targets = {}
+
+    try:
+        with open(filepath, 'r') as f:
+            content = f.read()
+
+        # Find the start of each &label { block using a simple scan
+        label_re = re.compile(r'&(\w+)\s*\{', re.DOTALL)
+        prop_re = re.compile(r'^([a-zA-Z][a-zA-Z0-9,._+#-]*)\s*[=;]')
+        child_re = re.compile(r'^([a-zA-Z][a-zA-Z0-9,._+#-]*)\s*\{')
+
+        for m in label_re.finditer(content):
+            label = m.group(1)
+            # Walk forward counting braces to find the matching closing brace
+            pos = m.end()   # just past the opening '{'
+            depth = 1
+            block_start = pos
+            block_end = pos
+            while pos < len(content) and depth > 0:
+                ch = content[pos]
+                if ch == '{':
+                    depth += 1
+                elif ch == '}':
+                    depth -= 1
+                    if depth == 0:
+                        block_end = pos
+                pos += 1
+
+            block = content[block_start:block_end]
+
+            # Parse direct properties and direct child nodes at depth=1
+            # We need to skip over nested blocks when looking for properties
+            props = []
+            children = []
+            inner_pos = 0
+            inner_depth = 0
+            line_buf = []
+            while inner_pos < len(block):
+                ch = block[inner_pos]
+                if ch == '{':
+                    if inner_depth == 0:
+                        # The text in line_buf is the child node name line
+                        child_line = ''.join(line_buf).strip()
+                        child_m = child_re.match(child_line)
+                        if child_m:
+                            children.append(child_m.group(1))
+                        line_buf = []
+                    inner_depth += 1
+                elif ch == '}':
+                    inner_depth -= 1
+                    line_buf = []
+                elif ch == '\n':
+                    if inner_depth == 0:
+                        line = ''.join(line_buf).strip()
+                        prop_m = prop_re.match(line)
+                        if prop_m:
+                            props.append(prop_m.group(1))
+                    line_buf = []
+                else:
+                    if inner_depth == 0:
+                        line_buf.append(ch)
+                inner_pos += 1
+
+            if label in targets:
+                targets[label]['props'].extend(props)
+                targets[label]['children'].extend(children)
+            else:
+                targets[label] = {'props': props, 'children': children}
+
+    except Exception as e:
+        lopper.log._warning(f"Failed to extract overlay targets from {filepath}: {e}")
+
+    return targets
+
+
+def extract_overlay_targets_from_tree(overlay_tree):
+    """Extract overlay targets by analyzing a compiled overlay tree.
+
+    A dtc plugin-compiled overlay has the structure:
+
+        fragment@N { target = <&label>; __overlay__ { props; child_nodes; }; };
+        __fixups__ { label = "/fragment@N:target:0"; other_label = "..."; };
+
+    __fixups__ maps every &label reference to its location. The target
+    label for fragment@N appears as the entry whose path contains ':target:'.
+    All other entries are phandle fixups inside the overlay body.
+
+    Args:
+        overlay_tree: A LopperTree loaded from a compiled overlay DTB
+
+    Returns:
+        dict: Mapping of label name to a dict with keys:
+              'props'    - list of direct property names on the overlay target
+              'children' - list of direct child node names added by the overlay
+              Example: {'mmi_dc': {'props': ['status', 'clocks'],
+                                   'children': ['ports']}}
+
+    Note:
+        The return value is a richer type than the regex fallback.
+        Callers that only need property names should iterate result[label]['props'].
+    """
+    targets = {}
+
+    try:
+        # Build fragment-path -> target-label mapping from __fixups__ node.
+        # __fixups__ property values are strings like "/fragment@0:target:0".
+        # The target label is the property name; the fragment path precedes the first ':'.
+        fragment_to_label = {}
+        fixups_node = overlay_tree.nodes('/__fixups__')
+        if fixups_node:
+            fixups_node = fixups_node[0] if isinstance(fixups_node, list) else fixups_node
+            for prop in fixups_node.__props__.values():
+                label = prop.name
+                # prop.value may be a string or list of strings
+                val = prop.value
+                if not isinstance(val, list):
+                    val = [val]
+                for path_str in val:
+                    if not isinstance(path_str, str):
+                        continue
+                    # path_str like "/fragment@0:target:0"
+                    # or "/fragment@0/__overlay__/child:some-prop:0"
+                    frag_path = path_str.split(':')[0]   # "/fragment@0"
+                    frag_name = frag_path.strip('/')      # "fragment@0"
+                    if frag_path.count('/') == 1 and ':target:' in path_str:
+                        fragment_to_label[frag_name] = label
+                        break
+
+        # Walk each top-level fragment@N node using the tree abstraction
+        for node in overlay_tree:
+            frag_name = node.name
+            if not frag_name.startswith('fragment@'):
+                continue
+            if frag_name not in fragment_to_label:
+                continue
+
+            label = fragment_to_label[frag_name]
+
+            # Find the __overlay__ child of this fragment.
+            # child_nodes keys are full paths; search by node name.
+            overlay_node = None
+            for child_path, child in node.child_nodes.items():
+                if child.name == '__overlay__':
+                    overlay_node = child
+                    break
+            if overlay_node is None:
+                continue
+
+            # Collect direct property names from __overlay__
+            props = list(overlay_node.__props__.keys())
+
+            # Collect direct child node names from __overlay__
+            children = [child.name for child in overlay_node.child_nodes.values()]
+
+            if label in targets:
+                targets[label]['props'].extend(props)
+                targets[label]['children'].extend(children)
+            else:
+                targets[label] = {'props': props, 'children': children}
+
+    except Exception as e:
+        lopper.log._warning(f"Failed to extract overlay targets from tree: {e}")
+
+    return targets
+
+
+def compile_overlay_standalone(overlay_file, include_paths="", tmpdir=None, save_temps=False):
+    """Compile an overlay file standalone using dtc's plugin support.
+
+    Uses dtc's native overlay compilation with /plugin/ directive.
+    The overlay is compiled standalone - dtc creates __fixups__ entries
+    for unresolved labels rather than requiring the base tree.
+
+    Args:
+        overlay_file: Path to the overlay DTS/DTSI file
+        include_paths: Include paths for preprocessing
+        tmpdir: Directory for temporary files. If None, a temporary directory
+                is created and cleaned up automatically unless save_temps is set.
+        save_temps: If True, compiled artifacts are kept on disk. If False
+                    (default), a temporary directory is created and deleted
+                    after the tree is loaded.
+
+    Returns:
+        LopperTree or None: Compiled tree if successful, None on failure
+    """
+    # Only overlay files can be compiled as plugins
+    if not is_overlay_file(overlay_file):
+        return None
+
+    def _compile(work_dir):
+        overlay_basename = os.path.basename(overlay_file)
+        plugin_file = os.path.join(work_dir, f"_plugin_{overlay_basename}")
+
+        with open(overlay_file, 'r') as f:
+            content = f.read()
+
+        # Add /dts-v1/ and /plugin/ if not present
+        has_dts_v1 = '/dts-v1/' in content
+        has_plugin = '/plugin/' in content
+
+        with open(plugin_file, 'w') as f:
+            if not has_dts_v1:
+                f.write('/dts-v1/;\n')
+            if not has_plugin:
+                f.write('/plugin/;\n\n')
+            f.write(content)
+
+        overlay_dir = os.path.dirname(overlay_file)
+        full_includes = f"{include_paths} {overlay_dir}".strip()
+
+        dtb_file, _ = Lopper.dt_compile(
+            plugin_file, [], full_includes,
+            force_overwrite=True, outdir=work_dir,
+            save_temps=save_temps, verbose=0, enhanced=False,
+            permissive=True, symbols=False
+        )
+
+        if dtb_file and os.path.exists(dtb_file):
+            overlay_tree = LopperTree()
+            fdt = Lopper.dt_to_fdt(dtb_file)
+            overlay_tree.load(Lopper.export(fdt))
+            return overlay_tree
+
+        return None
+
+    try:
+        if tmpdir is not None or save_temps:
+            # Caller-supplied dir, or save_temps: no automatic cleanup
+            work_dir = tmpdir if tmpdir is not None else tempfile.mkdtemp()
+            return _compile(work_dir)
+        else:
+            with tempfile.TemporaryDirectory() as work_dir:
+                return _compile(work_dir)
+
+    except Exception as e:
+        lopper.log._debug(f"Compiled overlay analysis failed for {overlay_file}: {e}")
+
+    return None
+
+
+def extract_overlay_targets(overlay_file, include_paths="", tmpdir=None, save_temps=False):
+    """Extract which nodes and properties an overlay file targets.
+
+    Uses dtc's native plugin compilation to compile the overlay standalone,
+    then analyzes the resulting tree. Falls back to brace-counting parser if
+    compilation fails.
+
+    Args:
+        overlay_file: Path to the overlay DTS/DTSI file
+        include_paths: Include paths for preprocessing (when compiling)
+        tmpdir: Temporary directory for compilation artifacts
+
+    Returns:
+        dict: Mapping of label names to a dict with keys:
+              'props'    - list of direct property names modified by the overlay
+              'children' - list of direct child node names added by the overlay
+              Example: {'mmi_dc': {'props': ['status', 'clocks'],
+                                   'children': ['ports']}}
+    """
+    overlay_tree = compile_overlay_standalone(
+        overlay_file, include_paths, tmpdir, save_temps
+    )
+    if overlay_tree:
+        targets = extract_overlay_targets_from_tree(overlay_tree)
+        if targets:
+            lopper.log._debug(f"Used compiled analysis for {overlay_file}")
+            return targets
+
+    # Fallback to regex parsing
+    lopper.log._debug(f"Using regex fallback for {overlay_file}")
+    return _extract_overlay_targets_regex(overlay_file)
+
+
 class LopperSDT:
     """The LopperSDT Class represents and manages the full system DTS file
 
@@ -134,6 +450,107 @@ class LopperSDT:
         self.werror = False
         self.tmpfiles = []
         self.schema = None
+
+    def _tag_overlay_properties(self):
+        """Tag properties that came from user overlay files.
+
+        Uses the overlay targets extracted before compilation (stored in
+        self._overlay_targets) to tag properties in the merged tree with
+        their source overlay file.
+
+        For each overlay target label:
+        - Direct properties listed in targets[label]['props'] are tagged on
+          the target node itself.
+        - Child node names listed in targets[label]['children'] are found
+          under the target node in the merged tree and ALL their properties
+          (and all descendant nodes' properties) are tagged recursively.
+          This is correct because if the overlay introduced a child node,
+          every property inside that subtree is overlay-sourced by definition.
+
+        This enables later identification of which properties came from
+        user overlays, allowing them to be pulled into generated overlay
+        fragments.
+
+        Called automatically by setup() after tree loading if overlay
+        targets were detected.
+        """
+        if not hasattr(self, '_overlay_targets') or not self._overlay_targets:
+            return
+
+        if self.tree is None:
+            return
+
+        tagged_count = 0
+
+        def tag_subtree(node, source_tag):
+            """Recursively tag all properties on node and all descendants."""
+            count = 0
+            for prop_name in list(node.__props__.keys()):
+                node.__props__[prop_name]._source = source_tag
+                count += 1
+                lopper.log._debug(f"Tagged {node.abs_path}.{prop_name} from {source_tag}")
+            for child in node.child_nodes.values():
+                count += tag_subtree(child, source_tag)
+            return count
+
+        for overlay_name, targets in self._overlay_targets.items():
+            source_tag = f"overlay:{overlay_name}"
+
+            for label, target_info in targets.items():
+                # Support both old list format and new dict format
+                if isinstance(target_info, dict):
+                    prop_names = target_info.get('props', [])
+                    child_names = target_info.get('children', [])
+                else:
+                    prop_names = target_info
+                    child_names = []
+
+                # Find node by label in merged tree
+                nodes = self.tree.lnodes(label, exact=True)
+                if not nodes:
+                    lopper.log._debug(f"Overlay target label '{label}' not found in tree")
+                    continue
+
+                node = nodes[0]
+
+                # Tag direct properties on the target node
+                for prop_name in prop_names:
+                    if prop_name in node.__props__:
+                        node.__props__[prop_name]._source = source_tag
+                        tagged_count += 1
+                        lopper.log._debug(f"Tagged {node.abs_path}.{prop_name} from {overlay_name}")
+
+                # Recursively tag all properties in overlay-introduced child subtrees
+                for child_name in child_names:
+                    child_path = node.abs_path.rstrip('/') + '/' + child_name
+                    if child_path in self.tree.__nodes__:
+                        child_node = self.tree.__nodes__[child_path]
+                        tagged_count += tag_subtree(child_node, source_tag)
+                    else:
+                        lopper.log._debug(f"Overlay child node '{child_path}' not found in merged tree")
+
+        if tagged_count > 0:
+            lopper.log._info(f"Tagged {tagged_count} properties from {len(self._overlay_targets)} overlay file(s)")
+
+    def subtrees_sync(self):
+        """Populate subtrees dict from self.tree._metadata['child_trees']
+
+        Copies child trees (extracted, overlays) tracked on the main SDT tree
+        into the subtrees dict so they're accessible by name. This allows
+        assists and other code to access these trees via sdt.subtrees['name'].
+
+        Called after assists run or when subtrees dict access is needed.
+
+        Note: Operates on self.tree (the main SDT tree), not arbitrary trees.
+        """
+        if self.tree is None:
+            return
+
+        for child in self.tree._metadata.get('child_trees', []):
+            name = child._metadata.get('name')
+            if name and name not in self.subtrees:
+                self.subtrees[name] = child
+                lopper.log._debug( f"Synced subtree '{name}' from tree metadata" )
 
     def setup(self, sdt_file, input_files, include_paths, force=False, libfdt=True, config=None):
         """executes setup and initialization tasks for a system device tree
@@ -305,6 +722,28 @@ class LopperSDT:
             if sdt_files:
                 sdt_files.insert( 0, self.dts )
 
+                # Identify overlay files and extract their targets for source tracking.
+                # This allows us to tag properties that came from user overlays
+                # after the full compilation is complete.
+                #
+                # Uses compiled tree analysis when possible (per design) - compiles
+                # overlay with base SDT context for label resolution, then analyzes
+                # the resulting tree. Falls back to regex parsing if compilation fails.
+                self._overlay_targets = {}
+                for f in sdt_files:
+                    if (f.endswith(".dts") or f.endswith(".dtsi")) and f != self.dts:
+                        if is_overlay_file(f):
+                            overlay_name = os.path.basename(f)
+                            targets = extract_overlay_targets(
+                                f,
+                                include_paths=include_paths,
+                                tmpdir=self.tmpdir,
+                                save_temps=self.save_temps
+                            )
+                            if targets:
+                                self._overlay_targets[overlay_name] = targets
+                                lopper.log._debug(f"Identified overlay {overlay_name} targeting: {list(targets.keys())}")
+
                 # this block concatenates all the files into a single dts to
                 # compile
                 with open( fpp.name, 'wb') as wfd:
@@ -468,6 +907,11 @@ class LopperSDT:
                             merge = True
 
                         self.tree = self.tree.add( node, merge=merge )
+
+            # Tag properties that came from user overlays
+            # This uses the overlay targets extracted before compilation
+            if hasattr(self, '_overlay_targets') and self._overlay_targets:
+                self._tag_overlay_properties()
 
             fpp.close()
             self.tmpfiles.append( fpp.name )

--- a/lopper/__init__.py
+++ b/lopper/__init__.py
@@ -451,6 +451,112 @@ class LopperSDT:
         self.tmpfiles = []
         self.schema = None
 
+    def _seed_base_layers(self):
+        """Seed the 'base' layer for all properties in self.tree.
+
+        Called after the base DTS is compiled and loaded, before any overlay
+        files are applied. Records the pre-overlay value of every property as
+        the 'base' layer so that tree.view('base') can return original values.
+        """
+        if self.tree is None:
+            return
+
+        for node in self.tree:
+            for prop_name, prop in node.__props__.items():
+                raw_val = prop.__dict__.get('value', [])
+                if 'base' not in prop._layers or not prop._layers['base'][1]:
+                    prop.set_layer_value('base', raw_val, priority=0)
+
+    def _apply_overlay_dts_files(self, overlay_dts_files, include_paths):
+        """Compile and apply DTS overlay files as separate layers.
+
+        For each overlay file:
+        1. Compile standalone using compile_overlay_standalone()
+        2. Walk the overlay tree nodes
+        3. Merge each overlay node into self.tree (adding new nodes and
+           updating existing ones)
+        4. Seed the overlay layer for every modified/added property
+
+        This is called after _seed_base_layers() so the 'base' layer has
+        already been populated with pre-overlay values.
+
+        Args:
+            overlay_dts_files: list of DTS/DTSI overlay file paths
+            include_paths: include path string for dtc preprocessing
+        """
+        if not overlay_dts_files or self.tree is None:
+            return
+
+        for overlay_file in overlay_dts_files:
+            overlay_name = os.path.basename(overlay_file)
+            overlay_layer = os.path.splitext(overlay_name)[0]
+            source_tag = f"overlay:{overlay_name}"
+
+            lopper.log._info(f"Applying overlay layer '{overlay_layer}' from {overlay_name}")
+
+            overlay_tree = compile_overlay_standalone(
+                overlay_file,
+                include_paths=include_paths,
+                tmpdir=self.tmpdir,
+                save_temps=self.save_temps
+            )
+
+            if overlay_tree is None:
+                lopper.log._warning(f"Could not compile overlay {overlay_name} standalone; "
+                                    f"skipping layer seeding for this file")
+                continue
+
+            # Walk overlay tree nodes and apply to self.tree
+            for o_node in overlay_tree:
+                if o_node.abs_path in ('/', '__fixups__', '/__fixups__',
+                                       '__local_fixups__', '/__local_fixups__',
+                                       '__symbols__', '/__symbols__'):
+                    continue
+
+                node_path = o_node.abs_path
+
+                if node_path in self.tree.__nodes__:
+                    # Existing node: merge overlay properties, seed overlay layer for each
+                    base_node = self.tree.__nodes__[node_path]
+                    for prop_name, o_prop in o_node.__props__.items():
+                        o_val = o_prop.__dict__.get('value', [])
+                        if prop_name in base_node.__props__:
+                            b_prop = base_node.__props__[prop_name]
+                            # Seed overlay layer with overlay's value before merge
+                            b_prop.set_layer_value(overlay_layer, o_val, priority=500)
+                            b_prop._source = source_tag
+                            # Update the raw value (winning: overlay wins over base)
+                            b_prop.__dict__['value'] = o_val
+                            b_prop._layers['modifications'] = (1000, o_val)
+                        else:
+                            # New property introduced by overlay
+                            from lopper.tree import LopperProp
+                            new_prop = LopperProp(prop_name, value=o_val)
+                            new_prop._source = source_tag
+                            new_prop.set_layer_value('base', [], priority=0)
+                            new_prop.set_layer_value(overlay_layer, o_val, priority=500)
+                            base_node[prop_name] = new_prop
+                else:
+                    # New node introduced by overlay — find/create parent
+                    parent_path = '/'.join(node_path.split('/')[:-1]) or '/'
+                    if parent_path in self.tree.__nodes__:
+                        parent_node = self.tree.__nodes__[parent_path]
+                        from lopper.tree import LopperNode
+                        new_node = LopperNode(-1, node_path)
+                        new_node._origin_layer = overlay_layer
+                        self.tree.add(new_node)
+                        # Copy properties from overlay node
+                        for prop_name, o_prop in o_node.__props__.items():
+                            o_val = o_prop.__dict__.get('value', [])
+                            from lopper.tree import LopperProp
+                            new_prop = LopperProp(prop_name, value=o_val)
+                            new_prop._source = source_tag
+                            new_prop.set_layer_value('base', [], priority=0)
+                            new_prop.set_layer_value(overlay_layer, o_val, priority=500)
+                            new_node[prop_name] = new_prop
+
+            lopper.log._debug(f"Applied overlay layer '{overlay_layer}' from {overlay_name}")
+
     def _tag_overlay_properties(self):
         """Tag properties that came from user overlay files.
 
@@ -725,6 +831,7 @@ class LopperSDT:
             # do we have any extra sdt files to concatenate first ?
             fp = ""
             fpp = tempfile.NamedTemporaryFile( delete=False )
+            overlay_dts_files = []
             # TODO: if the count is one, we shouldn't be doing the tmp file processing.
             if sdt_files:
                 sdt_files.insert( 0, self.dts )
@@ -751,36 +858,50 @@ class LopperSDT:
                                 self._overlay_targets[overlay_name] = targets
                                 lopper.log._debug(f"Identified overlay {overlay_name} targeting: {list(targets.keys())}")
 
-                # this block concatenates all the files into a single dts to
-                # compile
+                # Separate overlay DTS files from base DTS files so that
+                # base and overlay layers can be seeded independently.
+                # Overlay files use &label { } syntax to modify existing nodes.
+                overlay_dts_files = []
+                base_dts_files = []
+                for f in sdt_files:
+                    if f.endswith(".dts") or f.endswith(".dtsi"):
+                        if f != self.dts and is_overlay_file(f):
+                            overlay_dts_files.append(f)
+                        else:
+                            base_dts_files.append(f)
+
+                # Concatenate only base DTS files into the file to compile.
+                # Overlay files will be compiled separately after the base tree
+                # is loaded so that base and overlay layers are properly seeded.
                 with open( fpp.name, 'wb') as wfd:
-                    for f in sdt_files:
-                        if f.endswith(".dts") or f.endswith(".dtsi"):
-                            with open(f, 'rb') as fd:
-                                shutil.copyfileobj(fd, wfd)
+                    for f in base_dts_files:
+                        with open(f, 'rb') as fd:
+                            shutil.copyfileobj(fd, wfd)
 
-                        elif re.search( r".yaml$", f ):
-                            # Note: if tree merging isn't sufficient for these, we could use
-                            #       deepmerge functionality directly on mutltiple yaml files
-                            # look for a special front end, for this or any file for that matter
-                            yaml = LopperYAML( f, config=config )
-                            yaml_tree = yaml.to_tree()
-                            yaml_tree._type = "yaml"
+                # Handle yaml/json extended trees from all sdt_files
+                for f in sdt_files:
+                    if re.search( r".yaml$", f ):
+                        # Note: if tree merging isn't sufficient for these, we could use
+                        #       deepmerge functionality directly on mutltiple yaml files
+                        # look for a special front end, for this or any file for that matter
+                        yaml = LopperYAML( f, config=config )
+                        yaml_tree = yaml.to_tree()
+                        yaml_tree._type = "yaml"
 
-                            # save the tree for future processing (and joining with the main
-                            # system device tree). No code after this needs to be concerned that
-                            # this came from yaml.
-                            sdt_extended_trees.append( yaml_tree )
-                        elif re.search( r".json$", f ):
-                            # look for a special front end, for this or any file for that matter
-                            json = LopperJSON( json=f, config=config )
-                            json_tree = json.to_tree()
-                            json_tree._type = "json"
+                        # save the tree for future processing (and joining with the main
+                        # system device tree). No code after this needs to be concerned that
+                        # this came from yaml.
+                        sdt_extended_trees.append( yaml_tree )
+                    elif re.search( r".json$", f ):
+                        # look for a special front end, for this or any file for that matter
+                        json = LopperJSON( json=f, config=config )
+                        json_tree = json.to_tree()
+                        json_tree._type = "json"
 
-                            # save the tree for future processing (and joining with the main
-                            # system device tree). No code after this needs to be concerned that
-                            # this came from yaml.
-                            sdt_extended_trees.append( json_tree )
+                        # save the tree for future processing (and joining with the main
+                        # system device tree). No code after this needs to be concerned that
+                        # this came from yaml.
+                        sdt_extended_trees.append( json_tree )
 
                 fp = fpp.name
             else:
@@ -894,6 +1015,23 @@ class LopperSDT:
 
             self.tree.__symbols__ = self.symbols
 
+            # Seed the 'base' layer for every property in the base tree.
+            # This captures the pre-overlay values so that tree.view('base')
+            # returns original SDT values independent of any applied overlays.
+            self._seed_base_layers()
+
+            # Apply DTS overlay files as separate layers now that the base
+            # tree is loaded and the 'base' layer is seeded.  Each overlay
+            # is compiled standalone and merged so that its layer can be
+            # independently tracked.
+            if overlay_dts_files:
+                self._apply_overlay_dts_files(overlay_dts_files, include_paths)
+            elif hasattr(self, '_overlay_targets') and self._overlay_targets:
+                # Fallback: use the old _tag_overlay_properties() approach when
+                # overlay_dts_files was not populated (e.g. the sdt_files branch
+                # was not taken above).
+                self._tag_overlay_properties()
+
             # join any extended trees to the one we just created
             for t in sdt_extended_trees:
                 for node in t['/'].children():
@@ -914,11 +1052,6 @@ class LopperSDT:
                             merge = True
 
                         self.tree = self.tree.add( node, merge=merge )
-
-            # Tag properties that came from user overlays
-            # This uses the overlay targets extracted before compilation
-            if hasattr(self, '_overlay_targets') and self._overlay_targets:
-                self._tag_overlay_properties()
 
             fpp.close()
             self.tmpfiles.append( fpp.name )

--- a/lopper/__init__.py
+++ b/lopper/__init__.py
@@ -432,7 +432,6 @@ class LopperSDT:
         self.dryrun = False
         self.assists = []
         self.output_file = ""
-        self.write_view = None  # If set, main output is written in this layer view
         self.cleanup_flag = True
         self.save_temps = False
         self.enhanced = False
@@ -1424,12 +1423,8 @@ class LopperSDT:
 
             tree_to_write.strict = not self.permissive
             tree_to_write.resolve()
-            # Consume write_view immediately so it is one-shot and never
-            # silently carries over to a subsequent write() call.
-            active_view = view if view is not None else self.write_view
-            self.write_view = None
-            if active_view is not None:
-                with tree_to_write.view(active_view):
+            if view is not None:
+                with tree_to_write.view(view):
                     tree_to_write.print( output_filename )
             else:
                 tree_to_write.print( output_filename )

--- a/lopper/__init__.py
+++ b/lopper/__init__.py
@@ -432,6 +432,7 @@ class LopperSDT:
         self.dryrun = False
         self.assists = []
         self.output_file = ""
+        self.write_view = None  # If set, main output is written in this layer view
         self.cleanup_flag = True
         self.save_temps = False
         self.enhanced = False
@@ -1358,7 +1359,7 @@ class LopperSDT:
         #       not cleaning up the concatenated compiled. pp file, since
         #       it is created with mktmp()
 
-    def write( self, tree = None, output_filename = None, overwrite = True, enhanced = False ):
+    def write( self, tree = None, output_filename = None, overwrite = True, enhanced = False, view = None ):
         """Write a system device tree to a file
 
         Write a fdt (or system device tree) to an output file. This routine uses
@@ -1423,7 +1424,15 @@ class LopperSDT:
 
             tree_to_write.strict = not self.permissive
             tree_to_write.resolve()
-            tree_to_write.print( output_filename )
+            # Consume write_view immediately so it is one-shot and never
+            # silently carries over to a subsequent write() call.
+            active_view = view if view is not None else self.write_view
+            self.write_view = None
+            if active_view is not None:
+                with tree_to_write.view(active_view):
+                    tree_to_write.print( output_filename )
+            else:
+                tree_to_write.print( output_filename )
 
         elif re.search( r"\.yaml$", output_filename ):
             if self.outdir and not Path( output_filename ).is_absolute():

--- a/lopper/assists/xlnx_overlay_pl_dt.py
+++ b/lopper/assists/xlnx_overlay_pl_dt.py
@@ -137,7 +137,7 @@ def infer_platform_from_sdt(sdt):
     return None
 
 def usage():
-    print('Usage: lopper -O <output_dir> -f --enhanced <system-top.dts> [<lopper-gen DT>] -- xlnx_overlay_pl_dt [<machine>] <configuration> [<pl.dtsi>] [--firmware-name=<name>]')
+    print('Usage: lopper -O <output_dir> -f --enhanced <system-top.dts> [<lopper-gen DT>] -- xlnx_overlay_pl_dt [<machine>] <configuration> [<pl.dtsi>] [options]')
     print('\nArguments:')
     print('  <output_dir>      - Directory where the lopper generated overlay `pl.dtsi` file will be stored')
     print('  <system-top.dts>  - Full system device tree source')
@@ -148,14 +148,75 @@ def usage():
     print('  <configuration>   - Configuration type: full | segmented | dfx | external-fpga-config')
     print('  <pl.dtsi>         - (Optional, for backward compatibility only) pl.dtsi file path - IGNORED')
     print('                      This argument is accepted but not used. The assist reads pl.dtsi from system device tree.')
-    print('  --firmware-name=<name> - (Optional) Override the default firmware-name in the output')
+    print('\nOptions:')
+    print('  --firmware-name=<name> - Override the default firmware-name in the output')
+    print('  --nodes=<node-spec>[;<node-spec>;...] - Specify nodes to include in overlay')
+    print('                      Overrides default /amba_pl extraction when specified.')
+    print('                      Semicolons separate node specs; commas separate properties.')
+    print('                      Node spec format:')
+    print('                        <node>           - Include entire node (by path or label)')
+    print('                        <node>#<prop>,<prop>,... - Include only specific properties')
+    print('                      Examples:')
+    print('                        --nodes=/amba_pl                    - Extract entire /amba_pl node')
+    print('                        --nodes=mmi_dc#clocks,clock-names   - Only clocks/clock-names from mmi_dc')
+    print('                        --nodes=/amba_pl;mmi_dc#clocks      - Combine whole node and property specs')
     print('\nExamples:')
     print(' With machine argument:')
     print(' lopper -O <output_dir>/ -f --enhanced <path_to_system_top>/system-top.dts <path_to_lopper_gen_dt>/lopper-gen.dts -- xlnx_overlay_pl_dt <machine> <config> <path_to_pl_dtsi>/pl.dtsi')
     print('')
     print(' With automatic platform inference:')
     print(' lopper -O <output_dir>/ -f --enhanced <path_to_system_top>/system-top.dts <path_to_lopper_gen_dt>/lopper-gen.dts -- xlnx_overlay_pl_dt <config> <path_to_pl_dtsi>/pl.dtsi')
-    print('  --firmware-name=<name> - (Optional) Override the default firmware-name in the output')
+    print('')
+    print(' With explicit node selection:')
+    print(' lopper -O <output_dir>/ -f --enhanced system-top.dts out.dts -- xlnx_overlay_pl_dt cortexa78_0 full --nodes="mmi_dc#clocks,clock-names;phy0"')
+
+def parse_node_specs(specs_str):
+    """
+    Parse node specification string into structured format.
+
+    Format: <node-spec>[;<node-spec>;...]
+    Where node-spec is either:
+      - <node>              : Include entire node (path like /amba_pl or label like mmi_dc)
+      - <node>#<prop>[,<prop>,...] : Include only specific properties
+
+    Semicolons separate node specs; commas separate properties within a node spec.
+
+    Args:
+        specs_str: The specification string (value after --nodes=)
+
+    Returns:
+        list of dict: [{'node': str, 'properties': list or None}, ...]
+                      properties is None for whole-node extraction
+
+    Examples:
+        '/amba_pl'                    -> [{'node': '/amba_pl', 'properties': None}]
+        'mmi_dc#clocks,clock-names'   -> [{'node': 'mmi_dc', 'properties': ['clocks', 'clock-names']}]
+        'mmi_dc#clocks;phy0'          -> [{'node': 'mmi_dc', 'properties': ['clocks']},
+                                          {'node': 'phy0', 'properties': None}]
+    """
+    result = []
+
+    # Split on semicolons to get individual node specs
+    node_specs = specs_str.split(';')
+
+    for spec in node_specs:
+        spec = spec.strip()
+        if not spec:
+            continue
+
+        if '#' in spec:
+            # Node with specific properties
+            parts = spec.split('#', 1)
+            node_name = parts[0].strip()
+            props_part = parts[1].strip()
+            props = [p.strip() for p in props_part.split(',') if p.strip()]
+            result.append({'node': node_name, 'properties': props if props else None})
+        else:
+            # Whole node extraction
+            result.append({'node': spec, 'properties': None})
+
+    return result
+
 
 def validate_and_parse_options(options, sdt):
     """
@@ -202,9 +263,12 @@ def validate_and_parse_options(options, sdt):
 
     # Process optional arguments
     firmware_override = None
+    node_specs = None
     for arg in optional_args:
         if arg.startswith("--firmware-name="):
             firmware_override = arg.split("=", 1)[1]
+        elif arg.startswith("--nodes="):
+            node_specs = parse_node_specs(arg.split("=", 1)[1])
 
     # Parse arguments based on count
     try:
@@ -274,7 +338,7 @@ def validate_and_parse_options(options, sdt):
         usage()
         sys.exit(1)
 
-    return platform, config, zynq_platforms, versal_platforms, firmware_override
+    return platform, config, zynq_platforms, versal_platforms, firmware_override, node_specs
 
 def validate_amba_pl_node(amba_node):
     """
@@ -476,18 +540,23 @@ def move_nodes_to_fpga(new_amba_node, fpga_node, node_collections, platform, con
 
     return new_amba_node, fpga_node
 
-def build_overlay_tree(new_amba_node, fpga_node, fpga_node_name, base_tree):
+def build_overlay_tree(new_amba_node, fpga_node, fpga_node_name, base_tree,
+                       user_overlay_files=None):
     """
     Build overlay tree from amba and fpga nodes, establishing overlay relationship.
 
     Creates a new overlay tree, adds nodes, establishes overlay relationship with
-    base tree, reorders nodes, and resolves all references.
+    base tree, reorders nodes, and resolves all references. Also pulls fragments
+    for phandle references and user overlay properties.
 
     Args:
         new_amba_node: The prepared amba node for overlay
         fpga_node: The configured fpga node
         fpga_node_name: The name of the fpga node (e.g., "&fpga" or "&fpga_full")
         base_tree: The base device tree to overlay against
+        user_overlay_files: Optional list of user overlay filenames to pull back
+                            (e.g., ['mmi_dc.dtsi']). If None, pulls all overlay
+                            sources.
 
     Returns:
         LopperTree: The constructed and resolved overlay tree
@@ -504,6 +573,33 @@ def build_overlay_tree(new_amba_node, fpga_node, fpga_node_name, base_tree):
     # Add nodes to overlay_tree
     overlay_tree = overlay_tree + new_amba_node
     overlay_tree = overlay_tree + fpga_node
+
+    # Pull fragments for base tree properties that reference overlay nodes
+    # (e.g., cpus_a78.address-map, imux.interrupt-map referencing PL nodes)
+    ref_fragments = base_tree.fragment_add_for_refs(overlay_tree)
+    if ref_fragments:
+        _info(f"Added {len(ref_fragments)} fragment(s) for phandle references")
+
+    # Pull fragments for user overlay properties
+    # These are properties tagged with _source='overlay:<filename>' during setup
+    if user_overlay_files:
+        for overlay_file in user_overlay_files:
+            src_fragments = base_tree.fragment_add_for_overlay_sources(
+                overlay_tree,
+                source_filter=overlay_file,
+                mode='properties'
+            )
+            if src_fragments:
+                _info(f"Added {len(src_fragments)} fragment(s) for overlay '{overlay_file}'")
+    else:
+        # Pull all overlay-sourced properties
+        src_fragments = base_tree.fragment_add_for_overlay_sources(
+            overlay_tree,
+            source_filter='*',
+            mode='properties'
+        )
+        if src_fragments:
+            _info(f"Added {len(src_fragments)} fragment(s) for user overlay properties")
 
     # Establish overlay relationship to resolve phandle references against base tree
     overlay_tree.overlay_of(base_tree)
@@ -551,6 +647,114 @@ def clean_overlay_properties(overlay_tree):
                 node.delete('status')
         except:
             pass
+
+def resolve_node_by_label_or_path(sdt, node_ref):
+    """
+    Resolve a node reference which may be a path or a label.
+
+    Args:
+        sdt: System device tree object
+        node_ref: Node path (e.g., /amba_pl) or label (e.g., mmi_dc)
+
+    Returns:
+        LopperNode or None: The resolved node, or None if not found
+    """
+    # First try as a direct path
+    if node_ref.startswith('/'):
+        try:
+            return sdt.tree[node_ref]
+        except KeyError:
+            return None
+
+    # Try as a label - first check __symbols__ if present
+    try:
+        symbols = sdt.tree['/__symbols__']
+        for prop in symbols:
+            if prop.name == node_ref:
+                # prop.value is the path
+                path = prop.value[0] if isinstance(prop.value, list) else prop.value
+                return sdt.tree[path]
+    except (KeyError, IndexError, TypeError):
+        pass
+
+    # Fallback: iterate through all nodes checking their labels
+    # This handles cases where __symbols__ isn't present (e.g., source DTS files)
+    for node in sdt.tree:
+        if node.label == node_ref:
+            return node
+
+    return None
+
+
+def build_overlay_from_node_specs(sdt, node_specs, base_tree):
+    """
+    Build an overlay tree from explicit node specifications.
+
+    This is an alternative to the default /amba_pl extraction, allowing users
+    to specify exactly which nodes and/or properties should be in the overlay.
+
+    Args:
+        sdt: System device tree object
+        node_specs: List of node specs from parse_node_specs()
+                    [{'node': str, 'properties': list or None}, ...]
+        base_tree: The base tree to establish overlay relationship with
+
+    Returns:
+        LopperTree: The constructed overlay tree
+    """
+    overlay_tree = LopperTree()
+
+    for spec in node_specs:
+        node_ref = spec['node']
+        properties = spec['properties']
+
+        node = resolve_node_by_label_or_path(sdt, node_ref)
+        if node is None:
+            _warning(f"Node '{node_ref}' not found in device tree, skipping")
+            continue
+
+        if properties is None:
+            # Whole node extraction - clone the node for overlay
+            if not node.label:
+                _warning(f"Node '{node_ref}' has no label, cannot create overlay fragment")
+                continue
+
+            # Create overlay fragment reference
+            fragment = LopperNode(name="&" + node.label)
+            fragment.label = ""
+
+            # Copy all properties (except structural ones)
+            skip_props = {'phandle', 'linux,phandle', '#address-cells', '#size-cells',
+                          'ranges', 'compatible'}
+            for prop in node:
+                if prop.name not in skip_props and not prop.name.startswith('lopper-'):
+                    new_prop = copy.deepcopy(prop)
+                    new_prop.node = fragment
+                    fragment.__props__[prop.name] = new_prop
+
+            overlay_tree.add(fragment)
+            _info(f"Added overlay fragment for entire node '{node.label}'")
+
+        else:
+            # Property-specific extraction
+            if not node.label:
+                _warning(f"Node '{node_ref}' has no label, cannot create overlay fragment")
+                continue
+
+            # Use fragment_create from tree.py which handles companions
+            fragment = base_tree.fragment_create(node, properties, include_companions=True)
+            if fragment:
+                overlay_tree.add(fragment)
+                _info(f"Added overlay fragment for '{node.label}' with properties: {properties}")
+            else:
+                _warning(f"No matching properties found for '{node_ref}#{','.join(properties)}'")
+
+    # Establish overlay relationship for phandle resolution
+    overlay_tree.overlay_of(base_tree)
+    overlay_tree.resolve()
+
+    return overlay_tree
+
 
 def write_output_files(overlay_tree, sdt, pl_file, dtso_file):
     """
@@ -607,46 +811,67 @@ Output:
 def xlnx_generate_overlay_dt(tgt_node, sdt, options):
     _level(utils.log_setup(options), __name__)
     # Parse and validate options
-    platform, config, zynq_platforms, versal_platforms, firmware_override = validate_and_parse_options(options, sdt)
+    platform, config, zynq_platforms, versal_platforms, firmware_override, node_specs = validate_and_parse_options(options, sdt)
 
     overlay_tree = LopperTree()
 
     print("Starting overlay generation...")
 
-    # Extract the /amba_pl node from sdt.tree
-    amba_node = sdt.tree["/amba_pl"]
+    # Get user overlay files that were identified during setup
+    # These are -i files containing &label { } syntax
+    # The _overlay_targets dict has overlay filenames as keys
+    overlay_targets = getattr(sdt, '_overlay_targets', None)
+    user_overlay_files = list(overlay_targets.keys()) if overlay_targets else None
+    if user_overlay_files:
+        _info(f"User overlay files to pull back: {user_overlay_files}")
 
-    # Validate that amba_pl has valid PL nodes with register properties
-    if not validate_amba_pl_node(amba_node):
-        return True
+    # Check if explicit node selection was provided
+    if node_specs:
+        # Use explicit node specifications - completely overrides default behavior
+        _info(f"Using explicit node selection: {node_specs}")
+        overlay_tree = build_overlay_from_node_specs(sdt, node_specs, sdt.tree)
 
-    # Prepare amba node for overlay
-    new_amba_node = prepare_amba_node(amba_node, sdt, tgt_node)
+        if len(overlay_tree.__nodes__) == 0:
+            _error("No valid overlay nodes created from --nodes specification")
+            return True
 
-    # Extract firmware-name property from amba node and remove it from amba node
-    firmware_name = new_amba_node["firmware-name"]
-    new_amba_node = new_amba_node - firmware_name
+    else:
+        # Default behavior: extract /amba_pl node
+        # Extract the /amba_pl node from sdt.tree
+        amba_node = sdt.tree["/amba_pl"]
 
-    # Override firmware name if provided via command line
-    if firmware_override:
-        firmware_name.value = [firmware_override]
+        # Validate that amba_pl has valid PL nodes with register properties
+        if not validate_amba_pl_node(amba_node):
+            return True
 
-    # Create and configure FPGA node
-    fpga_node, fpga_node_name = create_fpga_node(
-        platform, config, firmware_name, zynq_platforms, versal_platforms
-    )
+        # Prepare amba node for overlay
+        new_amba_node = prepare_amba_node(amba_node, sdt, tgt_node)
 
-    # Collect special nodes from amba node
-    node_collections = collect_special_nodes(new_amba_node)
+        # Extract firmware-name property from amba node and remove it from amba node
+        firmware_name = new_amba_node["firmware-name"]
+        new_amba_node = new_amba_node - firmware_name
 
-    # Move special nodes to fpga node based on platform and configuration
-    new_amba_node, fpga_node = move_nodes_to_fpga(
-        new_amba_node, fpga_node, node_collections,
-        platform, config, zynq_platforms
-    )
+        # Override firmware name if provided via command line
+        if firmware_override:
+            firmware_name.value = [firmware_override]
 
-    # Build overlay tree
-    overlay_tree = build_overlay_tree(new_amba_node, fpga_node, fpga_node_name, sdt.tree)
+        # Create and configure FPGA node
+        fpga_node, fpga_node_name = create_fpga_node(
+            platform, config, firmware_name, zynq_platforms, versal_platforms
+        )
+
+        # Collect special nodes from amba node
+        node_collections = collect_special_nodes(new_amba_node)
+
+        # Move special nodes to fpga node based on platform and configuration
+        new_amba_node, fpga_node = move_nodes_to_fpga(
+            new_amba_node, fpga_node, node_collections,
+            platform, config, zynq_platforms
+        )
+
+        # Build overlay tree with user overlay content
+        overlay_tree = build_overlay_tree(new_amba_node, fpga_node, fpga_node_name, sdt.tree,
+                                          user_overlay_files=user_overlay_files)
 
     # Clean overlay properties
     clean_overlay_properties(overlay_tree)

--- a/lopper/assists/xlnx_overlay_pl_dt.py
+++ b/lopper/assists/xlnx_overlay_pl_dt.py
@@ -160,6 +160,12 @@ def usage():
     print('                        --nodes=/amba_pl                    - Extract entire /amba_pl node')
     print('                        --nodes=mmi_dc#clocks,clock-names   - Only clocks/clock-names from mmi_dc')
     print('                        --nodes=/amba_pl;mmi_dc#clocks      - Combine whole node and property specs')
+    print('  --exclude-props=<prop>[,<prop>,...] - Comma-separated list of properties to exclude from overlay')
+    print('                      These properties will be removed from the generated overlay output.')
+    print('                      Example: --exclude-props=address-map,interrupt-map')
+    print('  --exclude-nodes=<node>[,<node>,...] - Comma-separated list of node paths/labels to exclude')
+    print('                      These nodes will be removed from the generated overlay output.')
+    print('                      Example: --exclude-nodes=/amba_pl/some_node')
     print('\nExamples:')
     print(' With machine argument:')
     print(' lopper -O <output_dir>/ -f --enhanced <path_to_system_top>/system-top.dts <path_to_lopper_gen_dt>/lopper-gen.dts -- xlnx_overlay_pl_dt <machine> <config> <path_to_pl_dtsi>/pl.dtsi')
@@ -264,11 +270,17 @@ def validate_and_parse_options(options, sdt):
     # Process optional arguments
     firmware_override = None
     node_specs = None
+    exclude_props = None
+    exclude_nodes = None
     for arg in optional_args:
         if arg.startswith("--firmware-name="):
             firmware_override = arg.split("=", 1)[1]
         elif arg.startswith("--nodes="):
             node_specs = parse_node_specs(arg.split("=", 1)[1])
+        elif arg.startswith("--exclude-props="):
+            exclude_props = [p.strip() for p in arg.split("=", 1)[1].split(",") if p.strip()]
+        elif arg.startswith("--exclude-nodes="):
+            exclude_nodes = [n.strip() for n in arg.split("=", 1)[1].split(",") if n.strip()]
 
     # Parse arguments based on count
     try:
@@ -338,7 +350,7 @@ def validate_and_parse_options(options, sdt):
         usage()
         sys.exit(1)
 
-    return platform, config, zynq_platforms, versal_platforms, firmware_override, node_specs
+    return platform, config, zynq_platforms, versal_platforms, firmware_override, node_specs, exclude_props, exclude_nodes
 
 def validate_amba_pl_node(amba_node):
     """
@@ -541,7 +553,7 @@ def move_nodes_to_fpga(new_amba_node, fpga_node, node_collections, platform, con
     return new_amba_node, fpga_node
 
 def build_overlay_tree(new_amba_node, fpga_node, fpga_node_name, base_tree,
-                       user_overlay_files=None):
+                       user_overlay_files=None, exclude_props=None, exclude_nodes=None):
     """
     Build overlay tree from amba and fpga nodes, establishing overlay relationship.
 
@@ -599,7 +611,7 @@ def build_overlay_tree(new_amba_node, fpga_node, fpga_node_name, base_tree,
             _info(f"Added {len(src_fragments)} fragment(s) for user overlay properties")
 
     # Establish overlay relationship to resolve phandle references against base tree
-    overlay_tree.overlay_of(base_tree)
+    overlay_tree.overlay_of(base_tree, exclude_props=exclude_props, exclude_nodes=exclude_nodes)
 
     # Reorder nodes: fpga node should come after amba node
     try:
@@ -683,7 +695,7 @@ def resolve_node_by_label_or_path(sdt, node_ref):
     return None
 
 
-def build_overlay_from_node_specs(sdt, node_specs, base_tree):
+def build_overlay_from_node_specs(sdt, node_specs, base_tree, exclude_props=None, exclude_nodes=None):
     """
     Build an overlay tree from explicit node specifications.
 
@@ -747,7 +759,7 @@ def build_overlay_from_node_specs(sdt, node_specs, base_tree):
                 _warning(f"No matching properties found for '{node_ref}#{','.join(properties)}'")
 
     # Establish overlay relationship for phandle resolution
-    overlay_tree.overlay_of(base_tree)
+    overlay_tree.overlay_of(base_tree, exclude_props=exclude_props, exclude_nodes=exclude_nodes)
     overlay_tree.resolve()
 
     return overlay_tree
@@ -808,7 +820,7 @@ Output:
 def xlnx_generate_overlay_dt(tgt_node, sdt, options):
     _level(utils.log_setup(options), __name__)
     # Parse and validate options
-    platform, config, zynq_platforms, versal_platforms, firmware_override, node_specs = validate_and_parse_options(options, sdt)
+    platform, config, zynq_platforms, versal_platforms, firmware_override, node_specs, exclude_props, exclude_nodes = validate_and_parse_options(options, sdt)
 
     overlay_tree = LopperTree()
 
@@ -826,7 +838,8 @@ def xlnx_generate_overlay_dt(tgt_node, sdt, options):
     if node_specs:
         # Use explicit node specifications - completely overrides default behavior
         _info(f"Using explicit node selection: {node_specs}")
-        overlay_tree = build_overlay_from_node_specs(sdt, node_specs, sdt.tree)
+        overlay_tree = build_overlay_from_node_specs(sdt, node_specs, sdt.tree,
+                                                     exclude_props=exclude_props, exclude_nodes=exclude_nodes)
 
         if len(overlay_tree.__nodes__) == 0:
             _error("No valid overlay nodes created from --nodes specification")
@@ -868,7 +881,8 @@ def xlnx_generate_overlay_dt(tgt_node, sdt, options):
 
         # Build overlay tree with user overlay content
         overlay_tree = build_overlay_tree(new_amba_node, fpga_node, fpga_node_name, sdt.tree,
-                                          user_overlay_files=user_overlay_files)
+                                          user_overlay_files=user_overlay_files,
+                                          exclude_props=exclude_props, exclude_nodes=exclude_nodes)
 
     # Clean overlay properties
     clean_overlay_properties(overlay_tree)
@@ -880,6 +894,16 @@ def xlnx_generate_overlay_dt(tgt_node, sdt, options):
 
     # Write output files and perform post-processing
     write_output_files(overlay_tree, sdt, pl_file, dtso_file)
+
+    # Write the main SDT output in base view so overlay-originated property
+    # values (e.g., address-map, interrupt-map from cpus_a78) do not bleed
+    # into the no-pl SDT output.  We write it here with an explicit view
+    # context and clear sdt.output_file so the main lopper loop does not
+    # write a second (unviewed) copy.
+    if getattr(sdt, '_overlay_targets', None) and sdt.output_file:
+        with sdt.tree.view('base'):
+            sdt.write()
+        sdt.output_file = ""
 
     print("Overlay generation completed successfully!")
     return True

--- a/lopper/assists/xlnx_overlay_pl_dt.py
+++ b/lopper/assists/xlnx_overlay_pl_dt.py
@@ -574,14 +574,11 @@ def build_overlay_tree(new_amba_node, fpga_node, fpga_node_name, base_tree,
     overlay_tree = overlay_tree + new_amba_node
     overlay_tree = overlay_tree + fpga_node
 
-    # Pull fragments for base tree properties that reference overlay nodes
-    # (e.g., cpus_a78.address-map, imux.interrupt-map referencing PL nodes)
-    ref_fragments = base_tree.fragment_add_for_refs(overlay_tree)
-    if ref_fragments:
-        _info(f"Added {len(ref_fragments)} fragment(s) for phandle references")
-
     # Pull fragments for user overlay properties
     # These are properties tagged with _source='overlay:<filename>' during setup
+    # Note: fragments for base tree phandle refs (e.g., cpus_a78.address-map)
+    # are handled automatically by overlay_of() below — no need to call
+    # fragment_add_for_refs() here.
     if user_overlay_files:
         for overlay_file in user_overlay_files:
             src_fragments = base_tree.fragment_add_for_overlay_sources(

--- a/lopper/assists/yaml_to_dts_expansion.py
+++ b/lopper/assists/yaml_to_dts_expansion.py
@@ -249,7 +249,7 @@ def wildcard_devices( tree, domains_node ):
         try:
             compat = sibling["compatible"].value
             if isinstance(compat, list):
-                compat = ','.join(compat)
+                compat = ','.join(str(item) for item in compat)
             if ',devices' in compat:
                 devices_domain = sibling
                 _debug( f"found devices domain: {devices_domain.abs_path}" )
@@ -262,9 +262,12 @@ def wildcard_devices( tree, domains_node ):
         d_parent = domain_parent( domain )
         if d_parent:
             d_parent_path = d_parent.value
+            # .value returns a list; extract the first element as the path string
+            if isinstance(d_parent_path, list):
+                d_parent_path = d_parent_path[0] if d_parent_path else None
             if d_parent_path == "auto":
                 return infer_parent_domain( tree, domain )
-            else:
+            elif d_parent_path:
                 try:
                     if d_parent_path.startswith('/'):
                         return tree[d_parent_path]

--- a/lopper/base.py
+++ b/lopper/base.py
@@ -644,6 +644,59 @@ class lopper_base:
         except:
             return {}
 
+    @classmethod
+    def phandle_companion_properties(cls):
+        """Get the dictionary mapping phandle properties to companion -names properties
+
+        Many phandle-containing properties have an associated -names property that
+        provides string identifiers for each phandle entry by index. When manipulating
+        phandle properties (e.g., creating overlay fragments), the companion -names
+        property should be included to maintain consistency.
+
+        Args:
+            None
+
+        Returns:
+            dict: Mapping of phandle property name to its companion -names property.
+                  Only includes properties that have a standard companion.
+
+        Example:
+            >>> lopper_base.phandle_companion_properties()
+            {'clocks': 'clock-names', 'resets': 'reset-names', ...}
+        """
+        return {
+            "clocks": "clock-names",
+            "resets": "reset-names",
+            "dmas": "dma-names",
+            "mboxes": "mbox-names",
+            "phys": "phy-names",
+            "pwms": "pwm-names",
+            "gpios": "gpio-names",
+            "interrupts-extended": "interrupt-names",
+            "power-domains": "power-domain-names",
+            "mbox-names": "mboxes",  # reverse mapping
+            "clock-names": "clocks",
+            "reset-names": "resets",
+            "dma-names": "dmas",
+            "phy-names": "phys",
+            "pwm-names": "pwms",
+            "gpio-names": "gpios",
+            "interrupt-names": "interrupts-extended",
+            "power-domain-names": "power-domains",
+        }
+
+    @classmethod
+    def phandle_property_companion(cls, prop_name):
+        """Get the companion property name for a phandle or -names property
+
+        Args:
+            prop_name (str): The property name to look up
+
+        Returns:
+            str or None: The companion property name, or None if no companion exists
+        """
+        return cls.phandle_companion_properties().get(prop_name)
+
     @staticmethod
     def phandle_safe_name( phandle_name ):
         """Make the passed name safe to use as a phandle label/reference

--- a/lopper/tree.py
+++ b/lopper/tree.py
@@ -5973,7 +5973,17 @@ class LopperTree:
         if self.__new_iteration__:
             self.__new_iteration__ = False
 
-            child_nodes = self.subnodes( self.__nodes__[ "/"] )
+            if "/" in self.__nodes__:
+                child_nodes = self.subnodes( self.__nodes__[ "/"] )
+            else:
+                # Rootless tree (e.g. compiled overlay DTB): top-level nodes have
+                # no parent or a parent path of "/".  Collect them all and walk their
+                # subtrees so normal iteration works on fragment@N / __fixups__ etc.
+                top_nodes = [ n for n in self.__nodes__.values()
+                               if n.parent is None or n.parent.abs_path == "/" ]
+                child_nodes = []
+                for n in top_nodes:
+                    child_nodes.extend( self.subnodes(n) )
             self.__node_iter__ = iter( child_nodes )
 
             if self.__current_node__ == "/" and self.__start_node__ == "/":

--- a/lopper/tree.py
+++ b/lopper/tree.py
@@ -732,7 +732,7 @@ class LopperProp():
 
         return ret_val
 
-    def phandle_map( self, tag_invalid = True ):
+    def phandle_map( self, tag_invalid = True, context_trees=None ):
         """Determines the phandle elements/params of a property
 
         Takes a property name and returns a list of lists, where phandles are
@@ -740,6 +740,8 @@ class LopperProp():
 
         Args:
             tag_invalid (bool): default True. Whether or not invalid phandles should be indicated with "invald"
+            context_trees (list, optional): Additional trees to search for phandle resolution.
+                                            Useful for cross-tree resolution (e.g., overlay referencing base).
 
         Returns:
             A list / map of values. Where 0 in the list means no phandle, and
@@ -912,7 +914,7 @@ class LopperProp():
                     if len(derefs) >= 2:
                         # step 1) lookup the node
                         if self.node and self.node.tree:
-                            node_deref = self.node.tree.deref( val )
+                            node_deref = self.node.tree.deref( val, context_trees=context_trees )
                         else:
                             # if we aren't in a tree, we really can't continue since
                             # whatever we do will be wrong, just return an empty
@@ -1054,7 +1056,7 @@ class LopperProp():
             for p in property_val_group:
                 if property_chunk_idx in phandle_index_list:
                     if self.node and self.node.tree:
-                        node_deref = self.node.tree.deref( p )
+                        node_deref = self.node.tree.deref( p, context_trees=context_trees )
                         # This second check is currently disabled as it impacts runtime
                         # significantly. If the pattern learning isn't sufficient, this
                         # can be re-enabled
@@ -2497,7 +2499,7 @@ class LopperNode(object):
 
         return flat_list
 
-    def node_refs( self, search_tree=None ):
+    def node_refs( self, search_tree=None, context_trees=None ):
         """Find all properties in a tree that reference this node
 
         Scans all properties in the search tree (or this node's tree if not
@@ -2505,12 +2507,14 @@ class LopperNode(object):
         node. This is the reverse of resolve_all_refs() - instead of finding
         what this node references, it finds what references this node.
 
-        This method works even if the target node has been removed from the
-        search tree, by checking raw property values for phandle matches.
-
         Args:
             search_tree (LopperTree, optional): The tree to search for references.
                                                 If None, uses this node's tree.
+            context_trees (list, optional): Additional trees for phandle resolution.
+                                            If None, defaults to [self.tree] to enable
+                                            cross-tree reference detection (e.g., finding
+                                            base tree properties that reference overlay nodes).
+                                            Pass [] to disable cross-tree resolution.
 
         Returns:
             list of tuples: [(node, prop_name, companion_prop_name or None), ...]
@@ -2525,7 +2529,10 @@ class LopperNode(object):
         if self.phandle is None or self.phandle <= 0:
             return []
 
-        target_phandle = self.phandle
+        # Default context_trees to [self.tree] for cross-tree resolution
+        if context_trees is None:
+            context_trees = [self.tree] if self.tree else []
+
         referencing_props = []
 
         # Get the list of property names that can contain phandles
@@ -2545,27 +2552,22 @@ class LopperNode(object):
                 if prop.name not in phandle_props:
                     continue
 
-                # Use phandle_map() to identify phandle positions in the property
-                # Then check if any position contains our target_phandle value
+                # Use phandle_map() with context_trees to resolve phandles
+                # across trees. Non-zero entries are resolved nodes.
                 try:
-                    phandle_records = prop.phandle_map()
+                    phandle_records = prop.phandle_map(context_trees=context_trees)
+                    if not phandle_records:
+                        continue
 
-                    # phandle_map returns list of records, each record is a sublist
-                    # where the first element is the node (or #invalid) and remaining
-                    # elements are 0 for non-phandle cells
-                    # We need to check if any raw phandle value matches target_phandle
+                    # Check if any cell resolved to self
                     found_ref = False
-                    prop_val_idx = 0
                     for record in phandle_records:
-                        # First element is the phandle position
-                        # Even if it resolved to #invalid, check the raw value
-                        if prop_val_idx < len(prop.value):
-                            raw_phandle = prop.value[prop_val_idx]
-                            if raw_phandle == target_phandle:
+                        for cell in record:
+                            if cell != 0 and cell != "#invalid" and cell is self:
                                 found_ref = True
                                 break
-                        # Advance by record length
-                        prop_val_idx += len(record)
+                        if found_ref:
+                            break
 
                     if found_ref:
                         companion = lopper.base.lopper_base.phandle_property_companion(prop.name)
@@ -4562,7 +4564,15 @@ class LopperTree:
             parent_tree._metadata['child_trees'].append(self)
             lopper.log._debug( f"Registered overlay '{name}' with parent tree" )
 
-        # Apply property filtering if requested
+        # Auto-generate fragments for base tree properties that reference overlay nodes
+        # This ensures cross-tree references remain valid when the overlay is applied
+        # Done BEFORE filtering so exclude_props/exclude_nodes can filter fragment content too
+        auto_fragments = parent_tree.fragment_add_for_refs(self)
+        self._metadata['auto_fragments'] = auto_fragments
+        if auto_fragments:
+            lopper.log._debug( f"Auto-generated {len(auto_fragments)} fragment(s) for cross-tree references" )
+
+        # Apply property filtering if requested (runs after fragment generation)
         if exclude_props:
             for node in self:
                 for prop_name in exclude_props:
@@ -4570,7 +4580,7 @@ class LopperTree:
                         del node.__props__[prop_name]
                         lopper.log._debug( f"Removed property '{prop_name}' from {node.abs_path}" )
 
-        # Apply node filtering if requested
+        # Apply node filtering if requested (runs after fragment generation)
         if exclude_nodes:
             for pattern in exclude_nodes:
                 for node in list(self.nodes(pattern)):
@@ -4674,23 +4684,48 @@ class LopperTree:
         overlay nodes will have their complete values restored (rather than
         having invalid phandle references stripped during output).
 
+        Dangling Phandle Handling:
+            After nodes are extracted to an overlay, the base tree may contain
+            properties with phandle references to those (now missing) nodes.
+            This function does NOT remove those properties from the base tree.
+            Instead, Lopper's write-time strict mode drops properties containing
+            invalid phandle references. The workflow is:
+
+            1. Fragment is created containing the referencing property
+            2. Base tree retains property with (now dangling) phandle
+            3. On write, Lopper drops properties with invalid phandles from base
+            4. Result: property exists only in overlay (via fragment)
+
+            When the overlay is applied, the fragment restores the property with
+            valid phandle references.
+
+        Filtering Behavior:
+            If overlay_of() is called with exclude_props that filter a fragment
+            property, the property is removed from the fragment. Since the base
+            tree's dangling reference is also dropped at write time, the property
+            is effectively discarded from both trees - this is intentional when
+            filtering is requested.
+
         Args:
             overlay_tree (LopperTree): The overlay tree to add fragments to.
                                        Modified in place.
 
         Returns:
-            int: Number of fragments added
+            list: List of fragment nodes that were added to overlay_tree.
+                  Empty list if no fragments were needed.
 
         Example:
             # After extracting /amba_pl to overlay:
             # Find base tree props referencing overlay and add fragments
-            num_added = base_tree.fragment_add_for_refs(overlay_tree)
+            fragments = base_tree.fragment_add_for_refs(overlay_tree)
+            for frag in fragments:
+                print(f"Added fragment for {frag['target-path'].value[0]}")
         """
         # Find properties that reference the overlay
         referencing = self.tree_refs(overlay_tree)
 
         if not referencing:
-            return 0
+            return []
 
         # Group by node to create one fragment per node
         node_props = {}
@@ -4703,7 +4738,7 @@ class LopperTree:
                 node_props[key]['props'].add(companion)
 
         # Create fragments and add to overlay
-        fragments_added = 0
+        fragments_added = []
         for path, info in node_props.items():
             node = info['node']
             props = list(info['props'])
@@ -4712,10 +4747,124 @@ class LopperTree:
                 fragment = self.fragment_create(node, props)
                 if fragment:
                     overlay_tree.add(fragment)
-                    fragments_added += 1
+                    fragments_added.append(fragment)
                     lopper.log._info(f"Added overlay fragment for {node.label} with properties: {props}")
             except Exception as e:
                 lopper.log._warning(f"Failed to create overlay fragment for {node.abs_path}: {e}")
+
+        return fragments_added
+
+    def fragment_add_for_overlay_sources( self, overlay_tree, source_filter='*',
+                                          mode='properties' ):
+        """Add overlay fragments for properties that came from user overlays.
+
+        Scans this tree (the base tree) for properties that have a _source
+        attribute indicating they came from a user overlay file. Creates
+        overlay fragments containing those properties.
+
+        This complements fragment_add_for_refs() which handles phandle
+        references. Together they ensure that:
+        1. Properties referencing overlay nodes are pulled into fragments
+        2. Properties from user overlays are also pulled into fragments
+
+        Args:
+            overlay_tree (LopperTree): The overlay tree to add fragments to.
+                                       Modified in place.
+            source_filter: Filter for which overlay sources to include.
+                '*' - all overlay sources (default)
+                'mmi_dc.dtsi' - specific overlay filename
+                ['a.dtsi', 'b.dtsi'] - list of overlay filenames
+            mode: How to handle properties from matching overlays.
+                'properties' - only include properties with matching _source
+                'full_nodes' - include ALL properties from nodes that have
+                               any property with matching _source
+
+        Returns:
+            list: List of fragment nodes that were added to overlay_tree.
+                  Empty list if no fragments were needed.
+
+        Example:
+            # After extracting PL nodes to overlay, also pull user overlay content:
+            base_tree.fragment_add_for_refs(overlay_tree)  # phandle refs
+            base_tree.fragment_add_for_overlay_sources(
+                overlay_tree,
+                source_filter='mmi_dc.dtsi',
+                mode='properties'
+            )
+        """
+        # Find nodes with overlay-sourced properties
+        nodes_with_sources = self.nodes_with_overlay_sources(source_filter)
+
+        if not nodes_with_sources:
+            return []
+
+        # Group by node and determine which properties to include
+        node_props = {}
+        for node, overlay_props in nodes_with_sources:
+            key = node.abs_path
+
+            if mode == 'full_nodes':
+                # Include ALL properties from the node
+                all_prop_names = list(node.__props__.keys())
+                # Filter out internal properties
+                props_to_include = [p for p in all_prop_names
+                                    if not p.startswith('lopper-') and p != 'phandle']
+            else:
+                # mode == 'properties': only include overlay-sourced properties
+                props_to_include = [prop_name for prop_name, source in overlay_props]
+
+            if key not in node_props:
+                node_props[key] = {'node': node, 'props': set()}
+            node_props[key]['props'].update(props_to_include)
+
+        # Create fragments and add to overlay
+        fragments_added = []
+        for path, info in node_props.items():
+            node = info['node']
+            props = list(info['props'])
+
+            # Skip if node has no label (can't create fragment reference)
+            if not node.label:
+                lopper.log._debug(f"Skipping {node.abs_path}: no label for fragment reference")
+                continue
+
+            # Check if a fragment for this node already exists in overlay
+            # (may have been created by fragment_add_for_refs)
+            # Use __nodes__ dict directly to avoid disturbing iterator state
+            existing_fragment = None
+            fragment_name = "&" + node.label
+            for overlay_node in overlay_tree.__nodes__.values():
+                if overlay_node.name == fragment_name:
+                    existing_fragment = overlay_node
+                    break
+
+            if existing_fragment:
+                # Merge properties into existing fragment
+                props_added = 0
+                for prop_name in props:
+                    if prop_name not in existing_fragment.__props__:
+                        try:
+                            prop = node[prop_name]
+                            if prop:
+                                new_prop = copy.deepcopy(prop)
+                                new_prop.node = existing_fragment
+                                existing_fragment.__props__[prop_name] = new_prop
+                                props_added += 1
+                        except (KeyError, TypeError):
+                            pass
+
+                if props_added > 0:
+                    lopper.log._info(f"Merged {props_added} overlay-sourced properties into existing fragment for {node.label}")
+            else:
+                # Create new fragment
+                try:
+                    fragment = self.fragment_create(node, props)
+                    if fragment:
+                        overlay_tree.add(fragment)
+                        fragments_added.append(fragment)
+                        lopper.log._info(f"Added overlay fragment for {node.label} with overlay-sourced properties: {props}")
+                except Exception as e:
+                    lopper.log._warning(f"Failed to create overlay fragment for {node.abs_path}: {e}")
 
         return fragments_added
 
@@ -5583,13 +5732,15 @@ class LopperTree:
         return matches
 
 
-    def deref( self, phandle_or_label_or_alias ):
+    def deref( self, phandle_or_label_or_alias, context_trees=None ):
         """Find a node by a phandle or label
 
         dereferences a phandle or label to find the target node.
 
         Args:
            phandle_or_label_or_alias (int or string)
+           context_trees (list, optional): Additional trees to search for resolution.
+                                           These are checked after self and _external_trees.
 
         Returns:
            LopperNode: the matching node if found, None otherwise
@@ -5598,7 +5749,9 @@ class LopperTree:
         try:
             tgn = None
             trees_to_check = [ self ] + self._external_trees
-            for t in [ self ] + self._external_trees:
+            if context_trees:
+                trees_to_check = trees_to_check + context_trees
+            for t in trees_to_check:
                 try:
                     if tgn:
                         break

--- a/lopper/tree.py
+++ b/lopper/tree.py
@@ -1556,7 +1556,18 @@ class LopperProp():
                 formatted_records = []
                 phandle_record = []
                 if phandle_map:
+                    # Get companion property for syncing when records are dropped
+                    companion_val = None
+                    companion_prop = None
+                    if self.node:
+                        companion_name = lopper.base.lopper_base.phandle_property_companion(self.name)
+                        if companion_name and companion_name in self.node.__props__:
+                            companion_prop = self.node.__props__[companion_name]
+                            if isinstance(companion_prop.value, (list, tuple)):
+                                companion_val = list(companion_prop.value)
+
                     pval_index = 0
+                    kept_companion = []
                     # each entry in the phandle map list, is a "record" in the phandle
                     # list.
                     for rnum,record in enumerate(phandle_map):
@@ -1652,6 +1663,14 @@ class LopperProp():
                                     formatted_records.append( ",\n" )
                                 else:
                                     formatted_records.append( ";" )
+
+                            # Track kept companion entries
+                            if companion_val is not None and rnum < len(companion_val):
+                                kept_companion.append(companion_val[rnum])
+
+                    # Update companion property with kept entries
+                    if companion_prop is not None:
+                        companion_prop.value = kept_companion
                 else:
                     # no phandles
                     if resolver_type:
@@ -2471,6 +2490,66 @@ class LopperNode(object):
                     flat_list.append(sublist)
 
         return flat_list
+
+    def node_refs( self, search_tree=None ):
+        """Find all properties in a tree that reference this node
+
+        Scans all properties in the search tree (or this node's tree if not
+        specified) and returns those that contain phandle references to this
+        node. This is the reverse of resolve_all_refs() - instead of finding
+        what this node references, it finds what references this node.
+
+        This method works even if the target node has been removed from the
+        search tree, by checking raw property values for phandle matches.
+
+        Args:
+            search_tree (LopperTree, optional): The tree to search for references.
+                                                If None, uses this node's tree.
+
+        Returns:
+            list of tuples: [(node, prop_name, companion_prop_name or None), ...]
+                           where companion_prop_name is the associated -names
+                           property if one exists (e.g., clock-names for clocks)
+        """
+        if search_tree is None:
+            if self.tree is None:
+                return []
+            search_tree = self.tree
+
+        if self.phandle is None or self.phandle <= 0:
+            return []
+
+        target_phandle = self.phandle
+        referencing_props = []
+
+        # Get the list of property names that can contain phandles
+        phandle_props = lopper.base.lopper_base.phandle_possible_properties()
+
+        for node in search_tree:
+            # Don't include self-references
+            if node.abs_path == self.abs_path:
+                continue
+
+            for prop in node:
+                # Skip internal/structural properties
+                if prop.name.startswith('lopper-') or prop.name == 'phandle':
+                    continue
+
+                # Only check properties that can contain phandles
+                if prop.name not in phandle_props:
+                    continue
+
+                # Use resolve_phandles() to get actual phandle targets,
+                # avoiding false positives from matching non-phandle integers
+                try:
+                    phandle_targets = prop.resolve_phandles()
+                    if self in phandle_targets:
+                        companion = lopper.base.lopper_base.phandle_property_companion(prop.name)
+                        referencing_props.append((node, prop.name, companion))
+                except Exception:
+                    continue
+
+        return referencing_props
 
     def property_find(self, prop_name, inherit=True):
         """Find a property, optionally walking up the parent chain.
@@ -4251,6 +4330,148 @@ class LopperTree:
         # store the parent tree, this is used for resolving
         # lables and phandles before printing
         self._external_trees.append(parent_tree)
+
+    def tree_refs( self, target_tree ):
+        """Find properties in this tree that reference nodes in target_tree
+
+        Scans all nodes in target_tree and uses each node's node_refs()
+        method to find properties in this tree that reference them. This is
+        useful for finding properties that will become invalid when target_tree
+        nodes are extracted into an overlay.
+
+        Args:
+            target_tree (LopperTree): The tree containing nodes that might
+                                      be referenced
+
+        Returns:
+            list of tuples: [(node, prop_name, companion_prop_name or None), ...]
+                           where companion_prop_name is the associated -names
+                           property if one exists (e.g., clock-names for clocks)
+        """
+        referencing_props = []
+
+        # For each node in target_tree, find properties in self that reference it
+        for target_node in target_tree:
+            refs = target_node.node_refs(self)
+            referencing_props.extend(refs)
+
+        return referencing_props
+
+    def fragment_create( self, source_node, property_names, include_companions=True ):
+        """Create an overlay fragment node with only specified properties
+
+        Creates an overlay fragment (a node using &label syntax) containing
+        only the specified properties from the source node. This is used to
+        create partial overlays where only certain properties need to override
+        the base tree.
+
+        Args:
+            source_node (LopperNode): The node to extract properties from
+            property_names (list): List of property names to include
+            include_companions (bool): If True, automatically include companion
+                                       -names properties (e.g., clock-names
+                                       when clocks is specified)
+
+        Returns:
+            LopperNode: The created fragment node, or None if source_node has
+                        no label or no properties were found
+
+        Example:
+            # Create fragment: &mmi_dc { clocks = <...>; clock-names = "..."; };
+            fragment = tree.fragment_create(mmi_dc_node, ["clocks"])
+        """
+        if not source_node.label:
+            lopper.log._warning(f"Node {source_node.abs_path} has no label, cannot create overlay fragment")
+            return None
+
+        # Expand property list to include companions
+        all_props = set(property_names)
+        if include_companions:
+            for prop_name in property_names:
+                companion = lopper.base.lopper_base.phandle_property_companion(prop_name)
+                if companion:
+                    all_props.add(companion)
+
+        # Create fragment node with reference name
+        fragment_name = "&" + source_node.label
+        fragment = LopperNode(name=fragment_name)
+        fragment.label = ""  # Fragment itself doesn't need a label
+
+        props_added = 0
+        for prop_name in all_props:
+            try:
+                prop = source_node[prop_name]
+                if prop:
+                    # Use deepcopy which handles property copying correctly
+                    # (uses __dict__ assignment to avoid triggering resolution)
+                    new_prop = copy.deepcopy(prop)
+                    new_prop.node = fragment
+                    fragment.__props__[prop_name] = new_prop
+                    props_added += 1
+            except (KeyError, TypeError):
+                pass
+
+        if props_added == 0:
+            return None
+
+        return fragment
+
+    def fragment_add_for_refs( self, overlay_tree ):
+        """Add overlay fragments for properties that reference the overlay
+
+        Scans this tree (the base tree) for properties that contain phandle
+        references to nodes in overlay_tree. For each such property, creates
+        an overlay fragment containing that property (and its companion -names
+        property if applicable) and adds it to the overlay tree.
+
+        This ensures that when the overlay is applied, properties that reference
+        overlay nodes will have their complete values restored (rather than
+        having invalid phandle references stripped during output).
+
+        Args:
+            overlay_tree (LopperTree): The overlay tree to add fragments to.
+                                       Modified in place.
+
+        Returns:
+            int: Number of fragments added
+
+        Example:
+            # After extracting /amba_pl to overlay:
+            # Find base tree props referencing overlay and add fragments
+            num_added = base_tree.fragment_add_for_refs(overlay_tree)
+        """
+        # Find properties that reference the overlay
+        referencing = self.tree_refs(overlay_tree)
+
+        if not referencing:
+            return 0
+
+        # Group by node to create one fragment per node
+        node_props = {}
+        for node, prop_name, companion in referencing:
+            key = node.abs_path
+            if key not in node_props:
+                node_props[key] = {'node': node, 'props': set()}
+            node_props[key]['props'].add(prop_name)
+            if companion:
+                node_props[key]['props'].add(companion)
+
+        # Create fragments and add to overlay
+        fragments_added = 0
+        for path, info in node_props.items():
+            node = info['node']
+            props = list(info['props'])
+
+            try:
+                fragment = self.fragment_create(node, props)
+                if fragment:
+                    overlay_tree.add(fragment)
+                    fragments_added += 1
+                    lopper.log._info(f"Added overlay fragment for {node.label} with properties: {props}")
+            except Exception as e:
+                lopper.log._warning(f"Failed to create overlay fragment for {node.abs_path}: {e}")
+
+        return fragments_added
 
     def phandles( self ):
         """Utility function to get the active phandles in the tree

--- a/lopper/tree.py
+++ b/lopper/tree.py
@@ -4928,6 +4928,79 @@ class LopperTree:
 
         return fragments_added
 
+    def extract_nodes( self, dest_tree, layer_filter='*' ):
+        """Extract nodes into dest_tree based on their _origin_layer.
+
+        Finds top-level nodes in this tree whose _origin_layer matches
+        layer_filter, moves them (deep copy + delete) into dest_tree as real
+        nodes.  Only top-level matching nodes are moved; their children come
+        along automatically via the deep copy.
+
+        This is the node-level complement to fragment_add_for_overlay_sources(),
+        which handles property modifications on existing nodes.  Together they
+        enable full round-trip reconstruction of any layer-tagged content —
+        whether from an overlay applied via -i, a domain split, or any other
+        layer-named operation:
+
+            dest = LopperTree()
+            base_tree.extract_nodes(dest, layer_filter='pl')
+            base_tree.fragment_add_for_overlay_sources(dest, 'pl')
+            dest.overlay_of(base_tree)
+
+        Args:
+            dest_tree (LopperTree): Destination tree.  Modified in place.
+            layer_filter: Layer name stem or filename to match against
+                _origin_layer.  '*' matches any non-internal layer.
+                Accepts a single string or a list of strings.
+                Filenames are stem-matched: 'pl.dtsi' matches layer 'pl'.
+
+        Returns:
+            list: LopperNode objects moved into dest_tree.
+                  Empty list if nothing matched.
+        """
+        _INTERNAL = frozenset(('base', 'modifications'))
+
+        # Normalise filter to a set of stems (or None for wildcard)
+        if layer_filter is None or layer_filter == '*':
+            filter_set = None
+        else:
+            if isinstance(layer_filter, str):
+                layer_filter = [layer_filter]
+            filter_set = {os.path.splitext(f)[0] for f in layer_filter}
+
+        def _matches(origin):
+            if origin is None:
+                return False
+            if filter_set is None:
+                return origin not in _INTERNAL
+            return origin in filter_set
+
+        # Collect top-level matching nodes only (children travel with them)
+        matched = []
+        for node in list(self.__nodes__.values()):
+            if not _matches(node.__dict__.get('_origin_layer')):
+                continue
+            ancestor_matched = False
+            p = node.parent
+            while p is not None:
+                if _matches(p.__dict__.get('_origin_layer')):
+                    ancestor_matched = True
+                    break
+                p = p.parent
+            if not ancestor_matched:
+                matched.append(node)
+
+        moved = []
+        for node in matched:
+            cloned = node()
+            dest_tree.add(cloned)
+            self.delete(node, capture=False)
+            moved.append(cloned)
+            lopper.log._info(f"Extracted node {node.abs_path} "
+                             f"(layer '{node._origin_layer}') to dest tree")
+
+        return moved
+
     def fragment_add_for_overlay_sources( self, overlay_tree, source_filter='*',
                                           mode='properties' ):
         """Add overlay fragments for properties that came from user overlay layers.

--- a/lopper/tree.py
+++ b/lopper/tree.py
@@ -24,6 +24,8 @@ from collections import Counter
 from io import StringIO
 import copy
 import json
+import threading
+from contextlib import contextmanager
 
 import lopper.base
 from lopper.base import lopper_base
@@ -202,12 +204,16 @@ class LopperProp():
 
         self.abs_path = ""
 
-        # Source tracking for overlay provenance
-        # Format: None (base tree), 'overlay:<filename>', 'yaml:<filename>', etc.
-        self._source = None
+        # Layered value storage: layer_name -> (priority, value_list)
+        # Priorities: base=0, overlay layers=500, modifications=1000
+        self._layers = {}
+
+        # Back-reference to the owning LopperNode (set by LopperNode when added)
+        self._node = None
 
         if value == None:
             self.value = []
+            self._layers['base'] = (0, [])
         else:
             # we want to avoid the overriden __setattr__ below
             self.__dict__["value"] = value
@@ -215,6 +221,9 @@ class LopperProp():
             # resolved, it may be used in some sort of test that
             # needs a type
             self.ptype = self.property_type_guess()
+            # Seed base layer with initial value
+            v = value if isinstance(value, list) else [value]
+            self._layers['base'] = (0, v)
 
 
     def __deepcopy__(self, memodict={}):
@@ -255,12 +264,80 @@ class LopperProp():
         new_instance.ptype = self.ptype
         new_instance.binary = self.binary
         new_instance.phandle_resolution = self.phandle_resolution
-        new_instance._source = self._source
+        new_instance._layers = copy.deepcopy(self._layers, memodict)
+        new_instance._node = None  # don't copy the backref; caller sets it
 
         if self.__dbg__ > 1:
             lopper.log._debug( f"property deep copy done: {[self]} ({type(new_instance.value)})({new_instance.value})" )
 
         return new_instance
+
+    # ------------------------------------------------------------------
+    # Layered value API
+    # ------------------------------------------------------------------
+
+    def _set_layer_value(self, layer_name, value, priority=None):
+        """Store value for a named layer.
+
+        Default priorities: 'base'=0, named overlays=500, 'modifications'=1000.
+
+        Args:
+            layer_name: Name of the layer (e.g., 'base', 'pl_overlay', 'modifications')
+            value: The value to store (list or scalar, stored as list)
+            priority: Optional override; defaults based on layer_name
+        """
+        if priority is None:
+            priority = {'base': 0, 'modifications': 1000}.get(layer_name, 500)
+        v = value if isinstance(value, list) else [value]
+        self._layers[layer_name] = (priority, v)
+
+    def _layer_value(self, layer_name):
+        """Return value for a specific layer, or None if layer doesn't exist."""
+        entry = self._layers.get(layer_name)
+        return entry[1] if entry else None
+
+    def _winning_layer_value(self, view=None):
+        """Return value from the highest-priority layer, optionally for a view.
+
+        Args:
+            view: Layer name to select exactly, or None to return winning (highest priority)
+
+        Returns:
+            list value, or raw __dict__['value'] as fallback if _layers is empty
+        """
+        if not self._layers:
+            return self.__dict__.get('value', [])
+        if view is not None and view in self._layers:
+            return self._layers[view][1]
+        # Return value from highest priority layer
+        return max(self._layers.values(), key=lambda e: e[0])[1]
+
+    def __getattribute__(self, name):
+        """Intercept 'value' reads to return view-context-appropriate layer value."""
+        if name == 'value':
+            d = object.__getattribute__(self, '__dict__')
+            # Only activate layered logic if _layers is initialised and non-empty
+            layers = d.get('_layers')
+            if layers:
+                node = d.get('_node')
+                tree = None
+                if node is not None:
+                    # LopperNode uses .tree (not ._tree) for the owning tree
+                    try:
+                        tree = node.__dict__.get('tree')
+                    except Exception:
+                        pass
+                view = None
+                if tree is not None:
+                    # Access _view_local directly from tree's __dict__ to bypass
+                    # LopperTree.__getattribute__ which may not handle it yet
+                    view_local = tree.__dict__.get('_view_local')
+                    if view_local is not None:
+                        view = getattr(view_local, 'active', None)
+                return object.__getattribute__(self, '_winning_layer_value')(view)
+            # Fallback: return raw value from __dict__
+            return d.get('value', [])
+        return object.__getattribute__(self, name)
 
     def __str__( self ):
         """The string representation of the property
@@ -455,6 +532,10 @@ class LopperProp():
             except:
                 self.__modified__ = True
 
+            # Record explicit writes in the 'modifications' layer (highest priority)
+            if '_layers' in self.__dict__:
+                self.__dict__['_layers']['modifications'] = (1000, self.__dict__[name])
+
             self.resolve()
         else:
             self.__dict__[name] = value
@@ -519,6 +600,10 @@ class LopperProp():
                 # on the LopperProp class
                 self.__dict__["value"] = merged_json_str
 
+                # Update base layer only if not already set (preserve pre-merge value)
+                if 'base' not in self._layers or not self._layers['base'][1]:
+                    self.set_layer_value('base', merged_json_str)
+
                 lopper.log._debug(f"merged value: {self.value}")
 
             except Exception as e:
@@ -562,6 +647,10 @@ class LopperProp():
 
             # Assume `self.value` can store result directly for non-JSON data
             self.__dict__["value"] = result
+
+            # Update base layer only if not already set (preserve pre-merge value)
+            if 'base' not in self._layers or not self._layers['base'][1]:
+                self.set_layer_value('base', result)
 
             lopper.log._debug(f"merged value:: {self.value}")
 
@@ -1888,6 +1977,10 @@ class LopperNode(object):
         self.__nstate__ = "init"
         self.__modified__ = False
 
+        # Layered view: which overlay layer this node originated from.
+        # None = base tree node; '<overlay-name>' = node added by that overlay.
+        self._origin_layer = None
+
     def __deepcopy__(self, memodict={}):
         """ Create a deep copy of a node
 
@@ -1935,8 +2028,6 @@ class LopperNode(object):
         # /copied to the path, but for now, we leave it to the caller.
         new_instance.abs_path = copy.deepcopy( self.abs_path, memodict )
         new_instance.indent_char = self.indent_char
-
-        new_instance._source = self._source
 
         # this may cause duplicate phandles, be careful when assiging to
         # a tree ... but doing this means that there's a chance copied
@@ -2295,9 +2386,12 @@ class LopperNode(object):
         if isinstance(val, LopperProp ):
             # we can try to assign
             self.__props__[key] = val
+            val._node = self
+            val.node = self
         else:
             np = LopperProp( key, -1, self, val, self.__dbg__ )
             self.__props__[key] = np
+            np._node = self
             self.__props__[key].resolve()
 
             # throw an exception, since this is not a valid
@@ -2706,6 +2800,30 @@ class LopperNode(object):
                 except:
                     output = sys.stdout
 
+        # View context: check whether this node is visible in the active view.
+        # Nodes with _origin_layer set are overlay-introduced and invisible in 'base' view.
+        # The root '/' node is always visible.
+        if self.abs_path != '/':
+            try:
+                active_view = self.tree.__dict__.get('_view_local')
+                active_view = getattr(active_view, 'active', None) if active_view else None
+            except Exception:
+                active_view = None
+            if active_view is not None:
+                origin = self.__dict__.get('_origin_layer')
+                if active_view == 'base' and origin is not None:
+                    # Overlay-only node — not visible in base view
+                    if as_string:
+                        sys.stdout = sys.__stdout__
+                        return mystdout.getvalue()
+                    return
+                if active_view != 'base' and origin is not None and origin != active_view:
+                    # Node belongs to a different overlay layer
+                    if as_string:
+                        sys.stdout = sys.__stdout__
+                        return mystdout.getvalue()
+                    return
+
         try:
             if self.tree._type == "dts":
                 depth = self.depth
@@ -2807,10 +2925,35 @@ class LopperNode(object):
                 outstring = f"phandle = <{hex(self.phandle)}>;"
                 print(outstring.rjust(len(outstring)+(depth*8)+8, self.indent_char), file=output, flush=True )
 
+        # Determine active view for property filtering and re-resolution
+        try:
+            _vl = self.tree.__dict__.get('_view_local')
+            _active_view = getattr(_vl, 'active', None) if _vl else None
+        except Exception:
+            _active_view = None
+
         # now the properties
         for p in self:
             if resolve_props:
                 p.resolve( strict )
+
+            # View-based property filtering:
+            # In 'base' view, skip properties that came from an overlay
+            if _active_view == 'base' and any(
+                    k not in ('base', 'modifications') for k in p._layers):
+                continue
+
+            # Re-resolve string_val from the winning layer value for this view.
+            # This is needed because resolve() was called outside the view context
+            # and string_val was derived from the merged (winning-without-view) value.
+            if _active_view is not None and p._layers:
+                layer_val = p._winning_layer_value(_active_view)
+                if layer_val != p.__dict__.get('value'):
+                    # Temporarily update __dict__["value"] for resolve() then restore
+                    saved = p.__dict__.get('value')
+                    p.__dict__['value'] = layer_val
+                    p.resolve(strict)
+                    p.__dict__['value'] = saved
 
             p.print( output )
 
@@ -3123,59 +3266,44 @@ class LopperNode(object):
     def overlay_sourced_properties(self, source_filter=None):
         """Return properties that came from overlays matching the filter.
 
-        Finds properties on this node that have a _source attribute indicating
-        they came from a user overlay file. Used for pulling overlay-contributed
-        properties back into generated overlay fragments.
+        Finds properties on this node that have overlay layer entries in
+        _layers (any key that is not 'base' or 'modifications'). Used for
+        pulling overlay-contributed properties back into generated overlay
+        fragments.
 
         Args:
-            source_filter: Filter for which overlay sources to match.
+            source_filter: Filter for which overlay layers to match.
                 None - return all overlay-sourced properties
                 '*' - return all overlay-sourced properties (same as None)
-                'mmi_dc.dtsi' - match specific overlay filename
-                ['a.dtsi', 'b.dtsi'] - match any of these overlay filenames
+                'mmi_dc.dtsi' - match layer name 'mmi_dc' (stem without extension)
+                ['a.dtsi', 'b.dtsi'] - match any of these layer stems
 
         Returns:
-            list: List of (prop_name, source) tuples for matching properties.
+            list: List of (prop_name, layer_name) tuples for matching properties.
                   Empty list if no properties match.
-
-        Example:
-            # Find all properties from any overlay
-            props = node.overlay_sourced_properties('*')
-
-            # Find properties from specific overlay
-            props = node.overlay_sourced_properties('mmi_dc.dtsi')
-            for prop_name, source in props:
-                print(f"{prop_name} came from {source}")
         """
-        matches = []
+        _INTERNAL = frozenset(('base', 'modifications'))
 
-        # Normalize filter to list
+        # Normalise filter: convert filenames to stems, build set or None
         if source_filter is None or source_filter == '*':
-            # Match any overlay source
-            filter_list = None
-        elif isinstance(source_filter, str):
-            filter_list = [source_filter]
+            filter_set = None
         else:
-            filter_list = list(source_filter)
+            if isinstance(source_filter, str):
+                source_filter = [source_filter]
+            filter_set = {os.path.splitext(f)[0] for f in source_filter}
 
+        matches = []
         for prop_name, prop in self.__props__.items():
-            source = getattr(prop, '_source', None)
-            if source is None:
+            overlay_layers = [k for k in prop._layers if k not in _INTERNAL]
+            if not overlay_layers:
                 continue
-
-            # Check if source indicates an overlay
-            if not source.startswith('overlay:'):
-                continue
-
-            # Extract overlay filename from source
-            overlay_name = source[8:]  # Remove 'overlay:' prefix
-
-            if filter_list is None:
-                # Match any overlay
-                matches.append((prop_name, source))
-            elif overlay_name in filter_list:
-                # Match specific overlay(s)
-                matches.append((prop_name, source))
+            if filter_set is None:
+                matches.append((prop_name, overlay_layers[0]))
+            else:
+                for layer in overlay_layers:
+                    if layer in filter_set:
+                        matches.append((prop_name, layer))
+                        break
 
         return matches
 
@@ -3674,6 +3802,7 @@ class LopperNode(object):
                     else:
                         self.__props__[prop] = LopperProp( prop, -1, self,
                                                            prop_val, self.__dbg__ )
+                        self.__props__[prop]._node = self
 
                         if dtype == LopperFmt.UINT8:
                             self.__props__[prop].binary = True
@@ -3718,6 +3847,7 @@ class LopperNode(object):
                 if saved_props[p].__pstate__ != "deleted":
                     self.__props__[p] = saved_props[p]
                     self.__props__[p].node = self
+                    self.__props__[p]._node = self
 
             if not self.type:
                 self.type = [ "" ]
@@ -4109,6 +4239,10 @@ class LopperTree:
         self._resolver = None
         self._validator = None
 
+        # Thread-local view context: active layer name or None (= winning/merged)
+        self.__dict__['_view_local'] = threading.local()
+        self.__dict__['_view_local'].active = None
+
         # output/print information
         self.indent_char = ' '
 
@@ -4182,35 +4316,57 @@ class LopperTree:
         """
         return self.child_trees('overlay')
 
-    def nodes_with_overlay_sources(self, source_filter=None):
-        """Find all nodes that have properties from matching overlays.
+    @contextmanager
+    def view(self, layer_name):
+        """Context manager: set active view layer for property value reads.
 
-        Scans the tree for nodes containing properties that came from user
-        overlay files. Used for identifying which nodes need their overlay-
-        contributed properties pulled into generated overlay fragments.
+        Within the block, LopperProp.value returns the value from layer_name
+        rather than the winning (highest priority) value. Restores the previous
+        context on exit. Thread-safe via threading.local().
 
         Args:
-            source_filter: Filter for which overlay sources to match.
-                None - match all overlay sources
-                '*' - match all overlay sources (same as None)
-                'mmi_dc.dtsi' - match specific overlay filename
-                ['a.dtsi', 'b.dtsi'] - match any of these overlay filenames
+            layer_name: Layer to activate. Common values: 'base' (original SDT
+                        values before any overlay), '<overlay-name>' (a specific
+                        overlay's values), None (winning/merged, the default).
+
+        Example::
+
+            # Write base SDT without overlay properties
+            with sdt.tree.view('base'):
+                sdt.tree.print(output_file)
+
+            # Write with all applied overlays (default behaviour)
+            sdt.tree.print(output_file)
+
+        Yields:
+            self (the tree), to allow ``with sdt.tree.view('base') as t:`` usage.
+        """
+        view_local = self.__dict__.get('_view_local')
+        prev = getattr(view_local, 'active', None) if view_local else None
+        if view_local is not None:
+            view_local.active = layer_name
+        try:
+            yield self
+        finally:
+            if view_local is not None:
+                view_local.active = prev
+
+    def nodes_with_overlay_sources(self, source_filter=None):
+        """Find all nodes that have properties from matching overlay layers.
+
+        Scans the tree for nodes containing properties that carry overlay
+        layer entries in _layers. The filter accepts overlay filenames
+        (e.g., 'mmi_dc.dtsi') and matches against the stem ('mmi_dc').
+
+        Args:
+            source_filter: Filter for which overlay layers to match.
+                None/'*' - match all overlay layers
+                'mmi_dc.dtsi' - match layer stem 'mmi_dc'
+                ['a.dtsi', 'b.dtsi'] - match any of these layer stems
 
         Returns:
-            list: List of (node, [(prop_name, source), ...]) tuples.
-                  Each tuple contains a node and the list of its overlay-
-                  sourced properties matching the filter.
+            list: List of (node, [(prop_name, layer_name), ...]) tuples.
                   Empty list if no nodes match.
-
-        Example:
-            # Find all nodes with properties from any overlay
-            for node, props in tree.nodes_with_overlay_sources('*'):
-                print(f"{node.abs_path} has {len(props)} overlay properties")
-
-            # Find nodes touched by specific overlay
-            for node, props in tree.nodes_with_overlay_sources('mmi_dc.dtsi'):
-                for prop_name, source in props:
-                    print(f"  {node.abs_path}.{prop_name}")
         """
         matches = []
 
@@ -4756,41 +4912,27 @@ class LopperTree:
 
     def fragment_add_for_overlay_sources( self, overlay_tree, source_filter='*',
                                           mode='properties' ):
-        """Add overlay fragments for properties that came from user overlays.
+        """Add overlay fragments for properties that came from user overlay layers.
 
-        Scans this tree (the base tree) for properties that have a _source
-        attribute indicating they came from a user overlay file. Creates
-        overlay fragments containing those properties.
-
-        This complements fragment_add_for_refs() which handles phandle
-        references. Together they ensure that:
-        1. Properties referencing overlay nodes are pulled into fragments
-        2. Properties from user overlays are also pulled into fragments
+        Scans this tree (the base tree) for properties that carry overlay
+        layer entries in _layers and creates overlay fragments for them.
+        The filter accepts overlay filenames; matching is done against the
+        layer name (stem without extension).
 
         Args:
             overlay_tree (LopperTree): The overlay tree to add fragments to.
                                        Modified in place.
-            source_filter: Filter for which overlay sources to include.
-                '*' - all overlay sources (default)
-                'mmi_dc.dtsi' - specific overlay filename
-                ['a.dtsi', 'b.dtsi'] - list of overlay filenames
-            mode: How to handle properties from matching overlays.
-                'properties' - only include properties with matching _source
-                'full_nodes' - include ALL properties from nodes that have
-                               any property with matching _source
+            source_filter: Filter for which overlay layers to include.
+                '*' - all overlay layers (default)
+                'mmi_dc.dtsi' - layer named 'mmi_dc'
+                ['a.dtsi', 'b.dtsi'] - list of layer stems to match
+            mode: How to handle matched nodes.
+                'properties' - only include overlay-layer properties
+                'full_nodes' - include ALL properties from matched nodes
 
         Returns:
             list: List of fragment nodes that were added to overlay_tree.
                   Empty list if no fragments were needed.
-
-        Example:
-            # After extracting PL nodes to overlay, also pull user overlay content:
-            base_tree.fragment_add_for_refs(overlay_tree)  # phandle refs
-            base_tree.fragment_add_for_overlay_sources(
-                overlay_tree,
-                source_filter='mmi_dc.dtsi',
-                mode='properties'
-            )
         """
         # Find nodes with overlay-sourced properties
         nodes_with_sources = self.nodes_with_overlay_sources(source_filter)

--- a/lopper/tree.py
+++ b/lopper/tree.py
@@ -313,29 +313,33 @@ class LopperProp():
         return max(self._layers.values(), key=lambda e: e[0])[1]
 
     def __getattribute__(self, name):
-        """Intercept 'value' reads to return view-context-appropriate layer value."""
+        """Intercept 'value' reads to return view-context-appropriate layer value.
+
+        When no view context is active, returns __dict__["value"] directly
+        (identical to the pre-layers behaviour).  Only when a named view is
+        active does this look up the appropriate layer value, making the
+        layered storage transparent to all existing code paths.
+        """
         if name == 'value':
             d = object.__getattribute__(self, '__dict__')
-            # Only activate layered logic if _layers is initialised and non-empty
             layers = d.get('_layers')
             if layers:
+                # Check for an active view context via the owning tree
                 node = d.get('_node')
-                tree = None
+                view = None
                 if node is not None:
-                    # LopperNode uses .tree (not ._tree) for the owning tree
                     try:
                         tree = node.__dict__.get('tree')
+                        if tree is not None:
+                            view_local = tree.__dict__.get('_view_local')
+                            if view_local is not None:
+                                view = getattr(view_local, 'active', None)
                     except Exception:
                         pass
-                view = None
-                if tree is not None:
-                    # Access _view_local directly from tree's __dict__ to bypass
-                    # LopperTree.__getattribute__ which may not handle it yet
-                    view_local = tree.__dict__.get('_view_local')
-                    if view_local is not None:
-                        view = getattr(view_local, 'active', None)
-                return object.__getattribute__(self, '_winning_layer_value')(view)
-            # Fallback: return raw value from __dict__
+                if view is not None:
+                    # A named view is active — return that layer's value
+                    return object.__getattribute__(self, '_winning_layer_value')(view)
+            # No active view: return raw __dict__["value"] (original behaviour)
             return d.get('value', [])
         return object.__getattribute__(self, name)
 
@@ -578,9 +582,17 @@ class LopperProp():
         if self.pclass == "json" and other_prop.pclass == "json":
             lopper.log._debug( f"property merge: json -> json" )
             try:
-                # Decode the JSON strings
-                t1_list = json.loads(self.value)
-                t2_list = json.loads(other_prop.value)
+                # Use __dict__["value"] to get the raw JSON string, bypassing the
+                # layer-aware __getattribute__ which would return a list wrapper.
+                t1_raw = self.__dict__.get("value", self.value)
+                t2_raw = other_prop.__dict__.get("value", other_prop.value)
+                # If raw value is a list, unwrap to get the JSON string
+                if isinstance(t1_raw, list):
+                    t1_raw = t1_raw[0] if t1_raw else "[]"
+                if isinstance(t2_raw, list):
+                    t2_raw = t2_raw[0] if t2_raw else "[]"
+                t1_list = json.loads(t1_raw)
+                t2_list = json.loads(t2_raw)
 
                 # Check if both lists have exactly one dictionary each
                 if len(t1_list) == 1 and isinstance(t1_list[0], dict) and \
@@ -603,6 +615,9 @@ class LopperProp():
                 # Update base layer only if not already set (preserve pre-merge value)
                 if 'base' not in self._layers or not self._layers['base'][1]:
                     self.set_layer_value('base', merged_json_str)
+                else:
+                    # Base already exists; record merged result as modifications so it wins
+                    self.set_layer_value('modifications', merged_json_str)
 
                 lopper.log._debug(f"merged value: {self.value}")
 
@@ -651,6 +666,9 @@ class LopperProp():
             # Update base layer only if not already set (preserve pre-merge value)
             if 'base' not in self._layers or not self._layers['base'][1]:
                 self.set_layer_value('base', result)
+            else:
+                # Base already exists; record merged result as modifications so it wins
+                self.set_layer_value('modifications', result)
 
             lopper.log._debug(f"merged value:: {self.value}")
 

--- a/lopper/tree.py
+++ b/lopper/tree.py
@@ -202,6 +202,10 @@ class LopperProp():
 
         self.abs_path = ""
 
+        # Source tracking for overlay provenance
+        # Format: None (base tree), 'overlay:<filename>', 'yaml:<filename>', etc.
+        self._source = None
+
         if value == None:
             self.value = []
         else:
@@ -251,6 +255,7 @@ class LopperProp():
         new_instance.ptype = self.ptype
         new_instance.binary = self.binary
         new_instance.phandle_resolution = self.phandle_resolution
+        new_instance._source = self._source
 
         if self.__dbg__ > 1:
             lopper.log._debug( f"property deep copy done: {[self]} ({type(new_instance.value)})({new_instance.value})" )
@@ -1383,7 +1388,7 @@ class LopperProp():
 
         return ptype
 
-    def resolve( self, strict = None ):
+    def resolve( self, strict = None, sync_companions = True ):
         """resolve (calculate) property details
 
         Some attributes of a property are not known at initialization
@@ -1669,7 +1674,8 @@ class LopperProp():
                                 kept_companion.append(companion_val[rnum])
 
                     # Update companion property with kept entries
-                    if companion_prop is not None:
+                    # Only sync if sync_companions is True (default)
+                    if companion_prop is not None and sync_companions:
                         companion_prop.value = kept_companion
                 else:
                     # no phandles
@@ -2539,13 +2545,32 @@ class LopperNode(object):
                 if prop.name not in phandle_props:
                     continue
 
-                # Use resolve_phandles() to get actual phandle targets,
-                # avoiding false positives from matching non-phandle integers
+                # Use phandle_map() to identify phandle positions in the property
+                # Then check if any position contains our target_phandle value
                 try:
-                    phandle_targets = prop.resolve_phandles()
-                    if self in phandle_targets:
+                    phandle_records = prop.phandle_map()
+
+                    # phandle_map returns list of records, each record is a sublist
+                    # where the first element is the node (or #invalid) and remaining
+                    # elements are 0 for non-phandle cells
+                    # We need to check if any raw phandle value matches target_phandle
+                    found_ref = False
+                    prop_val_idx = 0
+                    for record in phandle_records:
+                        # First element is the phandle position
+                        # Even if it resolved to #invalid, check the raw value
+                        if prop_val_idx < len(prop.value):
+                            raw_phandle = prop.value[prop_val_idx]
+                            if raw_phandle == target_phandle:
+                                found_ref = True
+                                break
+                        # Advance by record length
+                        prop_val_idx += len(record)
+
+                    if found_ref:
                         companion = lopper.base.lopper_base.phandle_property_companion(prop.name)
                         referencing_props.append((node, prop.name, companion))
+
                 except Exception:
                     continue
 
@@ -3093,6 +3118,65 @@ class LopperNode(object):
             except:
                 return [""]
 
+    def overlay_sourced_properties(self, source_filter=None):
+        """Return properties that came from overlays matching the filter.
+
+        Finds properties on this node that have a _source attribute indicating
+        they came from a user overlay file. Used for pulling overlay-contributed
+        properties back into generated overlay fragments.
+
+        Args:
+            source_filter: Filter for which overlay sources to match.
+                None - return all overlay-sourced properties
+                '*' - return all overlay-sourced properties (same as None)
+                'mmi_dc.dtsi' - match specific overlay filename
+                ['a.dtsi', 'b.dtsi'] - match any of these overlay filenames
+
+        Returns:
+            list: List of (prop_name, source) tuples for matching properties.
+                  Empty list if no properties match.
+
+        Example:
+            # Find all properties from any overlay
+            props = node.overlay_sourced_properties('*')
+
+            # Find properties from specific overlay
+            props = node.overlay_sourced_properties('mmi_dc.dtsi')
+            for prop_name, source in props:
+                print(f"{prop_name} came from {source}")
+        """
+        matches = []
+
+        # Normalize filter to list
+        if source_filter is None or source_filter == '*':
+            # Match any overlay source
+            filter_list = None
+        elif isinstance(source_filter, str):
+            filter_list = [source_filter]
+        else:
+            filter_list = list(source_filter)
+
+        for prop_name, prop in self.__props__.items():
+            source = getattr(prop, '_source', None)
+            if source is None:
+                continue
+
+            # Check if source indicates an overlay
+            if not source.startswith('overlay:'):
+                continue
+
+            # Extract overlay filename from source
+            overlay_name = source[8:]  # Remove 'overlay:' prefix
+
+            if filter_list is None:
+                # Match any overlay
+                matches.append((prop_name, source))
+            elif overlay_name in filter_list:
+                # Match specific overlay(s)
+                matches.append((prop_name, source))
+
+        return matches
+
     def is_compatible(self, compat_string, match_type="substring"):
         """Check if the node is compatible with the given string(s).
 
@@ -3598,7 +3682,8 @@ class LopperNode(object):
                         if node_source:
                             self._source = node_source
 
-                        self.__props__[prop].resolve( strict )
+                        # Don't sync companions during tree load - only at final output
+                        self.__props__[prop].resolve( strict, sync_companions=False )
                         self.__props__[prop].__modified__ = False
 
                         # if our node has a property of type label, we bubble it up to the node
@@ -3613,7 +3698,8 @@ class LopperNode(object):
                 # we had labels, some output strings in the properities may need to be
                 # update to reflect the new targets
                 for p in self.__props__:
-                    self.__props__[p].resolve( strict )
+                    # Don't sync companions during tree load - only at final output
+                    self.__props__[p].resolve( strict, sync_companions=False )
                     self.__props__[p].__modified__ = False
 
                 # now delete the lopper-prop-* property, we'll just run with
@@ -3999,7 +4085,15 @@ class LopperTree:
         self.phandle_resolution = True
         self.phandle_static_map = None
 
-        self._external_trees = []
+        # Unified tree metadata - tracks relationships between trees
+        self._metadata = {
+            'type': 'primary',           # 'primary' | 'extracted' | 'overlay' | 'domain'
+            'name': None,                # Name used as key in sdt.subtrees
+            'source': None,              # Path this tree was extracted/derived from
+            'parent': None,              # Tree this was extracted/derived from
+            'child_trees': [],           # Trees derived from this one
+            'external_trees': [],        # Trees to search during phandle resolution
+        }
 
         self.strict = True
         self.warnings = []
@@ -4022,6 +4116,108 @@ class LopperTree:
                    '__fdt_number__' : 0,
                    '__fdt_phandle__' : -1 }
         self.load( i_dct )
+
+    @property
+    def _external_trees(self):
+        """Backward compatible property: return external_trees from metadata
+
+        This allows existing code that accesses self._external_trees to
+        continue working unchanged while we transition to unified metadata.
+
+        Returns:
+            list: Trees to search during phandle resolution
+        """
+        return self._metadata.get('external_trees', [])
+
+    @_external_trees.setter
+    def _external_trees(self, value):
+        """Backward compatible setter: set external_trees in metadata
+
+        Args:
+            value (list): Trees to set for phandle resolution
+        """
+        self._metadata['external_trees'] = value
+
+    def child_trees(self, tree_type=None):
+        """Return child trees, optionally filtered by type
+
+        Child trees are trees that were derived from this tree, such as
+        extracted nodes or overlays. They are tracked in the metadata
+        for reconstruction and verification purposes.
+
+        Args:
+            tree_type (str, optional): Filter by tree type. Valid values are
+                'extracted', 'overlay', 'domain'. If None, returns all child trees.
+
+        Returns:
+            list: List of LopperTree objects that are children of this tree
+        """
+        children = self._metadata.get('child_trees', [])
+        if tree_type:
+            return [t for t in children if t._metadata.get('type') == tree_type]
+        return children
+
+    def extracted_trees(self):
+        """Return all extracted trees
+
+        Extracted trees contain nodes that were removed from this tree via
+        delete() with capture=True. These nodes are preserved for later
+        reconstruction or verification.
+
+        Returns:
+            list: List of LopperTree objects containing extracted nodes
+        """
+        return self.child_trees('extracted')
+
+    def overlay_trees(self):
+        """Return all overlay trees
+
+        Overlay trees are trees that extend this tree via the overlay_of()
+        mechanism. They reference this tree for phandle resolution.
+
+        Returns:
+            list: List of LopperTree objects that are overlays of this tree
+        """
+        return self.child_trees('overlay')
+
+    def nodes_with_overlay_sources(self, source_filter=None):
+        """Find all nodes that have properties from matching overlays.
+
+        Scans the tree for nodes containing properties that came from user
+        overlay files. Used for identifying which nodes need their overlay-
+        contributed properties pulled into generated overlay fragments.
+
+        Args:
+            source_filter: Filter for which overlay sources to match.
+                None - match all overlay sources
+                '*' - match all overlay sources (same as None)
+                'mmi_dc.dtsi' - match specific overlay filename
+                ['a.dtsi', 'b.dtsi'] - match any of these overlay filenames
+
+        Returns:
+            list: List of (node, [(prop_name, source), ...]) tuples.
+                  Each tuple contains a node and the list of its overlay-
+                  sourced properties matching the filter.
+                  Empty list if no nodes match.
+
+        Example:
+            # Find all nodes with properties from any overlay
+            for node, props in tree.nodes_with_overlay_sources('*'):
+                print(f"{node.abs_path} has {len(props)} overlay properties")
+
+            # Find nodes touched by specific overlay
+            for node, props in tree.nodes_with_overlay_sources('mmi_dc.dtsi'):
+                for prop_name, source in props:
+                    print(f"  {node.abs_path}.{prop_name}")
+        """
+        matches = []
+
+        for node in self:
+            overlay_props = node.overlay_sourced_properties(source_filter)
+            if overlay_props:
+                matches.append((node, overlay_props))
+
+        return matches
 
     def __iter__(self):
         """magic method to support iteration
@@ -4100,6 +4296,13 @@ class LopperTree:
             self.__dict__[name] = value
             for n in self.__nodes__.values():
                 n.__dbg__ = value
+        elif name == "_external_trees":
+            # Route through the metadata for backward compat
+            if '_metadata' in self.__dict__:
+                self.__dict__['_metadata']['external_trees'] = value
+            else:
+                # During __init__, _metadata may not exist yet
+                self.__dict__[name] = value
         else:
             self.__dict__[name] = value
 
@@ -4313,7 +4516,22 @@ class LopperTree:
                                 node_string="node:" + node_string
                                 lopper.log._warning( node_string )
 
-    def overlay_of( self, parent_tree ):
+    def overlay_of( self, parent_tree, name=None, exclude_props=None, exclude_nodes=None ):
+        """Make this tree an overlay of parent_tree
+
+        Sets up this tree to be an overlay that extends parent_tree. The overlay
+        will use parent_tree for phandle resolution and will be registered as a
+        child tree of parent_tree for tracking purposes.
+
+        Args:
+            parent_tree (LopperTree): The base tree this overlays
+            name (str, optional): Name for tracking in sdt.subtrees. If None,
+                                  generates a name like 'overlay_1'
+            exclude_props (list, optional): List of property names to remove from
+                                           overlay (e.g., ['address-map', 'interrupt-map'])
+            exclude_nodes (list, optional): List of node paths/patterns to remove
+                                           from overlay
+        """
         # we are becoming an overlay_of the passed tree
         self._type = "dts_overlay"
 
@@ -4328,8 +4546,36 @@ class LopperTree:
             del n.__props__['phandle']
 
         # store the parent tree, this is used for resolving
-        # lables and phandles before printing
-        self._external_trees.append(parent_tree)
+        # labels and phandles before printing
+        self._metadata['external_trees'].append(parent_tree)
+
+        # Set metadata for this overlay
+        if name is None:
+            name = f"overlay_{len(parent_tree._metadata.get('child_trees', [])) + 1}"
+
+        self._metadata['type'] = 'overlay'
+        self._metadata['name'] = name
+        self._metadata['parent'] = parent_tree
+
+        # Register with parent (for tracking, NOT resolution)
+        if self not in parent_tree._metadata.get('child_trees', []):
+            parent_tree._metadata['child_trees'].append(self)
+            lopper.log._debug( f"Registered overlay '{name}' with parent tree" )
+
+        # Apply property filtering if requested
+        if exclude_props:
+            for node in self:
+                for prop_name in exclude_props:
+                    if prop_name in node.__props__:
+                        del node.__props__[prop_name]
+                        lopper.log._debug( f"Removed property '{prop_name}' from {node.abs_path}" )
+
+        # Apply node filtering if requested
+        if exclude_nodes:
+            for pattern in exclude_nodes:
+                for node in list(self.nodes(pattern)):
+                    self.delete(node, capture=False)
+                    lopper.log._debug( f"Removed node {node.abs_path} matching pattern '{pattern}'" )
 
     def tree_refs( self, target_tree ):
         """Find properties in this tree that reference nodes in target_tree
@@ -4810,16 +5056,24 @@ class LopperTree:
 
         return self
 
-    def delete( self, node, delete_from_parent = True, force=False ):
+    def delete( self, node, delete_from_parent = True, force=False, capture=True ):
         """delete a node from a tree
 
         If a node is resolved and syncd to the FDT, this routine deletes it
         from the FDT and the LopperTree structure.
 
+        When capture=True and the node is resolved, a copy of the node (and its
+        children) is preserved in an extracted tree tracked via _metadata['child_trees'].
+        This enables round-trip reconstruction and verification.
+
         Args:
            node (int or LopperNode): the node to delete
            delete_fom_parent (bool): flag indicating if the node should be
                                      removed from the parent node.
+           force (bool): force deletion even if node is not resolved
+           capture (bool): if True, capture the deleted node in an extracted tree
+                          for later reconstruction. Set to False for internal
+                          deletions or when capture is not needed.
 
         Returns:
            Boolean: True if deleted, False otherwise. KeyError if node is not found
@@ -4839,9 +5093,48 @@ class LopperTree:
         if n.__nstate__ == "resolved" and self.__must_sync__ == False:
             lopper.log._debug( f"{self} deleting [{[n]}] node {n.abs_path}" )
 
+            # Capture the node before deletion if:
+            # 1. capture=True
+            # 2. delete_from_parent=True (indicates top-level deletion, not recursive)
+            # 3. This tree is NOT an extracted/derived tree (prevent infinite recursion)
+            should_capture = (capture and
+                              delete_from_parent and
+                              self._metadata.get('type') not in ('extracted', 'overlay'))
+
+            if should_capture:
+                # Create a name based on the node name
+                extracted_name = f"extracted_{n.name}"
+
+                # Find or create extracted tree for this source
+                extracted = None
+                for t in self._metadata['child_trees']:
+                    if t._metadata.get('name') == extracted_name:
+                        extracted = t
+                        break
+
+                if extracted is None:
+                    extracted = LopperTree()
+                    extracted._metadata = {
+                        'type': 'extracted',
+                        'name': extracted_name,
+                        'source': n.abs_path,
+                        'parent': self,
+                        'child_trees': [],
+                        'external_trees': [],
+                    }
+                    self._metadata['child_trees'].append(extracted)
+                    lopper.log._debug( f"Created extracted tree '{extracted_name}' for {n.abs_path}" )
+
+                # Clone the node and add to extracted tree
+                # The () operator creates a deep copy
+                cloned = n()
+                extracted.add(cloned)
+                lopper.log._debug( f"Captured node {n.abs_path} in extracted tree '{extracted_name}'" )
+
             if n.child_nodes:
                 for cn_path,cn in list(n.child_nodes.items()):
-                    self.delete( cn, False, force=force )
+                    # Recursive deletes don't capture - the parent clone includes children
+                    self.delete( cn, False, force=force, capture=False )
 
             try:
                 del self.__nodes__[n.abs_path]

--- a/lopper/tree.py
+++ b/lopper/tree.py
@@ -4868,6 +4868,148 @@ class LopperTree:
 
         return fragments_added
 
+    def tree_refs( self, target_tree ):
+        """Find properties in this tree that reference nodes in target_tree
+
+        Scans all nodes in target_tree and uses each node's node_refs()
+        method to find properties in this tree that reference them. This is
+        useful for finding properties that will become invalid when target_tree
+        nodes are extracted into an overlay.
+
+        Args:
+            target_tree (LopperTree): The tree containing nodes that might
+                                      be referenced
+
+        Returns:
+            list of tuples: [(node, prop_name, companion_prop_name or None), ...]
+                           where companion_prop_name is the associated -names
+                           property if one exists (e.g., clock-names for clocks)
+        """
+        referencing_props = []
+
+        # For each node in target_tree, find properties in self that reference it
+        for target_node in target_tree:
+            refs = target_node.node_refs(self)
+            referencing_props.extend(refs)
+
+        return referencing_props
+
+    def fragment_create( self, source_node, property_names, include_companions=True ):
+        """Create an overlay fragment node with only specified properties
+
+        Creates an overlay fragment (a node using &label syntax) containing
+        only the specified properties from the source node. This is used to
+        create partial overlays where only certain properties need to override
+        the base tree.
+
+        Args:
+            source_node (LopperNode): The node to extract properties from
+            property_names (list): List of property names to include
+            include_companions (bool): If True, automatically include companion
+                                       -names properties (e.g., clock-names
+                                       when clocks is specified)
+
+        Returns:
+            LopperNode: The created fragment node, or None if source_node has
+                        no label or no properties were found
+
+        Example:
+            # Create fragment: &mmi_dc { clocks = <...>; clock-names = "..."; };
+            fragment = tree.fragment_create(mmi_dc_node, ["clocks"])
+        """
+        if not source_node.label:
+            lopper.log._warning(f"Node {source_node.abs_path} has no label, cannot create overlay fragment")
+            return None
+
+        # Expand property list to include companions
+        all_props = set(property_names)
+        if include_companions:
+            for prop_name in property_names:
+                companion = lopper.base.lopper_base.phandle_property_companion(prop_name)
+                if companion:
+                    all_props.add(companion)
+
+        # Create fragment node with reference name
+        fragment_name = "&" + source_node.label
+        fragment = LopperNode(name=fragment_name)
+        fragment.label = ""  # Fragment itself doesn't need a label
+
+        props_added = 0
+        for prop_name in all_props:
+            try:
+                prop = source_node[prop_name]
+                if prop:
+                    # Use deepcopy which handles property copying correctly
+                    # (uses __dict__ assignment to avoid triggering resolution)
+                    new_prop = copy.deepcopy(prop)
+                    new_prop.node = fragment
+                    fragment.__props__[prop_name] = new_prop
+                    props_added += 1
+            except (KeyError, TypeError):
+                pass
+
+        if props_added == 0:
+            return None
+
+        return fragment
+
+    def fragment_add_for_refs( self, overlay_tree ):
+        """Add overlay fragments for properties that reference the overlay
+
+        Scans this tree (the base tree) for properties that contain phandle
+        references to nodes in overlay_tree. For each such property, creates
+        an overlay fragment containing that property (and its companion -names
+        property if applicable) and adds it to the overlay tree.
+
+        This ensures that when the overlay is applied, properties that reference
+        overlay nodes will have their complete values restored (rather than
+        having invalid phandle references stripped during output).
+
+        Args:
+            overlay_tree (LopperTree): The overlay tree to add fragments to.
+                                       Modified in place.
+
+        Returns:
+            int: Number of fragments added
+
+        Example:
+            # After extracting /amba_pl to overlay:
+            # Find base tree props referencing overlay and add fragments
+            num_added = base_tree.fragment_add_for_refs(overlay_tree)
+        """
+        # Find properties that reference the overlay
+        referencing = self.tree_refs(overlay_tree)
+
+        if not referencing:
+            return 0
+
+        # Group by node to create one fragment per node
+        node_props = {}
+        for node, prop_name, companion in referencing:
+            key = node.abs_path
+            if key not in node_props:
+                node_props[key] = {'node': node, 'props': set()}
+            node_props[key]['props'].add(prop_name)
+            if companion:
+                node_props[key]['props'].add(companion)
+
+        # Create fragments and add to overlay
+        fragments_added = 0
+        for path, info in node_props.items():
+            node = info['node']
+            props = list(info['props'])
+
+            try:
+                fragment = self.fragment_create(node, props)
+                if fragment:
+                    overlay_tree.add(fragment)
+                    fragments_added += 1
+                    lopper.log._info(f"Added overlay fragment for {node.label} with properties: {props}")
+            except Exception as e:
+                lopper.log._warning(f"Failed to create overlay fragment for {node.abs_path}: {e}")
+
+        return fragments_added
+
     def phandles( self ):
         """Utility function to get the active phandles in the tree
 

--- a/tests/test_extract_overlay_nodes.py
+++ b/tests/test_extract_overlay_nodes.py
@@ -1,0 +1,156 @@
+"""
+Tests for LopperTree.extract_nodes().
+
+Verifies that nodes introduced by an overlay (tracked via _origin_layer)
+are correctly moved from the base tree into the overlay tree, leaving
+property-only modifications behind for fragment_add_for_overlay_sources().
+"""
+
+import pytest
+import copy
+from lopper.tree import LopperTree, LopperNode, LopperProp
+
+
+def _make_tree_with_overlay_nodes():
+    """
+    Build a base tree that looks like the result of applying an overlay:
+
+    / {
+        cpus {                     <- existing node, no overlay origin
+            cpu@0 { ... };
+        };
+        amba_pl {                  <- entire node introduced by overlay 'pl'
+            uart0: uart@ff000000 { ... };
+        };
+    };
+
+    Also tag cpus/cpu@0 with a modified 'status' property from the overlay.
+    """
+    tree = LopperTree()
+
+    cpus = LopperNode(-1, "/cpus")
+    cpus.label = "cpus"
+    tree.add(cpus)
+
+    cpu0 = LopperNode(-1, "/cpus/cpu@0")
+    cpu0.label = "cpu0"
+    tree.add(cpu0)
+
+    # Property on existing node modified by overlay
+    status = LopperProp(name='status', value=["okay"])
+    status._set_layer_value('pl', ["okay"], priority=500)
+    tree['/cpus/cpu@0'].__props__['status'] = status
+
+    # Whole node introduced by overlay
+    amba_pl = LopperNode(-1, "/amba_pl")
+    amba_pl.label = "amba_pl"
+    amba_pl._origin_layer = 'pl'
+    tree.add(amba_pl)
+
+    uart = LopperNode(-1, "/amba_pl/uart@ff000000")
+    uart.label = "uart0"
+    uart._origin_layer = 'pl'
+    tree.add(uart)
+
+    reg = LopperProp(name='reg', value=[0xff000000, 0x1000])
+    reg._set_layer_value('pl', [0xff000000, 0x1000], priority=500)
+    tree['/amba_pl/uart@ff000000'].__props__['reg'] = reg
+
+    tree.sync()
+    tree.resolve()
+    return tree
+
+
+class TestExtractOverlayNodes:
+
+    def test_introduced_node_moves_to_overlay_tree(self):
+        """Overlay-introduced nodes should be moved into overlay_tree."""
+        base = _make_tree_with_overlay_nodes()
+        overlay = LopperTree()
+
+        moved = base.extract_nodes(overlay, layer_filter='pl')
+
+        assert len(moved) == 1
+        # The top-level introduced node amba_pl was moved
+        abs_paths = [n.abs_path for n in moved]
+        assert '/amba_pl' in abs_paths
+
+    def test_introduced_node_removed_from_base(self):
+        """After extraction the node must not remain in the base tree."""
+        base = _make_tree_with_overlay_nodes()
+        overlay = LopperTree()
+
+        base.extract_nodes(overlay, layer_filter='pl')
+
+        assert '/amba_pl' not in base.__nodes__
+
+    def test_child_of_introduced_node_not_double_moved(self):
+        """Children of a moved node should not appear as separate top-level moves."""
+        base = _make_tree_with_overlay_nodes()
+        overlay = LopperTree()
+
+        moved = base.extract_nodes(overlay, layer_filter='pl')
+
+        # Only one top-level node (amba_pl), not also its child uart@ff000000
+        assert len(moved) == 1
+
+    def test_existing_node_not_moved(self):
+        """Nodes without _origin_layer should stay in base tree."""
+        base = _make_tree_with_overlay_nodes()
+        overlay = LopperTree()
+
+        base.extract_nodes(overlay, layer_filter='pl')
+
+        assert '/cpus' in base.__nodes__
+        assert '/cpus/cpu@0' in base.__nodes__
+
+    def test_wildcard_filter_matches_any_origin_layer(self):
+        """layer_filter='*' should match all overlay-introduced nodes."""
+        base = _make_tree_with_overlay_nodes()
+        overlay = LopperTree()
+
+        moved = base.extract_nodes(overlay, layer_filter='*')
+
+        assert len(moved) == 1
+        assert '/amba_pl' not in base.__nodes__
+
+    def test_non_matching_filter_moves_nothing(self):
+        """A filter that matches no layer should move nothing."""
+        base = _make_tree_with_overlay_nodes()
+        overlay = LopperTree()
+
+        moved = base.extract_nodes(overlay, layer_filter='other_overlay')
+
+        assert moved == []
+        assert '/amba_pl' in base.__nodes__
+
+    def test_property_modified_nodes_untouched(self):
+        """Nodes with overlay-sourced properties but no _origin_layer stay in base."""
+        base = _make_tree_with_overlay_nodes()
+        overlay = LopperTree()
+
+        base.extract_nodes(overlay, layer_filter='pl')
+
+        # cpu@0 has a 'status' property from the 'pl' layer but _origin_layer is None
+        assert '/cpus/cpu@0' in base.__nodes__
+
+    def test_round_trip_combined_with_fragment_add(self):
+        """
+        Full round-trip: extract_nodes + fragment_add_for_overlay_sources
+        gives overlay tree containing both whole nodes and property fragments.
+        """
+        base = _make_tree_with_overlay_nodes()
+        overlay = LopperTree()
+
+        # Step 1: move whole overlay-introduced nodes
+        moved = base.extract_nodes(overlay, layer_filter='pl')
+        assert len(moved) == 1
+
+        # Step 2: add fragments for overlay-modified properties on existing nodes
+        fragments = base.fragment_add_for_overlay_sources(overlay, source_filter='pl')
+        # cpu@0 has status modified by pl layer → should produce a fragment
+        assert len(fragments) >= 1
+
+        # Verify the overlay tree has the extracted node
+        assert any(n.abs_path == '/amba_pl' for n in overlay.__nodes__.values()
+                   if hasattr(n, 'abs_path'))

--- a/tests/test_glob_access.py
+++ b/tests/test_glob_access.py
@@ -15,6 +15,7 @@ Author:
 """
 
 import os
+import sys
 import json
 import pytest
 from lopper.assists.yaml_to_dts_expansion import (
@@ -235,7 +236,7 @@ domains:
 
         # Run lopper
         cmd = [
-            "./lopper.py", "-f", "--permissive", "--auto",
+            sys.executable, "./lopper.py", "-f", "--permissive", "--auto",
             "-i", str(devices_yaml),
             "-i", str(child_yaml),
             "./lopper/selftest/system-top.dts",
@@ -316,7 +317,7 @@ domains:
         output_dts = tmp_path / "output.dts"
 
         cmd = [
-            "./lopper.py", "-f", "--permissive", "--auto",
+            sys.executable, "./lopper.py", "-f", "--permissive", "--auto",
             "-i", str(devices_yaml),
             "-i", str(child_yaml),
             "./lopper/selftest/system-top.dts",
@@ -383,7 +384,7 @@ domains:
         output_dts = tmp_path / "output.dts"
 
         cmd = [
-            "./lopper.py", "-f", "--permissive", "--auto",
+            sys.executable, "./lopper.py", "-f", "--permissive", "--auto",
             "-i", str(devices_yaml),
             "-i", str(child_yaml),
             "./lopper/selftest/system-top.dts",
@@ -441,7 +442,7 @@ domains:
         output_dts = tmp_path / "output.dts"
 
         cmd = [
-            "./lopper.py", "-f", "--permissive", "--auto",
+            sys.executable, "./lopper.py", "-f", "--permissive", "--auto",
             "-i", str(domains_yaml),
             "./lopper/selftest/system-top.dts",
             str(output_dts)

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -112,9 +112,14 @@ class TestLayeredPropStorage:
 
 class TestViewContextManager:
     def test_default_view_is_winning(self):
+        """Without a view, prop.value returns __dict__['value'] (live value)."""
         t, n, p = _make_tree_with_prop([100])
         p.set_layer_value('base', [100])
         p.set_layer_value('pl_overlay', [200], priority=500)
+        # No view active: returns raw __dict__['value'] which is [100] (initial)
+        assert p.value == [100]
+        # Writing through the normal path updates __dict__['value']
+        p.value = [200]
         assert p.value == [200]
 
     def test_base_view_returns_base(self):
@@ -135,23 +140,25 @@ class TestViewContextManager:
         t, n, p = _make_tree_with_prop([100])
         p.set_layer_value('base', [100])
         p.set_layer_value('pl_overlay', [200], priority=500)
+        p.__dict__['value'] = [200]  # simulate overlay being applied
         with t.view('base'):
             assert p.value == [100]
-        # After exiting, returns to winning
+        # After exiting, returns to raw value (overlay applied)
         assert p.value == [200]
 
     def test_nested_views(self):
-        t, n, p = _make_tree_with_prop([100])
+        t, n, p = _make_tree_with_prop([300])
         p.set_layer_value('base', [100])
         p.set_layer_value('overlay_a', [200], priority=500)
         p.set_layer_value('overlay_b', [300], priority=600)
+        # __dict__['value'] = [300] (set by _make_tree_with_prop)
         with t.view('base'):
             assert p.value == [100]
             with t.view('overlay_a'):
                 assert p.value == [200]
             # Inner view exited, back to base
             assert p.value == [100]
-        # Both exited, back to winning
+        # Both exited, back to raw value
         assert p.value == [300]
 
     def test_view_yields_tree(self):
@@ -196,12 +203,13 @@ class TestBackwardCompat:
         assert p.value == [10, 20]
 
     def test_propval_no_view(self):
-        """LopperNode.propval() should return winning value with no view set."""
+        """LopperNode.propval() returns raw __dict__['value'] with no view set."""
         t, n, p = _make_tree_with_prop([42], name='reg')
         p.set_layer_value('base', [42])
         p.set_layer_value('overlay', [99], priority=500)
+        # No view: propval returns the live __dict__['value'] = [42]
         result = n.propval('reg')
-        assert result == [99]
+        assert result == [42]
 
     def test_propval_in_base_view(self):
         """LopperNode.propval() returns base value inside base view."""

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the layered property view system.
+
+Covers:
+- LopperProp._layers storage and layer API
+- View context manager (tree.view())
+- Backward compatibility (prop.value, prop.value[0], propval())
+- Node visibility in base/overlay views
+- merge() doesn't overwrite an already-set base layer
+"""
+
+import sys
+import os
+import io
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from lopper.tree import LopperProp, LopperNode, LopperTree
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_tree_with_prop(value, name='clocks', node_path='/cpu0'):
+    """Return (tree, node, prop) with prop added to node."""
+    t = LopperTree()
+    n = LopperNode(-1, node_path)
+    t.add(n)
+    p = LopperProp(name, value=value)
+    n[name] = p
+    return t, n, n.__props__[name]
+
+
+# ---------------------------------------------------------------------------
+# Layer storage tests
+# ---------------------------------------------------------------------------
+
+class TestLayeredPropStorage:
+    def test_init_seeds_base_layer(self):
+        p = LopperProp('clocks', value=[42])
+        assert 'base' in p._layers
+        assert p._layers['base'] == (0, [42])
+
+    def test_init_empty_value_seeds_empty_base(self):
+        p = LopperProp('status', value=[])
+        # __init__ branches on value == None; empty list is not None
+        # base layer is seeded with initial value
+        assert 'base' in p._layers
+
+    def test_set_layer_value_default_priority(self):
+        p = LopperProp('clocks', value=[1])
+        p._set_layer_value('base', [10])
+        assert p._layers['base'] == (0, [10])
+
+        p._set_layer_value('modifications', [99])
+        assert p._layers['modifications'] == (1000, [99])
+
+        p._set_layer_value('pl_overlay', [50])
+        assert p._layers['pl_overlay'] == (500, [50])
+
+    def test_set_layer_value_custom_priority(self):
+        p = LopperProp('reg', value=[0])
+        p._set_layer_value('special', [7], priority=750)
+        assert p._layers['special'] == (750, [7])
+
+    def test_layer_value_returns_value(self):
+        p = LopperProp('clocks', value=[1])
+        p._set_layer_value('base', [10])
+        p._set_layer_value('pl_overlay', [20], priority=500)
+        assert p._layer_value('base') == [10]
+        assert p._layer_value('pl_overlay') == [20]
+        assert p._layer_value('nonexistent') is None
+
+    def test_winning_layer_no_view(self):
+        p = LopperProp('clocks', value=[1])
+        p._set_layer_value('base', [10])
+        p._set_layer_value('pl_overlay', [20], priority=500)
+        assert p._winning_layer_value() == [20]
+
+    def test_winning_layer_with_view(self):
+        p = LopperProp('clocks', value=[1])
+        p._set_layer_value('base', [10])
+        p._set_layer_value('pl_overlay', [20], priority=500)
+        assert p._winning_layer_value('base') == [10]
+        assert p._winning_layer_value('pl_overlay') == [20]
+
+    def test_winning_layer_view_missing_falls_back_to_winning(self):
+        p = LopperProp('clocks', value=[1])
+        p._set_layer_value('base', [10])
+        # no 'other_overlay' layer
+        assert p._winning_layer_value('other_overlay') == [10]
+
+    def test_modifications_wins_over_all(self):
+        p = LopperProp('clocks', value=[1])
+        p._set_layer_value('base', [10])
+        p._set_layer_value('pl_overlay', [20], priority=500)
+        p._set_layer_value('modifications', [999], priority=1000)
+        assert p._winning_layer_value() == [999]
+
+    def test_setattr_writes_modifications_layer(self):
+        t, n, p = _make_tree_with_prop([1])
+        p.value = [42]
+        assert 'modifications' in p._layers
+        assert p._layers['modifications'] == (1000, [42])
+
+
+# ---------------------------------------------------------------------------
+# View context manager tests
+# ---------------------------------------------------------------------------
+
+class TestViewContextManager:
+    def test_default_view_is_winning(self):
+        t, n, p = _make_tree_with_prop([100])
+        p.set_layer_value('base', [100])
+        p.set_layer_value('pl_overlay', [200], priority=500)
+        assert p.value == [200]
+
+    def test_base_view_returns_base(self):
+        t, n, p = _make_tree_with_prop([100])
+        p._set_layer_value('base', [100])
+        p._set_layer_value('pl_overlay', [200], priority=500)
+        with t.view('base'):
+            assert p.value == [100]
+
+    def test_overlay_view_returns_overlay(self):
+        t, n, p = _make_tree_with_prop([100])
+        p._set_layer_value('base', [100])
+        p._set_layer_value('pl_overlay', [200], priority=500)
+        with t.view('pl_overlay'):
+            assert p.value == [200]
+
+    def test_view_restores_after_exit(self):
+        t, n, p = _make_tree_with_prop([100])
+        p.set_layer_value('base', [100])
+        p.set_layer_value('pl_overlay', [200], priority=500)
+        with t.view('base'):
+            assert p.value == [100]
+        # After exiting, returns to winning
+        assert p.value == [200]
+
+    def test_nested_views(self):
+        t, n, p = _make_tree_with_prop([100])
+        p.set_layer_value('base', [100])
+        p.set_layer_value('overlay_a', [200], priority=500)
+        p.set_layer_value('overlay_b', [300], priority=600)
+        with t.view('base'):
+            assert p.value == [100]
+            with t.view('overlay_a'):
+                assert p.value == [200]
+            # Inner view exited, back to base
+            assert p.value == [100]
+        # Both exited, back to winning
+        assert p.value == [300]
+
+    def test_view_yields_tree(self):
+        t = LopperTree()
+        with t.view('base') as tree:
+            assert tree is t
+
+    def test_modifications_win_in_base_view(self):
+        """Explicit writes always win, even in base view."""
+        t, n, p = _make_tree_with_prop([1])
+        p._set_layer_value('base', [10])
+        p._set_layer_value('pl_overlay', [20], priority=500)
+        p.value = [999]   # modifications layer, priority 1000
+        with t.view('base'):
+            # modifications (1000) > base (0), modifications wins when viewing base
+            # because view selects the 'base' layer explicitly
+            assert p.value == [10]
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility tests
+# ---------------------------------------------------------------------------
+
+class TestBackwardCompat:
+    def test_prop_value_returns_list(self):
+        t, n, p = _make_tree_with_prop([42])
+        assert isinstance(p.value, list)
+        assert p.value == [42]
+
+    def test_prop_value_index(self):
+        t, n, p = _make_tree_with_prop([42])
+        assert p.value[0] == 42
+
+    def test_prop_value_assign_scalar(self):
+        t, n, p = _make_tree_with_prop([1])
+        p.value = 99
+        assert p.value == [99]
+
+    def test_prop_value_assign_list(self):
+        t, n, p = _make_tree_with_prop([1])
+        p.value = [10, 20]
+        assert p.value == [10, 20]
+
+    def test_propval_no_view(self):
+        """LopperNode.propval() should return winning value with no view set."""
+        t, n, p = _make_tree_with_prop([42], name='reg')
+        p.set_layer_value('base', [42])
+        p.set_layer_value('overlay', [99], priority=500)
+        result = n.propval('reg')
+        assert result == [99]
+
+    def test_propval_in_base_view(self):
+        """LopperNode.propval() returns base value inside base view."""
+        t, n, p = _make_tree_with_prop([42], name='reg')
+        p._set_layer_value('base', [42])
+        p._set_layer_value('overlay', [99], priority=500)
+        with t.view('base'):
+            result = n.propval('reg')
+        assert result == [42]
+
+    def test_no_layers_fallback(self):
+        """Props with empty _layers fall back to __dict__['value']."""
+        p = LopperProp('clocks', value=[7])
+        p._layers.clear()
+        assert p.value == [7]
+
+    def test_deepcopy_preserves_layers(self):
+        import copy
+        t, n, p = _make_tree_with_prop([1])
+        p._set_layer_value('base', [1])
+        p._set_layer_value('pl_overlay', [2], priority=500)
+        p2 = copy.deepcopy(p)
+        assert 'base' in p2._layers
+        assert 'pl_overlay' in p2._layers
+        assert p2._layers['base'] == p._layers['base']
+        assert p2._node is None  # backref not copied
+
+
+# ---------------------------------------------------------------------------
+# Node visibility tests
+# ---------------------------------------------------------------------------
+
+class TestNodeVisibility:
+    def test_overlay_node_hidden_in_base_view(self):
+        """A node with _origin_layer set should not appear in 'base' view output."""
+        t = LopperTree()
+        root = t['/']
+
+        n = LopperNode(-1, '/overlay_node')
+        n._origin_layer = 'pl_overlay'
+        t.add(n)
+        t.resolve()
+
+        buf = io.StringIO()
+        with t.view('base'):
+            root.print(buf)
+        output = buf.getvalue()
+        assert 'overlay_node' not in output
+
+    def test_base_node_visible_in_base_view(self):
+        """A node with _origin_layer=None should appear in 'base' view output."""
+        t = LopperTree()
+        n = LopperNode(-1, '/base_node')
+        # _origin_layer stays None (default)
+        t.add(n)
+        t.resolve()
+
+        buf = io.StringIO()
+        with t.view('base'):
+            t['/'].print(buf)
+        output = buf.getvalue()
+        assert 'base_node' in output
+
+    def test_overlay_node_visible_in_overlay_view(self):
+        """Overlay node appears when viewing the correct overlay layer."""
+        t = LopperTree()
+        n = LopperNode(-1, '/pl_thing')
+        n._origin_layer = 'pl_overlay'
+        t.add(n)
+        t.resolve()
+
+        buf = io.StringIO()
+        with t.view('pl_overlay'):
+            t['/'].print(buf)
+        output = buf.getvalue()
+        assert 'pl_thing' in output
+
+    def test_overlay_property_hidden_in_base_view(self):
+        """A property tagged as overlay-sourced should not appear in base view."""
+        t, n, p = _make_tree_with_prop([200], name='address-map')
+        p._set_layer_value('pl', [200], priority=500)
+        t.resolve()
+
+        buf = io.StringIO()
+        with t.view('base'):
+            t['/'].print(buf)
+        output = buf.getvalue()
+        assert 'address-map' not in output
+
+    def test_base_property_not_skipped_in_base_view(self):
+        """A property without overlay source should NOT be filtered in base view.
+
+        We verify this by checking the filtering logic directly rather than
+        relying on full print() output (which has its own phandle-resolution
+        quirks for synthetic nodes not loaded from FDT).
+        """
+        t, n, p = _make_tree_with_prop([100], name='status', node_path='/base_node')
+        # Use a string value so it resolves cleanly
+        p2 = LopperProp('status', value=['okay'])
+        n['status'] = p2
+        real_p = n.__props__['status']
+        # No overlay layers (base tree property) — should NOT be filtered
+        overlay_layers = [k for k in real_p._layers if k not in ('base', 'modifications')]
+        assert overlay_layers == []
+        # In base view: no overlay layers => not filtered
+        with t.view('base'):
+            active = t.__dict__.get('_view_local')
+            active_view = getattr(active, 'active', None) if active else None
+            assert active_view == 'base'
+            # Property should pass the filter (no overlay layers)
+            should_skip = (active_view == 'base' and
+                           any(k not in ('base', 'modifications') for k in real_p._layers))
+            assert not should_skip
+
+
+# ---------------------------------------------------------------------------
+# Merge protection tests
+# ---------------------------------------------------------------------------
+
+class TestMergeBaseProtection:
+    def test_merge_doesnt_overwrite_existing_base(self):
+        """merge() should not overwrite 'base' layer if it already has a value."""
+        t, n, p1 = _make_tree_with_prop([10], name='clocks')
+        p1._set_layer_value('base', [10])
+
+        p2 = LopperProp('clocks', value=[20])
+        p1.merge(p2)
+
+        # base layer should still be [10]
+        assert p1._layer_value('base') == [10]
+
+    def test_merge_sets_base_if_empty(self):
+        """merge() should set 'base' layer if it wasn't set."""
+        p = LopperProp('clocks', value=[])
+        p._layers.clear()  # simulate prop with no layers
+
+        p2 = LopperProp('clocks', value=[42])
+        p.merge(p2)
+
+        # base was empty, merge should set it
+        assert 'base' in p._layers
+
+
+if __name__ == '__main__':
+    import pytest
+    pytest.main([__file__, '-v'])

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -1,0 +1,296 @@
+"""
+Tests for overlay generation functionality.
+
+Tests the node_refs(), tree_refs(), fragment_create(), and fragment_add_for_refs()
+methods used for generating overlay fragments when base tree properties reference
+overlay nodes.
+"""
+
+import pytest
+import tempfile
+from pathlib import Path
+
+from lopper.tree import LopperTree, LopperNode, LopperProp
+import lopper.base
+
+
+class TestNodeRefs:
+    """Tests for LopperNode.node_refs() method."""
+
+    def test_node_refs_finds_phandle_reference(self, lopper_tree):
+        """
+        Test that node_refs finds properties that reference a node's phandle.
+        """
+        # Find a node that has a phandle and is referenced by another property
+        # In the test tree, interrupt-parent properties reference interrupt controllers
+        target_node = None
+        for node in lopper_tree:
+            if node.phandle and node.phandle > 0:
+                # Check if any node references this phandle
+                refs = node.node_refs(lopper_tree)
+                if refs:
+                    target_node = node
+                    break
+
+        if target_node:
+            refs = target_node.node_refs(lopper_tree)
+            assert len(refs) > 0, "Expected to find references"
+            # Each ref is (node, prop_name, companion)
+            for ref_node, prop_name, companion in refs:
+                assert ref_node is not None
+                assert prop_name is not None
+
+    def test_node_refs_no_false_positives_from_integers(self):
+        """
+        Test that node_refs doesn't match arbitrary integers as phandles.
+
+        This tests the fix for Bug 2: reset-gpios = <&gpio0 0x19 0x1> should
+        not match a node with phandle 0x19 because 0x19 is a GPIO pin number,
+        not a phandle reference.
+        """
+        # Create a minimal tree
+        tree = LopperTree()
+        root = tree['/']
+        root + LopperProp(name='#gpio-cells', value=[2])
+
+        # GPIO controller with phandle 0x96
+        gpio0 = LopperNode(-1, "/gpio0")
+        gpio0.phandle = 0x96
+        gpio0 + LopperProp(name='#gpio-cells', value=[2])
+        tree.add(gpio0)
+
+        # A node with phandle 0x19 (same as GPIO pin number in reset-gpios)
+        other_node = LopperNode(-1, "/other_node")
+        other_node.phandle = 0x19
+        tree.add(other_node)
+
+        # PHY node with reset-gpios referencing gpio0, with pin 0x19
+        phy0 = LopperNode(-1, "/phy0")
+        phy0.phandle = 0x10
+        # reset-gpios = <&gpio0 0x19 0x1> -> [0x96, 0x19, 0x1]
+        phy0 + LopperProp(name='reset-gpios', value=[0x96, 0x19, 0x1])
+        tree.add(phy0)
+
+        # Sync and resolve the tree
+        tree.sync()
+        tree.resolve()
+
+        # Now check: other_node (phandle 0x19) should NOT be found as referenced
+        # by phy0's reset-gpios, because 0x19 is the GPIO pin, not a phandle
+        refs = other_node.node_refs(tree)
+
+        # Should find NO references - 0x19 is a GPIO pin number, not a phandle
+        assert len(refs) == 0, (
+            f"False positive: found {len(refs)} references to node with phandle 0x19, "
+            "but 0x19 appears as a GPIO pin number, not a phandle reference"
+        )
+
+
+class TestCompanionPropertySync:
+    """Tests for companion property synchronization in strict mode."""
+
+    def test_companion_sync_on_phandle_drop(self):
+        """
+        Test that when strict mode drops invalid phandle records,
+        the companion property is also updated.
+
+        This tests the fix for Bug 1: clock-names should be synced
+        when clocks entries are dropped due to invalid phandles.
+        """
+        # Create a tree with clocks and clock-names properties
+        tree = LopperTree()
+        tree.strict = True
+        root = tree['/']
+        root + LopperProp(name='#clock-cells', value=[1])
+
+        # Valid clock controller
+        clk_ctrl = LopperNode(-1, "/clock-controller")
+        clk_ctrl.phandle = 0xAD
+        clk_ctrl + LopperProp(name='#clock-cells', value=[1])
+        tree.add(clk_ctrl)
+
+        # Device node with clocks and clock-names
+        device = LopperNode(-1, "/device")
+        device.phandle = 0x10
+
+        # clocks = <&clk_ctrl 0x1>, <&invalid 0x2>, <&clk_ctrl 0x3>
+        # where &invalid (0xFF) doesn't exist in the tree
+        device + LopperProp(name='clocks', value=[0xAD, 0x1, 0xFF, 0x2, 0xAD, 0x3])
+        device + LopperProp(name='clock-names', value=["clk_a", "clk_b", "clk_c"])
+        tree.add(device)
+
+        tree.sync()
+
+        # Resolve the clocks property with strict mode and companion sync
+        clocks_prop = device['clocks']
+        clocks_prop.resolve(strict=True, sync_companions=True)
+
+        # After strict mode drops the invalid record, clock-names should have 2 entries
+        clock_names_prop = device['clock-names']
+        assert len(clock_names_prop.value) == 2, (
+            f"Expected clock-names to have 2 entries after dropping invalid phandle, "
+            f"got {len(clock_names_prop.value)}: {clock_names_prop.value}"
+        )
+        assert clock_names_prop.value == ["clk_a", "clk_c"], (
+            f"Expected clock-names to be ['clk_a', 'clk_c'], got {clock_names_prop.value}"
+        )
+
+
+class TestTreeRefs:
+    """Tests for LopperTree.tree_refs() method."""
+
+    def test_tree_refs_finds_cross_tree_references(self):
+        """
+        Test that tree_refs finds properties in base tree that reference
+        nodes in a target (overlay) tree.
+        """
+        # Create base tree
+        base_tree = LopperTree()
+        base_root = base_tree['/']
+        base_root + LopperProp(name='#clock-cells', value=[1])
+
+        # Device in base tree that references a clock
+        device = LopperNode(-1, "/device")
+        device.phandle = 0x10
+        device.label = "my_device"
+        device + LopperProp(name='clocks', value=[0x20, 0x0])  # References phandle 0x20
+        device + LopperProp(name='clock-names', value=["pl_clk"])
+        base_tree.add(device)
+        base_tree.sync()
+        base_tree.resolve()
+
+        # Create overlay tree with the referenced clock node
+        overlay_tree = LopperTree()
+        overlay_root = overlay_tree['/']
+
+        pl_clock = LopperNode(-1, "/pl_clock")
+        pl_clock.phandle = 0x20  # This is what device references
+        pl_clock.label = "pl_clk_0"
+        pl_clock + LopperProp(name='#clock-cells', value=[1])
+        overlay_tree.add(pl_clock)
+        overlay_tree.sync()
+        overlay_tree.resolve()
+
+        # Find references from base_tree to overlay_tree
+        refs = base_tree.tree_refs(overlay_tree)
+
+        # Should find device's clocks property references pl_clock
+        assert len(refs) > 0, "Expected to find references from base to overlay"
+
+        found_device_ref = False
+        for ref_node, prop_name, companion in refs:
+            if ref_node.name == "device" and prop_name == "clocks":
+                found_device_ref = True
+                assert companion == "clock-names", f"Expected companion 'clock-names', got {companion}"
+
+        assert found_device_ref, "Expected to find device's clocks property in refs"
+
+
+class TestFragmentCreate:
+    """Tests for LopperTree.fragment_create() method."""
+
+    def test_fragment_create_copies_specified_properties(self):
+        """
+        Test that fragment_create creates a node with only specified properties.
+        """
+        tree = LopperTree()
+        root = tree['/']
+
+        # Source node with multiple properties
+        source = LopperNode(-1, "/source_node")
+        source.phandle = 0x10
+        source.label = "my_source"
+        source + LopperProp(name='prop_a', value=[1, 2, 3])
+        source + LopperProp(name='prop_b', value=["hello"])
+        source + LopperProp(name='prop_c', value=[0xFF])
+        tree.add(source)
+        tree.sync()
+
+        # Create fragment with only prop_a and prop_b
+        fragment = tree.fragment_create(source, ["prop_a", "prop_b"])
+
+        assert fragment is not None, "fragment_create should return a node"
+        assert fragment.name == "&my_source", f"Expected name '&my_source', got {fragment.name}"
+        assert "prop_a" in fragment.__props__, "Fragment should have prop_a"
+        assert "prop_b" in fragment.__props__, "Fragment should have prop_b"
+        assert "prop_c" not in fragment.__props__, "Fragment should NOT have prop_c"
+
+    def test_fragment_create_requires_label(self):
+        """
+        Test that fragment_create returns None if source node has no label.
+        """
+        tree = LopperTree()
+        root = tree['/']
+
+        # Source node WITHOUT label
+        source = LopperNode(-1, "/source_node")
+        source.phandle = 0x10
+        # source.label is not set
+        source + LopperProp(name='prop_a', value=[1, 2, 3])
+        tree.add(source)
+        tree.sync()
+
+        # Create fragment - should return None because no label
+        fragment = tree.fragment_create(source, ["prop_a"])
+
+        assert fragment is None, "fragment_create should return None when source has no label"
+
+
+class TestFragmentAddForRefs:
+    """Tests for LopperTree.fragment_add_for_refs() method."""
+
+    def test_fragment_add_for_refs_creates_overlay_fragments(self):
+        """
+        Test that fragment_add_for_refs creates overlay fragments for
+        properties that reference overlay nodes.
+        """
+        # Create base tree
+        base_tree = LopperTree()
+        base_root = base_tree['/']
+        base_root + LopperProp(name='#clock-cells', value=[1])
+
+        # Device that references an overlay clock
+        device = LopperNode(-1, "/device")
+        device.phandle = 0x10
+        device.label = "my_device"
+        device + LopperProp(name='clocks', value=[0x20, 0x0])  # References phandle 0x20
+        device + LopperProp(name='clock-names', value=["pl_clk"])
+        base_tree.add(device)
+        base_tree.sync()
+        base_tree.resolve()
+
+        # Create overlay tree
+        overlay_tree = LopperTree()
+        overlay_root = overlay_tree['/']
+
+        pl_clock = LopperNode(-1, "/pl_clock")
+        pl_clock.phandle = 0x20
+        pl_clock.label = "pl_clk_0"
+        pl_clock + LopperProp(name='#clock-cells', value=[1])
+        overlay_tree.add(pl_clock)
+        overlay_tree.sync()
+        overlay_tree.resolve()
+
+        # Count nodes before
+        overlay_count_before = sum(1 for _ in overlay_tree)
+
+        # Add fragments for refs
+        fragments_added = base_tree.fragment_add_for_refs(overlay_tree)
+
+        # Count nodes after
+        overlay_count_after = sum(1 for _ in overlay_tree)
+
+        assert len(fragments_added) > 0, "Expected at least one fragment to be added"
+        assert overlay_count_after > overlay_count_before, (
+            "Overlay tree should have more nodes after adding fragments"
+        )
+
+        # Find the fragment node
+        fragment_found = False
+        for node in overlay_tree:
+            if node.name == "&my_device":
+                fragment_found = True
+                assert "clocks" in node.__props__, "Fragment should have clocks property"
+                break
+
+        assert fragment_found, "Expected to find &my_device fragment in overlay tree"

--- a/tests/test_overlay_sources.py
+++ b/tests/test_overlay_sources.py
@@ -1,0 +1,1443 @@
+"""
+Tests for overlay source tracking infrastructure.
+
+Tests the _source attribute on LopperProp and helper methods for
+finding overlay-sourced properties on nodes and trees.
+
+Also tests the helper functions for identifying and extracting
+overlay targets from DTS files.
+"""
+
+import pytest
+import subprocess
+import tempfile
+import os
+from lopper.tree import LopperTree, LopperNode, LopperProp
+from lopper import LopperSDT
+
+
+class TestPropertySourceAttribute:
+    """Test that _source attribute is properly initialized and copied."""
+
+    def test_source_defaults_to_none(self):
+        """New properties should have _source = None."""
+        prop = LopperProp('test-prop', value=[1, 2, 3])
+        assert prop._source is None
+
+    def test_source_can_be_set(self):
+        """_source should be settable."""
+        prop = LopperProp('test-prop', value=[1, 2, 3])
+        prop._source = 'overlay:mmi_dc.dtsi'
+        assert prop._source == 'overlay:mmi_dc.dtsi'
+
+    def test_source_preserved_on_deepcopy(self):
+        """_source should be preserved when property is deep copied."""
+        import copy
+        prop = LopperProp('test-prop', value=[1, 2, 3])
+        prop._source = 'overlay:test.dtsi'
+
+        prop_copy = copy.deepcopy(prop)
+
+        assert prop_copy._source == 'overlay:test.dtsi'
+
+    def test_source_formats(self):
+        """Various source format strings should be accepted."""
+        prop = LopperProp('test-prop', value=[1])
+
+        # Test various formats
+        prop._source = 'overlay:mmi_dc.dtsi'
+        assert prop._source == 'overlay:mmi_dc.dtsi'
+
+        prop._source = 'yaml:domains.yaml'
+        assert prop._source == 'yaml:domains.yaml'
+
+        prop._source = 'json:config.json'
+        assert prop._source == 'json:config.json'
+
+
+class TestNodeOverlaySourcedProperties:
+    """Test LopperNode.overlay_sourced_properties() method."""
+
+    def test_returns_empty_for_no_overlay_sources(self):
+        """Node with no overlay sources should return empty list."""
+        tree = LopperTree()
+        node = LopperNode(-1, "/test")
+        tree.add(node)
+        tree.sync()
+        tree.resolve()
+
+        # Add a property without source
+        tree['/test'] + LopperProp(name='regular-prop', value=[1])
+
+        result = tree['/test'].overlay_sourced_properties()
+        assert result == []
+
+    def test_finds_overlay_sourced_property(self):
+        """Should find properties with overlay source."""
+        tree = LopperTree()
+        node = LopperNode(-1, "/test")
+        tree.add(node)
+        tree.sync()
+        tree.resolve()
+
+        # Add property with overlay source
+        prop = LopperProp(name='overlay-prop', value=[1])
+        prop._source = 'overlay:mmi_dc.dtsi'
+        tree['/test'].__props__['overlay-prop'] = prop
+
+        result = tree['/test'].overlay_sourced_properties()
+        assert len(result) == 1
+        assert result[0] == ('overlay-prop', 'overlay:mmi_dc.dtsi')
+
+    def test_filter_by_specific_overlay(self):
+        """Should filter by specific overlay name."""
+        tree = LopperTree()
+        node = LopperNode(-1, "/test")
+        tree.add(node)
+        tree.sync()
+        tree.resolve()
+
+        # Add properties from different overlays
+        prop1 = LopperProp(name='prop1', value=[1])
+        prop1._source = 'overlay:overlay_a.dtsi'
+        tree['/test'].__props__['prop1'] = prop1
+
+        prop2 = LopperProp(name='prop2', value=[2])
+        prop2._source = 'overlay:overlay_b.dtsi'
+        tree['/test'].__props__['prop2'] = prop2
+
+        # Filter for overlay_a only
+        result = tree['/test'].overlay_sourced_properties('overlay_a.dtsi')
+        assert len(result) == 1
+        assert result[0][0] == 'prop1'
+
+        # Filter for overlay_b only
+        result = tree['/test'].overlay_sourced_properties('overlay_b.dtsi')
+        assert len(result) == 1
+        assert result[0][0] == 'prop2'
+
+    def test_filter_by_list_of_overlays(self):
+        """Should filter by list of overlay names."""
+        tree = LopperTree()
+        node = LopperNode(-1, "/test")
+        tree.add(node)
+        tree.sync()
+        tree.resolve()
+
+        # Add properties from different overlays
+        prop1 = LopperProp(name='prop1', value=[1])
+        prop1._source = 'overlay:a.dtsi'
+        tree['/test'].__props__['prop1'] = prop1
+
+        prop2 = LopperProp(name='prop2', value=[2])
+        prop2._source = 'overlay:b.dtsi'
+        tree['/test'].__props__['prop2'] = prop2
+
+        prop3 = LopperProp(name='prop3', value=[3])
+        prop3._source = 'overlay:c.dtsi'
+        tree['/test'].__props__['prop3'] = prop3
+
+        # Filter for a and b
+        result = tree['/test'].overlay_sourced_properties(['a.dtsi', 'b.dtsi'])
+        assert len(result) == 2
+        prop_names = [r[0] for r in result]
+        assert 'prop1' in prop_names
+        assert 'prop2' in prop_names
+        assert 'prop3' not in prop_names
+
+    def test_wildcard_matches_all_overlays(self):
+        """Wildcard '*' should match all overlay sources."""
+        tree = LopperTree()
+        node = LopperNode(-1, "/test")
+        tree.add(node)
+        tree.sync()
+        tree.resolve()
+
+        # Add properties from different overlays
+        prop1 = LopperProp(name='prop1', value=[1])
+        prop1._source = 'overlay:a.dtsi'
+        tree['/test'].__props__['prop1'] = prop1
+
+        prop2 = LopperProp(name='prop2', value=[2])
+        prop2._source = 'overlay:b.dtsi'
+        tree['/test'].__props__['prop2'] = prop2
+
+        result = tree['/test'].overlay_sourced_properties('*')
+        assert len(result) == 2
+
+    def test_ignores_non_overlay_sources(self):
+        """Should ignore properties with non-overlay sources (yaml, json)."""
+        tree = LopperTree()
+        node = LopperNode(-1, "/test")
+        tree.add(node)
+        tree.sync()
+        tree.resolve()
+
+        # Add property with yaml source
+        prop = LopperProp(name='yaml-prop', value=[1])
+        prop._source = 'yaml:domains.yaml'
+        tree['/test'].__props__['yaml-prop'] = prop
+
+        result = tree['/test'].overlay_sourced_properties('*')
+        assert result == []
+
+
+class TestTreeNodesWithOverlaySources:
+    """Test LopperTree.nodes_with_overlay_sources() method."""
+
+    def test_returns_empty_for_no_overlay_sources(self):
+        """Tree with no overlay sources should return empty list."""
+        tree = LopperTree()
+        node = LopperNode(-1, "/test")
+        tree.add(node)
+        tree.sync()
+        tree.resolve()
+
+        result = tree.nodes_with_overlay_sources()
+        assert result == []
+
+    def test_finds_nodes_with_overlay_properties(self):
+        """Should find nodes that have overlay-sourced properties."""
+        tree = LopperTree()
+        node1 = LopperNode(-1, "/node1")
+        node2 = LopperNode(-1, "/node2")
+        tree.add(node1)
+        tree.add(node2)
+        tree.sync()
+        tree.resolve()
+
+        # Add overlay property to node1 only
+        prop = LopperProp(name='overlay-prop', value=[1])
+        prop._source = 'overlay:test.dtsi'
+        tree['/node1'].__props__['overlay-prop'] = prop
+
+        result = tree.nodes_with_overlay_sources()
+        assert len(result) == 1
+        assert result[0][0].abs_path == '/node1'
+        assert len(result[0][1]) == 1
+
+    def test_filters_by_overlay_name(self):
+        """Should filter nodes by overlay source name."""
+        tree = LopperTree()
+        node1 = LopperNode(-1, "/node1")
+        node2 = LopperNode(-1, "/node2")
+        tree.add(node1)
+        tree.add(node2)
+        tree.sync()
+        tree.resolve()
+
+        # Add overlay property from 'a.dtsi' to node1
+        prop1 = LopperProp(name='prop1', value=[1])
+        prop1._source = 'overlay:a.dtsi'
+        tree['/node1'].__props__['prop1'] = prop1
+
+        # Add overlay property from 'b.dtsi' to node2
+        prop2 = LopperProp(name='prop2', value=[2])
+        prop2._source = 'overlay:b.dtsi'
+        tree['/node2'].__props__['prop2'] = prop2
+
+        # Filter for a.dtsi
+        result = tree.nodes_with_overlay_sources('a.dtsi')
+        assert len(result) == 1
+        assert result[0][0].abs_path == '/node1'
+
+        # Filter for b.dtsi
+        result = tree.nodes_with_overlay_sources('b.dtsi')
+        assert len(result) == 1
+        assert result[0][0].abs_path == '/node2'
+
+    def test_multiple_properties_per_node(self):
+        """Should return all matching properties for each node."""
+        tree = LopperTree()
+        node = LopperNode(-1, "/test")
+        tree.add(node)
+        tree.sync()
+        tree.resolve()
+
+        # Add multiple overlay properties
+        for i in range(3):
+            prop = LopperProp(name=f'prop{i}', value=[i])
+            prop._source = 'overlay:test.dtsi'
+            tree['/test'].__props__[f'prop{i}'] = prop
+
+        result = tree.nodes_with_overlay_sources()
+        assert len(result) == 1
+        assert len(result[0][1]) == 3
+
+
+class TestIsOverlayFile:
+    """Test is_overlay_file() helper function."""
+
+    def test_detects_overlay_syntax(self):
+        """Should detect &label { } overlay syntax."""
+        from lopper import is_overlay_file
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.dtsi', delete=False) as f:
+            f.write("""
+            &mmi_dc {
+                status = "okay";
+                clocks = <&pl_clk 0>;
+            };
+            """)
+            f.flush()
+            try:
+                assert is_overlay_file(f.name) is True
+            finally:
+                os.unlink(f.name)
+
+    def test_rejects_non_overlay_file(self):
+        """Should return False for files without overlay syntax."""
+        from lopper import is_overlay_file
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.dts', delete=False) as f:
+            f.write("""
+            /dts-v1/;
+            / {
+                model = "test";
+                compatible = "test,board";
+
+                device@0 {
+                    reg = <0x0 0x1000>;
+                };
+            };
+            """)
+            f.flush()
+            try:
+                assert is_overlay_file(f.name) is False
+            finally:
+                os.unlink(f.name)
+
+    def test_handles_missing_file(self):
+        """Should return False for non-existent files."""
+        from lopper import is_overlay_file
+        assert is_overlay_file('/nonexistent/path/file.dts') is False
+
+
+class TestExtractOverlayTargets:
+    """Test extract_overlay_targets() helper function."""
+
+    def test_extracts_single_target(self):
+        """Should extract single overlay target with properties."""
+        from lopper import extract_overlay_targets
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.dtsi', delete=False) as f:
+            f.write("""
+            &mmi_dc {
+                status = "okay";
+                clocks = <&pl_clk 0>;
+                clock-names = "pl_clk";
+            };
+            """)
+            f.flush()
+            try:
+                targets = extract_overlay_targets(f.name)
+                assert 'mmi_dc' in targets
+                assert 'status' in targets['mmi_dc']['props']
+                assert 'clocks' in targets['mmi_dc']['props']
+                assert 'clock-names' in targets['mmi_dc']['props']
+            finally:
+                os.unlink(f.name)
+
+    def test_extracts_multiple_targets(self):
+        """Should extract multiple overlay targets."""
+        from lopper import extract_overlay_targets
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.dtsi', delete=False) as f:
+            f.write("""
+            &node_a {
+                prop1 = "value1";
+            };
+
+            &node_b {
+                prop2 = "value2";
+                prop3 = <0x100>;
+            };
+            """)
+            f.flush()
+            try:
+                targets = extract_overlay_targets(f.name)
+                assert 'node_a' in targets
+                assert 'node_b' in targets
+                assert 'prop1' in targets['node_a']['props']
+                assert 'prop2' in targets['node_b']['props']
+                assert 'prop3' in targets['node_b']['props']
+            finally:
+                os.unlink(f.name)
+
+    def test_returns_empty_for_non_overlay(self):
+        """Should return empty dict for non-overlay file."""
+        from lopper import extract_overlay_targets
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.dts', delete=False) as f:
+            f.write("""
+            /dts-v1/;
+            / {
+                model = "test";
+            };
+            """)
+            f.flush()
+            try:
+                targets = extract_overlay_targets(f.name)
+                assert targets == {}
+            finally:
+                os.unlink(f.name)
+
+    def test_handles_missing_file(self):
+        """Should return empty dict for non-existent files."""
+        from lopper import extract_overlay_targets
+        targets = extract_overlay_targets('/nonexistent/path/file.dts')
+        assert targets == {}
+
+
+class TestExtractOverlayTargetsFromTree:
+    """Test extract_overlay_targets_from_tree() for compiled tree analysis.
+
+    Uses compile_overlay_standalone() to produce a real dtc-compiled tree,
+    then verifies extract_overlay_targets_from_tree() reads the fragment@N/
+    __overlay__ structure correctly.
+    """
+
+    def test_extracts_targets_from_tree(self):
+        """Should extract props and children from a compiled overlay tree."""
+        from lopper import extract_overlay_targets_from_tree, compile_overlay_standalone
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.dtsi', delete=False) as f:
+            f.write("&mmi_dc { status = \"okay\"; clocks = <&pl_clk 0>; };\n")
+            f.flush()
+            try:
+                tree = compile_overlay_standalone(f.name)
+                if tree is None:
+                    pytest.skip("dtc not available for overlay compilation")
+                targets = extract_overlay_targets_from_tree(tree)
+                assert 'mmi_dc' in targets
+                assert 'status' in targets['mmi_dc']['props']
+                assert 'clocks' in targets['mmi_dc']['props']
+                assert targets['mmi_dc']['children'] == []
+            finally:
+                os.unlink(f.name)
+
+    def test_extracts_multiple_targets(self):
+        """Should extract multiple overlay targets from compiled tree."""
+        from lopper import extract_overlay_targets_from_tree, compile_overlay_standalone
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.dtsi', delete=False) as f:
+            f.write("&device_a { prop1 = \"value1\"; };\n"
+                    "&device_b { prop2 = <0x100>; };\n")
+            f.flush()
+            try:
+                tree = compile_overlay_standalone(f.name)
+                if tree is None:
+                    pytest.skip("dtc not available for overlay compilation")
+                targets = extract_overlay_targets_from_tree(tree)
+                assert 'device_a' in targets
+                assert 'device_b' in targets
+                assert 'prop1' in targets['device_a']['props']
+                assert 'prop2' in targets['device_b']['props']
+            finally:
+                os.unlink(f.name)
+
+    def test_ignores_non_overlay_nodes(self):
+        """Should return empty dict for a non-overlay (normal DTS) file."""
+        from lopper import extract_overlay_targets_from_tree, compile_overlay_standalone
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.dts', delete=False) as f:
+            f.write("/dts-v1/;\n/ { model = \"test\"; };\n")
+            f.flush()
+            try:
+                # compile_overlay_standalone returns None for non-overlay files
+                tree = compile_overlay_standalone(f.name)
+                if tree is not None:
+                    targets = extract_overlay_targets_from_tree(tree)
+                    assert targets == {}
+                # If None, the function correctly rejected the non-overlay file
+            finally:
+                os.unlink(f.name)
+
+
+class TestRegexFallback:
+    """Test _extract_overlay_targets_regex() fallback function."""
+
+    def test_regex_fallback_works(self):
+        """Should extract targets using brace-counting parser when no dtc available."""
+        from lopper import _extract_overlay_targets_regex
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.dtsi', delete=False) as f:
+            f.write("""
+            &my_device {
+                status = "okay";
+                reg = <0x100 0x1000>;
+            };
+            """)
+            f.flush()
+            try:
+                targets = _extract_overlay_targets_regex(f.name)
+                assert 'my_device' in targets
+                assert 'status' in targets['my_device']['props']
+                assert 'reg' in targets['my_device']['props']
+            finally:
+                os.unlink(f.name)
+
+
+class TestFragmentAddForOverlaySources:
+    """Test LopperTree.fragment_add_for_overlay_sources() method."""
+
+    def test_creates_fragment_for_overlay_sourced_props(self):
+        """Should create fragment for nodes with overlay-sourced properties."""
+        tree = LopperTree()
+
+        # Create a node with a label (required for fragment creation)
+        device = LopperNode(-1, "/device")
+        device.label = "my_device"
+        tree.add(device)
+        tree.sync()
+        tree.resolve()
+
+        # Add overlay-sourced properties
+        prop1 = LopperProp(name='status', value=["okay"])
+        prop1._source = 'overlay:test.dtsi'
+        tree['/device'].__props__['status'] = prop1
+
+        prop2 = LopperProp(name='clocks', value=[0x20, 0x0])
+        prop2._source = 'overlay:test.dtsi'
+        tree['/device'].__props__['clocks'] = prop2
+
+        # Create overlay tree
+        overlay = LopperTree()
+
+        # Add fragments for overlay sources
+        fragments = tree.fragment_add_for_overlay_sources(overlay)
+
+        assert len(fragments) == 1
+        assert fragments[0].name == '&my_device'
+
+    def test_mode_properties_only_includes_sourced_props(self):
+        """Mode 'properties' should only include overlay-sourced properties."""
+        tree = LopperTree()
+
+        device = LopperNode(-1, "/device")
+        device.label = "my_device"
+        tree.add(device)
+        tree.sync()
+        tree.resolve()
+
+        # Add one overlay-sourced property
+        prop1 = LopperProp(name='status', value=["okay"])
+        prop1._source = 'overlay:test.dtsi'
+        tree['/device'].__props__['status'] = prop1
+
+        # Add one non-sourced property
+        prop2 = LopperProp(name='reg', value=[0x0, 0x1000])
+        tree['/device'].__props__['reg'] = prop2
+
+        overlay = LopperTree()
+        fragments = tree.fragment_add_for_overlay_sources(overlay, mode='properties')
+
+        assert len(fragments) == 1
+        # Fragment should only have 'status', not 'reg'
+        assert 'status' in fragments[0].__props__
+        assert 'reg' not in fragments[0].__props__
+
+    def test_mode_full_nodes_includes_all_props(self):
+        """Mode 'full_nodes' should include all properties from touched nodes."""
+        tree = LopperTree()
+
+        device = LopperNode(-1, "/device")
+        device.label = "my_device"
+        tree.add(device)
+        tree.sync()
+        tree.resolve()
+
+        # Add one overlay-sourced property
+        prop1 = LopperProp(name='status', value=["okay"])
+        prop1._source = 'overlay:test.dtsi'
+        tree['/device'].__props__['status'] = prop1
+
+        # Add one non-sourced property
+        prop2 = LopperProp(name='reg', value=[0x0, 0x1000])
+        tree['/device'].__props__['reg'] = prop2
+
+        overlay = LopperTree()
+        fragments = tree.fragment_add_for_overlay_sources(overlay, mode='full_nodes')
+
+        assert len(fragments) == 1
+        # Fragment should have both properties
+        assert 'status' in fragments[0].__props__
+        assert 'reg' in fragments[0].__props__
+
+    def test_filter_by_specific_overlay(self):
+        """Should filter by specific overlay filename."""
+        tree = LopperTree()
+
+        device = LopperNode(-1, "/device")
+        device.label = "my_device"
+        tree.add(device)
+        tree.sync()
+        tree.resolve()
+
+        # Add properties from different overlays
+        prop1 = LopperProp(name='prop_a', value=[1])
+        prop1._source = 'overlay:a.dtsi'
+        tree['/device'].__props__['prop_a'] = prop1
+
+        prop2 = LopperProp(name='prop_b', value=[2])
+        prop2._source = 'overlay:b.dtsi'
+        tree['/device'].__props__['prop_b'] = prop2
+
+        overlay = LopperTree()
+        # Only get properties from a.dtsi
+        fragments = tree.fragment_add_for_overlay_sources(
+            overlay,
+            source_filter='a.dtsi',
+            mode='properties'
+        )
+
+        assert len(fragments) == 1
+        assert 'prop_a' in fragments[0].__props__
+        assert 'prop_b' not in fragments[0].__props__
+
+    def test_returns_empty_for_no_overlay_sources(self):
+        """Should return empty list when no overlay sources exist."""
+        tree = LopperTree()
+        device = LopperNode(-1, "/device")
+        device.label = "my_device"
+        tree.add(device)
+        tree.sync()
+        tree.resolve()
+
+        # Add property without source
+        prop = LopperProp(name='reg', value=[0x0, 0x1000])
+        tree['/device'].__props__['reg'] = prop
+
+        overlay = LopperTree()
+        fragments = tree.fragment_add_for_overlay_sources(overlay)
+
+        assert fragments == []
+
+    def test_merges_into_existing_fragment(self):
+        """Should merge properties into existing fragment if present."""
+        tree = LopperTree()
+
+        device = LopperNode(-1, "/device")
+        device.label = "my_device"
+        tree.add(device)
+        tree.sync()
+        tree.resolve()
+
+        # Add overlay-sourced property
+        prop = LopperProp(name='status', value=["okay"])
+        prop._source = 'overlay:test.dtsi'
+        tree['/device'].__props__['status'] = prop
+
+        # Create overlay with existing fragment for same node
+        overlay = LopperTree()
+        existing_frag = LopperNode(name="&my_device")
+        existing_prop = LopperProp(name='clocks', value=[0x20])
+        existing_frag.__props__['clocks'] = existing_prop
+        overlay.add(existing_frag)
+        overlay.sync()
+
+        # Should merge into existing fragment rather than create new one
+        fragments = tree.fragment_add_for_overlay_sources(overlay)
+
+        # No new fragments created (merged into existing)
+        assert len(fragments) == 0
+
+        # Find the existing fragment and verify it has both properties
+        found_frag = None
+        for node in overlay:
+            if node.name == '&my_device':
+                found_frag = node
+                break
+
+        assert found_frag is not None
+        assert 'clocks' in found_frag.__props__  # Original
+        assert 'status' in found_frag.__props__  # Merged
+
+    def test_skips_nodes_without_labels(self):
+        """Should skip nodes that don't have labels."""
+        tree = LopperTree()
+
+        # Node without a label
+        device = LopperNode(-1, "/device")
+        # No device.label = ...
+        tree.add(device)
+        tree.sync()
+        tree.resolve()
+
+        prop = LopperProp(name='status', value=["okay"])
+        prop._source = 'overlay:test.dtsi'
+        tree['/device'].__props__['status'] = prop
+
+        overlay = LopperTree()
+        fragments = tree.fragment_add_for_overlay_sources(overlay)
+
+        # No fragment created because node has no label
+        assert fragments == []
+
+
+class TestOverlaySourceIntegration:
+    """Integration tests for the full overlay source tracking workflow.
+
+    These tests verify the end-to-end use case:
+    1. User provides overlay file modifying existing nodes
+    2. Overlay is analyzed and properties tagged during setup
+    3. Fragment generation pulls user's overlay properties into output
+    """
+
+    def test_full_workflow_single_overlay(self):
+        """Test full workflow: overlay file → tagging → fragment generation.
+
+        Simulates the real use case where user's mmi_dc.dtsi adds properties
+        to an existing node, and those properties should appear in the
+        generated output overlay.
+        """
+        from lopper import extract_overlay_targets
+
+        # Step 1: Create overlay file (simulating user's mmi_dc.dtsi)
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.dtsi', delete=False) as f:
+            f.write("""
+            &mmi_dc {
+                status = "okay";
+                xlnx,dc-pixel-format = "rgb888";
+                clocks = <&pl_clk 0>;
+            };
+            """)
+            overlay_file = f.name
+            f.flush()
+
+        try:
+            # Step 2: Extract overlay targets (what _tag_overlay_properties does)
+            targets = extract_overlay_targets(overlay_file)
+            assert 'mmi_dc' in targets
+            assert 'status' in targets['mmi_dc']['props']
+            assert 'xlnx,dc-pixel-format' in targets['mmi_dc']['props']
+            assert 'clocks' in targets['mmi_dc']['props']
+
+            # Step 3: Create base tree with the target node
+            tree = LopperTree()
+            mmi_dc = LopperNode(-1, "/amba/mmi_dc@fd4a0000")
+            mmi_dc.label = "mmi_dc"
+            tree.add(mmi_dc)
+            tree.sync()
+            tree.resolve()
+
+            # Step 4: Tag properties as coming from overlay
+            # (simulating what _tag_overlay_properties does after merge)
+            source_tag = f"overlay:{os.path.basename(overlay_file)}"
+            for label, target_info in targets.items():
+                # Find node by label - use __nodes__ to avoid iterator state issues
+                node = None
+                for n in tree.__nodes__.values():
+                    if n.label == label:
+                        node = n
+                        break
+
+                if node:
+                    for prop_name in target_info['props']:
+                        # Simulate merged property
+                        if prop_name == 'status':
+                            prop = LopperProp(name=prop_name, value=["okay"])
+                        elif prop_name == 'xlnx,dc-pixel-format':
+                            prop = LopperProp(name=prop_name, value=["rgb888"])
+                        else:
+                            prop = LopperProp(name=prop_name, value=[0x20, 0x0])
+
+                        prop._source = source_tag
+                        node.__props__[prop_name] = prop
+
+            # Step 5: Verify properties are tagged
+            overlay_props = tree['/amba/mmi_dc@fd4a0000'].overlay_sourced_properties()
+            assert len(overlay_props) == 3
+            prop_names = [p[0] for p in overlay_props]
+            assert 'status' in prop_names
+            assert 'xlnx,dc-pixel-format' in prop_names
+            assert 'clocks' in prop_names
+
+            # Step 6: Generate fragment for output overlay
+            output_overlay = LopperTree()
+            fragments = tree.fragment_add_for_overlay_sources(output_overlay)
+
+            # Step 7: Verify fragment contains user's properties
+            assert len(fragments) == 1
+            frag = fragments[0]
+            assert frag.name == '&mmi_dc'
+            assert 'status' in frag.__props__
+            assert 'xlnx,dc-pixel-format' in frag.__props__
+            assert 'clocks' in frag.__props__
+
+        finally:
+            os.unlink(overlay_file)
+
+    def test_multiple_overlays_selective_pullback(self):
+        """Test selective pullback when multiple overlays modify the tree.
+
+        User provides two overlays:
+        - display.dtsi: modifies &mmi_dc
+        - audio.dtsi: modifies &audio_controller
+
+        Output should be able to pull back only display.dtsi content.
+        """
+        from lopper import extract_overlay_targets
+
+        # Create two overlay files
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.dtsi', delete=False) as f1:
+            f1.write("""
+            &mmi_dc {
+                status = "okay";
+            };
+            """)
+            display_file = f1.name
+            f1.flush()
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.dtsi', delete=False) as f2:
+            f2.write("""
+            &audio_ctrl {
+                status = "disabled";
+            };
+            """)
+            audio_file = f2.name
+            f2.flush()
+
+        try:
+            # Create base tree with both nodes
+            tree = LopperTree()
+
+            mmi_dc = LopperNode(-1, "/amba/mmi_dc@fd4a0000")
+            mmi_dc.label = "mmi_dc"
+            tree.add(mmi_dc)
+
+            audio = LopperNode(-1, "/amba/audio@fd4b0000")
+            audio.label = "audio_ctrl"
+            tree.add(audio)
+
+            tree.sync()
+            tree.resolve()
+
+            # Tag properties from each overlay
+            for overlay_file in [display_file, audio_file]:
+                targets = extract_overlay_targets(overlay_file)
+                source_tag = f"overlay:{os.path.basename(overlay_file)}"
+
+                for label, target_info in targets.items():
+                    # Use __nodes__ to avoid iterator state issues
+                    node = None
+                    for n in tree.__nodes__.values():
+                        if n.label == label:
+                            node = n
+                            break
+
+                    if node:
+                        for prop_name in target_info['props']:
+                            prop = LopperProp(name=prop_name, value=["okay"])
+                            prop._source = source_tag
+                            node.__props__[prop_name] = prop
+
+            # Generate fragments for only display.dtsi
+            output_overlay = LopperTree()
+            fragments = tree.fragment_add_for_overlay_sources(
+                output_overlay,
+                source_filter=os.path.basename(display_file)
+            )
+
+            # Should only have fragment for mmi_dc, not audio_ctrl
+            assert len(fragments) == 1
+            assert fragments[0].name == '&mmi_dc'
+
+        finally:
+            os.unlink(display_file)
+            os.unlink(audio_file)
+
+    def test_phandle_refs_plus_overlay_sources(self):
+        """Test that both phandle refs and overlay sources are captured.
+
+        This tests the complete scenario:
+        - User overlay adds clocks property referencing PL node
+        - PL node is extracted to overlay
+        - fragment_add_for_refs() adds fragment for clocks
+        - fragment_add_for_overlay_sources() adds any other user properties
+
+        The two methods should work together without duplication.
+        """
+        tree = LopperTree()
+
+        # Create PS node that user overlay will modify
+        mmi_dc = LopperNode(-1, "/amba/mmi_dc@fd4a0000")
+        mmi_dc.label = "mmi_dc"
+        tree.add(mmi_dc)
+
+        # Create PL node (will be "extracted" to overlay)
+        pl_clk = LopperNode(-1, "/amba_pl/clkx5_wiz_0")
+        pl_clk.label = "clkx5_wiz_0"
+        pl_clk.phandle = 0x50
+        tree.add(pl_clk)
+
+        tree.sync()
+        tree.resolve()
+
+        # User overlay adds:
+        # 1. clocks property referencing PL node (phandle ref)
+        # 2. status property (non-phandle, just overlay source)
+        clocks_prop = LopperProp(name='clocks', value=[0x50, 0x0])
+        clocks_prop._source = 'overlay:mmi_dc.dtsi'
+        tree['/amba/mmi_dc@fd4a0000'].__props__['clocks'] = clocks_prop
+
+        status_prop = LopperProp(name='status', value=["okay"])
+        status_prop._source = 'overlay:mmi_dc.dtsi'
+        tree['/amba/mmi_dc@fd4a0000'].__props__['status'] = status_prop
+
+        # Create output overlay (simulating extracted PL nodes)
+        output_overlay = LopperTree()
+        extracted = LopperNode(-1, "/amba_pl/clkx5_wiz_0")
+        extracted.label = "clkx5_wiz_0"
+        extracted.phandle = 0x50
+        output_overlay.add(extracted)
+        output_overlay.sync()
+
+        # First: fragment_add_for_refs would add fragment for clocks
+        # (We simulate this by adding a fragment manually)
+        frag_from_refs = LopperNode(name="&mmi_dc")
+        frag_from_refs.__props__['clocks'] = LopperProp(name='clocks', value=[0x50, 0x0])
+        output_overlay.add(frag_from_refs)
+        output_overlay.sync()
+
+        # Second: fragment_add_for_overlay_sources should merge status
+        # into existing fragment, not create duplicate
+        fragments = tree.fragment_add_for_overlay_sources(output_overlay)
+
+        # Should return 0 new fragments (merged into existing)
+        assert len(fragments) == 0
+
+        # Find the fragment and verify both properties present
+        frag = None
+        for node in output_overlay:
+            if node.name == '&mmi_dc':
+                frag = node
+                break
+
+        assert frag is not None
+        assert 'clocks' in frag.__props__  # From fragment_add_for_refs
+        assert 'status' in frag.__props__  # From fragment_add_for_overlay_sources
+
+    def test_overlay_with_vendor_specific_properties(self):
+        """Test that vendor-specific properties are captured.
+
+        Real use case: User overlay sets xlnx,* properties that aren't
+        phandle references but should still appear in output.
+        """
+        tree = LopperTree()
+
+        dc = LopperNode(-1, "/amba/mmi_dc@fd4a0000")
+        dc.label = "mmi_dc"
+        tree.add(dc)
+        tree.sync()
+        tree.resolve()
+
+        # Add vendor-specific properties from user overlay
+        props_from_overlay = [
+            ('status', ["okay"]),
+            ('xlnx,dc-pixel-format', ["rgb888"]),
+            ('xlnx,dc-timing-mode', [1]),
+            ('xlnx,dc-height', [1080]),
+            ('xlnx,dc-width', [1920]),
+        ]
+
+        for name, value in props_from_overlay:
+            prop = LopperProp(name=name, value=value)
+            prop._source = 'overlay:mmi_dc.dtsi'
+            tree['/amba/mmi_dc@fd4a0000'].__props__[name] = prop
+
+        # Generate fragment
+        output_overlay = LopperTree()
+        fragments = tree.fragment_add_for_overlay_sources(output_overlay)
+
+        assert len(fragments) == 1
+        frag = fragments[0]
+
+        # All properties should be in fragment
+        for name, _ in props_from_overlay:
+            assert name in frag.__props__, f"Missing property: {name}"
+
+    def test_round_trip_overlay_reconstruction(self):
+        """Test that an overlay can be reconstructed from the merged tree.
+
+        This is the key use case: user provides overlay, it gets merged
+        for validation, then we extract it back out and verify it matches
+        the original.
+
+        Input overlay:
+            &mmi_dc {
+                status = "okay";
+                xlnx,dc-pixel-format = "rgb888";
+                xlnx,dc-timing-mode = <1>;
+            };
+
+        After merge + extraction, the generated fragment should contain
+        exactly those same properties with the same values.
+        """
+        from lopper import extract_overlay_targets
+
+        # Define the original overlay content
+        original_overlay_content = """
+        &mmi_dc {
+            status = "okay";
+            xlnx,dc-pixel-format = "rgb888";
+            xlnx,dc-timing-mode = <1>;
+        };
+        """
+
+        # Expected properties and values from the overlay
+        expected_props = {
+            'status': ["okay"],
+            'xlnx,dc-pixel-format': ["rgb888"],
+            'xlnx,dc-timing-mode': [1],
+        }
+
+        # Step 1: Write overlay to temp file and extract targets
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.dtsi', delete=False) as f:
+            f.write(original_overlay_content)
+            overlay_file = f.name
+            f.flush()
+
+        try:
+            targets = extract_overlay_targets(overlay_file)
+            overlay_basename = os.path.basename(overlay_file)
+
+            # Step 2: Create base tree representing the SDT
+            base_tree = LopperTree()
+
+            # Base tree has mmi_dc with some existing properties
+            mmi_dc = LopperNode(-1, "/amba/mmi_dc@fd4a0000")
+            mmi_dc.label = "mmi_dc"
+            base_tree.add(mmi_dc)
+            base_tree.sync()
+            base_tree.resolve()
+
+            # Add a property that exists in base but NOT in overlay
+            base_only_prop = LopperProp(name='reg', value=[0xfd4a0000, 0x10000])
+            base_tree['/amba/mmi_dc@fd4a0000'].__props__['reg'] = base_only_prop
+
+            # Step 3: Simulate merge - add overlay properties to base tree
+            # (In real flow, DTC does this during concatenated compilation)
+            source_tag = f"overlay:{overlay_basename}"
+            for label, target_info in targets.items():
+                node = None
+                for n in base_tree.__nodes__.values():
+                    if n.label == label:
+                        node = n
+                        break
+
+                if node:
+                    for prop_name in target_info['props']:
+                        # Create property with value from expected_props
+                        value = expected_props.get(prop_name, ["unknown"])
+                        prop = LopperProp(name=prop_name, value=value)
+                        prop._source = source_tag
+                        node.__props__[prop_name] = prop
+
+            # Step 4: Extract overlay content back out
+            reconstructed_overlay = LopperTree()
+            fragments = base_tree.fragment_add_for_overlay_sources(
+                reconstructed_overlay,
+                source_filter=overlay_basename,
+                mode='properties'  # Only properties from overlay
+            )
+
+            # Step 5: Verify reconstruction matches original
+            assert len(fragments) == 1, "Should have exactly one fragment"
+
+            frag = fragments[0]
+            assert frag.name == '&mmi_dc', "Fragment should target mmi_dc"
+
+            # Verify all expected properties are present with correct values
+            for prop_name, expected_value in expected_props.items():
+                assert prop_name in frag.__props__, \
+                    f"Missing property '{prop_name}' in reconstructed overlay"
+
+                actual_value = frag.__props__[prop_name].value
+                assert actual_value == expected_value, \
+                    f"Property '{prop_name}': expected {expected_value}, got {actual_value}"
+
+            # Verify base-only properties are NOT in the fragment
+            assert 'reg' not in frag.__props__, \
+                "Base-only property 'reg' should not be in reconstructed overlay"
+
+            # Verify property count matches (no extra properties)
+            # Filter out internal properties like phandle
+            frag_props = [p for p in frag.__props__.keys()
+                          if not p.startswith('lopper-') and p != 'phandle']
+            assert len(frag_props) == len(expected_props), \
+                f"Property count mismatch: expected {len(expected_props)}, got {len(frag_props)}"
+
+        finally:
+            os.unlink(overlay_file)
+
+    def test_assist_workflow_simulation(self):
+        """Simulate the xlnx_overlay_pl_dt assist workflow.
+
+        This test mirrors what the assist does:
+        1. User provides overlay modifying PS node with PL clock references
+        2. PL nodes are extracted to overlay tree
+        3. fragment_add_for_refs() pulls properties referencing PL nodes
+        4. fragment_add_for_overlay_sources() pulls user's other properties
+        5. Output overlay contains both phandle refs AND user properties
+
+        This is the workflow shown in xlnx_overlay_pl_dt-integration-sample.md
+        """
+        from lopper import extract_overlay_targets
+
+        # User's overlay: mmi_dc with status and clocks referencing PL
+        user_overlay = """
+        &mmi_dc {
+            status = "okay";
+            xlnx,dc-pixel-format = "rgb888";
+            clocks = <&clkx5_wiz_0 0>;
+        };
+        """
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.dtsi', delete=False) as f:
+            f.write(user_overlay)
+            overlay_file = f.name
+            f.flush()
+
+        try:
+            # === SETUP: Create base tree (SDT) ===
+            base_tree = LopperTree()
+
+            # PS node that user overlay modifies
+            mmi_dc = LopperNode(-1, "/amba/mmi_dc@fd4a0000")
+            mmi_dc.label = "mmi_dc"
+            base_tree.add(mmi_dc)
+
+            # PL node that will be extracted to overlay
+            clkx5_wiz = LopperNode(-1, "/amba_pl/clkx5_wiz_0")
+            clkx5_wiz.label = "clkx5_wiz_0"
+            clkx5_wiz.phandle = 0x50
+            base_tree.add(clkx5_wiz)
+
+            base_tree.sync()
+            base_tree.resolve()
+
+            # === STEP 1: Tag user overlay properties (done by LopperSDT.setup) ===
+            targets = extract_overlay_targets(overlay_file)
+            source_tag = f"overlay:{os.path.basename(overlay_file)}"
+
+            for label, target_info in targets.items():
+                node = None
+                for n in base_tree.__nodes__.values():
+                    if n.label == label:
+                        node = n
+                        break
+
+                if node:
+                    for prop_name in target_info['props']:
+                        if prop_name == 'status':
+                            prop = LopperProp(name=prop_name, value=["okay"])
+                        elif prop_name == 'xlnx,dc-pixel-format':
+                            prop = LopperProp(name=prop_name, value=["rgb888"])
+                        elif prop_name == 'clocks':
+                            # Phandle reference to PL node
+                            prop = LopperProp(name=prop_name, value=[0x50, 0x0])
+                        else:
+                            prop = LopperProp(name=prop_name, value=["unknown"])
+
+                        prop._source = source_tag
+                        node.__props__[prop_name] = prop
+
+            # === STEP 2: Extract PL nodes to overlay (done by assist) ===
+            overlay_tree = LopperTree()
+
+            # Simulate extracting clkx5_wiz_0 to overlay
+            extracted_node = LopperNode(-1, "/amba_pl/clkx5_wiz_0")
+            extracted_node.label = "clkx5_wiz_0"
+            extracted_node.phandle = 0x50
+            overlay_tree.add(extracted_node)
+            overlay_tree.sync()
+
+            # === STEP 3: Pull phandle references ===
+            # This would add &mmi_dc { clocks = <...>; } because clocks refs PL
+            # (In real code: base_tree.fragment_add_for_refs(overlay_tree))
+            # We simulate by checking the property references overlay node
+            phandle_refs_fragments = base_tree.fragment_add_for_refs(overlay_tree)
+
+            # === STEP 4: Pull user overlay properties ===
+            # This adds status, xlnx,dc-pixel-format to the existing &mmi_dc fragment
+            overlay_source_fragments = base_tree.fragment_add_for_overlay_sources(
+                overlay_tree,
+                source_filter=os.path.basename(overlay_file),
+                mode='properties'
+            )
+
+            # === VERIFY: Output overlay has all expected content ===
+
+            # Find the mmi_dc fragment
+            mmi_dc_frag = None
+            for node in overlay_tree.__nodes__.values():
+                if node.name == '&mmi_dc':
+                    mmi_dc_frag = node
+                    break
+
+            assert mmi_dc_frag is not None, "mmi_dc fragment should exist"
+
+            # Should have all three properties from user overlay
+            assert 'status' in mmi_dc_frag.__props__, "Missing status"
+            assert 'xlnx,dc-pixel-format' in mmi_dc_frag.__props__, "Missing xlnx,dc-pixel-format"
+            assert 'clocks' in mmi_dc_frag.__props__, "Missing clocks"
+
+            # Verify values
+            assert mmi_dc_frag.__props__['status'].value == ["okay"]
+            assert mmi_dc_frag.__props__['xlnx,dc-pixel-format'].value == ["rgb888"]
+            assert mmi_dc_frag.__props__['clocks'].value == [0x50, 0x0]
+
+            # Extracted PL node should still be there
+            pl_node = None
+            for node in overlay_tree.__nodes__.values():
+                if node.label == 'clkx5_wiz_0':
+                    pl_node = node
+                    break
+            assert pl_node is not None, "Extracted PL node should exist"
+
+        finally:
+            os.unlink(overlay_file)
+
+    def test_overlay_with_nested_child_nodes(self):
+        """Test end-to-end: nested child nodes from user overlay appear in output overlay.
+
+        Onkar's use case: User overlay for mmi_dc driver includes nested
+        ports/endpoint hierarchy with remote-endpoint phandle to a PL node.
+        extract_overlay_targets() must detect 'ports' as a child added by the
+        overlay. _tag_overlay_properties() must recursively tag all properties
+        inside the ports subtree. fragment_add_for_overlay_sources() must then
+        pull them into the output overlay fragment.
+        """
+        from lopper import extract_overlay_targets
+
+        user_overlay = """\
+&mmi_dc {
+    status = "okay";
+    xlnx,dc-pixel-format = "rgb888";
+    ports {
+        port@0 {
+            endpoint {
+                remote-endpoint = <&avpg_outdc_0>;
+            };
+        };
+    };
+};
+"""
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.dtsi', delete=False) as f:
+            f.write(user_overlay)
+            overlay_file = f.name
+            f.flush()
+
+        try:
+            # === STEP 1: extract_overlay_targets must detect props AND children ===
+            targets = extract_overlay_targets(overlay_file)
+            assert 'mmi_dc' in targets, "mmi_dc should be identified as overlay target"
+            assert 'status' in targets['mmi_dc']['props'], "status should be in props"
+            assert 'xlnx,dc-pixel-format' in targets['mmi_dc']['props'], \
+                "xlnx,dc-pixel-format should be in props"
+            assert 'ports' in targets['mmi_dc']['children'], \
+                "ports should be detected as a child node added by the overlay"
+
+            # === SETUP: Create base tree simulating merged SDT ===
+            base_tree = LopperTree()
+
+            mmi_dc = LopperNode(-1, "/amba/mmi_dc@fd4a0000")
+            mmi_dc.label = "mmi_dc"
+            base_tree.add(mmi_dc)
+
+            avpg = LopperNode(-1, "/amba_pl/avpg_outdc_0")
+            avpg.label = "avpg_outdc_0"
+            avpg.phandle = 0x60
+            base_tree.add(avpg)
+
+            # Child nodes from the overlay are present in the merged tree
+            ports_node = LopperNode(-1, "/amba/mmi_dc@fd4a0000/ports")
+            base_tree.add(ports_node)
+            port0_node = LopperNode(-1, "/amba/mmi_dc@fd4a0000/ports/port@0")
+            base_tree.add(port0_node)
+            ep_node = LopperNode(-1, "/amba/mmi_dc@fd4a0000/ports/port@0/endpoint")
+            base_tree.add(ep_node)
+
+            base_tree.sync()
+            base_tree.resolve()
+
+            # Add properties that came from the overlay
+            for prop_name, val in [('status', ["okay"]), ('xlnx,dc-pixel-format', ["rgb888"])]:
+                base_tree['/amba/mmi_dc@fd4a0000'].__props__[prop_name] = LopperProp(name=prop_name, value=val)
+
+            base_tree['/amba/mmi_dc@fd4a0000/ports'].__props__['#address-cells'] = \
+                LopperProp(name='#address-cells', value=[1])
+
+            remote_ep = LopperProp(name='remote-endpoint', value=[0x60])
+            base_tree['/amba/mmi_dc@fd4a0000/ports/port@0/endpoint'].__props__['remote-endpoint'] = remote_ep
+
+            # === STEP 2: LopperSDT._tag_overlay_properties tags props AND child subtrees ===
+            overlay_basename = os.path.basename(overlay_file)
+            source_tag = f"overlay:{overlay_basename}"
+
+            sdt = LopperSDT("")
+            sdt.tree = base_tree
+            sdt._overlay_targets = {overlay_basename: targets}
+            sdt._tag_overlay_properties()
+
+            # Verify tagging reached the deep endpoint node
+            ep_props = base_tree['/amba/mmi_dc@fd4a0000/ports/port@0/endpoint'].__props__
+            assert ep_props['remote-endpoint']._source == source_tag, \
+                "remote-endpoint inside nested endpoint should be tagged as overlay-sourced"
+
+            ports_props = base_tree['/amba/mmi_dc@fd4a0000/ports'].__props__
+            assert ports_props['#address-cells']._source == source_tag, \
+                "#address-cells on ports node should be tagged as overlay-sourced"
+
+            # === STEP 3: fragment generation pulls both flat props and child content ===
+            output_overlay = LopperTree()
+            extracted_avpg = LopperNode(-1, "/amba_pl/avpg_outdc_0")
+            extracted_avpg.label = "avpg_outdc_0"
+            extracted_avpg.phandle = 0x60
+            output_overlay.add(extracted_avpg)
+            output_overlay.sync()
+
+            base_tree.fragment_add_for_refs(output_overlay)
+            base_tree.fragment_add_for_overlay_sources(
+                output_overlay,
+                source_filter=overlay_basename,
+                mode='properties'
+            )
+
+            mmi_dc_frag = None
+            for node in output_overlay.__nodes__.values():
+                if node.name == '&mmi_dc':
+                    mmi_dc_frag = node
+                    break
+
+            assert mmi_dc_frag is not None, "mmi_dc fragment should exist in output overlay"
+            assert 'status' in mmi_dc_frag.__props__, "status should be in output overlay"
+            assert 'xlnx,dc-pixel-format' in mmi_dc_frag.__props__, \
+                "xlnx,dc-pixel-format should be in output overlay"
+
+            pl_found = any(n.label == 'avpg_outdc_0' for n in output_overlay.__nodes__.values())
+            assert pl_found, "Extracted PL node avpg_outdc_0 should remain in overlay"
+
+        finally:
+            os.unlink(overlay_file)
+
+    def test_overlay_nested_nodes_without_pl_refs(self):
+        """Test end-to-end: nested child nodes without PL refs also go to overlay.
+
+        Per Onkar's requirement: Even when the user overlay has nested child
+        nodes that do NOT reference PL nodes (pure structural/config data),
+        those children must appear in the output overlay.
+        """
+        from lopper import extract_overlay_targets
+
+        user_overlay = """\
+&mmi_dc {
+    status = "okay";
+    xlnx,dc-timing-mode = <1>;
+    ports {
+        port@0 {
+            endpoint {
+                data-lanes = <0 1 2 3>;
+            };
+        };
+    };
+};
+"""
+
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.dtsi', delete=False) as f:
+            f.write(user_overlay)
+            overlay_file = f.name
+            f.flush()
+
+        try:
+            # === STEP 1: Verify overlay target extraction detects children ===
+            targets = extract_overlay_targets(overlay_file)
+            assert 'mmi_dc' in targets
+            assert 'ports' in targets['mmi_dc']['children'], \
+                "ports should be detected as child node even without PL references"
+
+            # === SETUP: Merged tree ===
+            base_tree = LopperTree()
+            mmi_dc = LopperNode(-1, "/amba/mmi_dc@fd4a0000")
+            mmi_dc.label = "mmi_dc"
+            base_tree.add(mmi_dc)
+
+            ports_node = LopperNode(-1, "/amba/mmi_dc@fd4a0000/ports")
+            base_tree.add(ports_node)
+            port0_node = LopperNode(-1, "/amba/mmi_dc@fd4a0000/ports/port@0")
+            base_tree.add(port0_node)
+            ep_node = LopperNode(-1, "/amba/mmi_dc@fd4a0000/ports/port@0/endpoint")
+            base_tree.add(ep_node)
+
+            base_tree.sync()
+            base_tree.resolve()
+
+            for prop_name, val in [('status', ["okay"]), ('xlnx,dc-timing-mode', [1])]:
+                base_tree['/amba/mmi_dc@fd4a0000'].__props__[prop_name] = LopperProp(name=prop_name, value=val)
+
+            base_tree['/amba/mmi_dc@fd4a0000/ports/port@0/endpoint'].__props__['data-lanes'] = \
+                LopperProp(name='data-lanes', value=[0, 1, 2, 3])
+
+            # === STEP 2: LopperSDT._tag_overlay_properties tags props AND child subtrees ===
+            overlay_basename = os.path.basename(overlay_file)
+            source_tag = f"overlay:{overlay_basename}"
+
+            sdt = LopperSDT("")
+            sdt.tree = base_tree
+            sdt._overlay_targets = {overlay_basename: targets}
+            sdt._tag_overlay_properties()
+
+            # Endpoint's data-lanes must be tagged even though it has no PL ref
+            ep_props = base_tree['/amba/mmi_dc@fd4a0000/ports/port@0/endpoint'].__props__
+            assert ep_props['data-lanes']._source == source_tag, \
+                "data-lanes inside nested endpoint should be tagged as overlay-sourced"
+
+            # === STEP 3: Fragment generation captures flat properties ===
+            output_overlay = LopperTree()
+            base_tree.fragment_add_for_overlay_sources(
+                output_overlay,
+                source_filter=overlay_basename,
+                mode='properties'
+            )
+
+            mmi_dc_frag = None
+            for node in output_overlay.__nodes__.values():
+                if node.name == '&mmi_dc':
+                    mmi_dc_frag = node
+                    break
+
+            assert mmi_dc_frag is not None, \
+                "mmi_dc fragment should exist even without PL phandle references"
+            assert 'status' in mmi_dc_frag.__props__
+            assert 'xlnx,dc-timing-mode' in mmi_dc_frag.__props__
+
+        finally:
+            os.unlink(overlay_file)
+
+
+# Minimal base DTS for overlay CLI tests.
+# Has a labelled mmi_dc node so &mmi_dc in the user overlay resolves.
+_BASE_DTS = """\
+/dts-v1/;
+/ {
+    #address-cells = <2>;
+    #size-cells = <2>;
+    compatible = "test";
+
+    amba: amba {
+        #address-cells = <2>;
+        #size-cells = <2>;
+        ranges;
+
+        mmi_dc: mmi_dc@fd4a0000 {
+            compatible = "xlnx,mmi-dc";
+            reg = <0x0 0xfd4a0000 0x0 0x10000>;
+            status = "disabled";
+        };
+    };
+};
+"""
+
+

--- a/tests/test_overlay_sources.py
+++ b/tests/test_overlay_sources.py
@@ -478,6 +478,7 @@ class TestRegexFallback:
                 os.unlink(f.name)
 
 
+
 class TestFragmentAddForOverlaySources:
     """Test LopperTree.fragment_add_for_overlay_sources() method."""
 

--- a/tests/test_overlay_sources.py
+++ b/tests/test_overlay_sources.py
@@ -1,7 +1,7 @@
 """
-Tests for overlay source tracking infrastructure.
+Tests for overlay layer tracking infrastructure.
 
-Tests the _source attribute on LopperProp and helper methods for
+Tests the _layers dict on LopperProp and helper methods for
 finding overlay-sourced properties on nodes and trees.
 
 Also tests the helper functions for identifying and extracting
@@ -16,43 +16,41 @@ from lopper.tree import LopperTree, LopperNode, LopperProp
 from lopper import LopperSDT
 
 
-class TestPropertySourceAttribute:
-    """Test that _source attribute is properly initialized and copied."""
+class TestPropertyLayerTracking:
+    """Test that _layers dict tracks overlay provenance correctly."""
 
-    def test_source_defaults_to_none(self):
-        """New properties should have _source = None."""
+    def test_new_prop_has_no_overlay_layers(self):
+        """New properties should have no overlay layers in _layers."""
         prop = LopperProp('test-prop', value=[1, 2, 3])
-        assert prop._source is None
+        overlay_layers = [k for k in prop._layers if k not in ('base', 'modifications')]
+        assert overlay_layers == []
 
-    def test_source_can_be_set(self):
-        """_source should be settable."""
+    def test_set_layer_value_records_layer(self):
+        """_set_layer_value should store the layer in _layers."""
         prop = LopperProp('test-prop', value=[1, 2, 3])
-        prop._source = 'overlay:mmi_dc.dtsi'
-        assert prop._source == 'overlay:mmi_dc.dtsi'
+        prop._set_layer_value('mmi_dc', [42], priority=500)
+        assert 'mmi_dc' in prop._layers
+        assert prop._layers['mmi_dc'] == (500, [42])
 
-    def test_source_preserved_on_deepcopy(self):
-        """_source should be preserved when property is deep copied."""
+    def test_overlay_layer_preserved_on_deepcopy(self):
+        """Overlay layers should be preserved when property is deep copied."""
         import copy
         prop = LopperProp('test-prop', value=[1, 2, 3])
-        prop._source = 'overlay:test.dtsi'
+        prop._set_layer_value('test', [99], priority=500)
 
         prop_copy = copy.deepcopy(prop)
 
-        assert prop_copy._source == 'overlay:test.dtsi'
+        assert 'test' in prop_copy._layers
+        assert prop_copy._layers['test'] == (500, [99])
 
-    def test_source_formats(self):
-        """Various source format strings should be accepted."""
+    def test_multiple_overlay_layers(self):
+        """Multiple overlay layers can coexist."""
         prop = LopperProp('test-prop', value=[1])
-
-        # Test various formats
-        prop._source = 'overlay:mmi_dc.dtsi'
-        assert prop._source == 'overlay:mmi_dc.dtsi'
-
-        prop._source = 'yaml:domains.yaml'
-        assert prop._source == 'yaml:domains.yaml'
-
-        prop._source = 'json:config.json'
-        assert prop._source == 'json:config.json'
+        prop._set_layer_value('mmi_dc', [1], priority=500)
+        prop._set_layer_value('pl_overlay', [2], priority=500)
+        overlay_layers = [k for k in prop._layers if k not in ('base', 'modifications')]
+        assert 'mmi_dc' in overlay_layers
+        assert 'pl_overlay' in overlay_layers
 
 
 class TestNodeOverlaySourcedProperties:
@@ -80,14 +78,15 @@ class TestNodeOverlaySourcedProperties:
         tree.sync()
         tree.resolve()
 
-        # Add property with overlay source
+        # Add property with overlay layer
         prop = LopperProp(name='overlay-prop', value=[1])
-        prop._source = 'overlay:mmi_dc.dtsi'
+        prop._set_layer_value('mmi_dc', [1], priority=500)
         tree['/test'].__props__['overlay-prop'] = prop
 
         result = tree['/test'].overlay_sourced_properties()
         assert len(result) == 1
-        assert result[0] == ('overlay-prop', 'overlay:mmi_dc.dtsi')
+        assert result[0][0] == 'overlay-prop'
+        assert result[0][1] == 'mmi_dc'
 
     def test_filter_by_specific_overlay(self):
         """Should filter by specific overlay name."""
@@ -99,11 +98,11 @@ class TestNodeOverlaySourcedProperties:
 
         # Add properties from different overlays
         prop1 = LopperProp(name='prop1', value=[1])
-        prop1._source = 'overlay:overlay_a.dtsi'
+        prop1._set_layer_value('overlay_a', [1], priority=500)
         tree['/test'].__props__['prop1'] = prop1
 
         prop2 = LopperProp(name='prop2', value=[2])
-        prop2._source = 'overlay:overlay_b.dtsi'
+        prop2._set_layer_value('overlay_b', [2], priority=500)
         tree['/test'].__props__['prop2'] = prop2
 
         # Filter for overlay_a only
@@ -126,15 +125,15 @@ class TestNodeOverlaySourcedProperties:
 
         # Add properties from different overlays
         prop1 = LopperProp(name='prop1', value=[1])
-        prop1._source = 'overlay:a.dtsi'
+        prop1._set_layer_value('a', [1], priority=500)
         tree['/test'].__props__['prop1'] = prop1
 
         prop2 = LopperProp(name='prop2', value=[2])
-        prop2._source = 'overlay:b.dtsi'
+        prop2._set_layer_value('b', [2], priority=500)
         tree['/test'].__props__['prop2'] = prop2
 
         prop3 = LopperProp(name='prop3', value=[3])
-        prop3._source = 'overlay:c.dtsi'
+        prop3._set_layer_value('c', [3], priority=500)
         tree['/test'].__props__['prop3'] = prop3
 
         # Filter for a and b
@@ -155,28 +154,28 @@ class TestNodeOverlaySourcedProperties:
 
         # Add properties from different overlays
         prop1 = LopperProp(name='prop1', value=[1])
-        prop1._source = 'overlay:a.dtsi'
+        prop1._set_layer_value('a', [1], priority=500)
         tree['/test'].__props__['prop1'] = prop1
 
         prop2 = LopperProp(name='prop2', value=[2])
-        prop2._source = 'overlay:b.dtsi'
+        prop2._set_layer_value('b', [2], priority=500)
         tree['/test'].__props__['prop2'] = prop2
 
         result = tree['/test'].overlay_sourced_properties('*')
         assert len(result) == 2
 
-    def test_ignores_non_overlay_sources(self):
-        """Should ignore properties with non-overlay sources (yaml, json)."""
+    def test_ignores_base_and_modifications_layers(self):
+        """Should ignore 'base' and 'modifications' layers — only overlay layers count."""
         tree = LopperTree()
         node = LopperNode(-1, "/test")
         tree.add(node)
         tree.sync()
         tree.resolve()
 
-        # Add property with yaml source
-        prop = LopperProp(name='yaml-prop', value=[1])
-        prop._source = 'yaml:domains.yaml'
-        tree['/test'].__props__['yaml-prop'] = prop
+        # A prop with only base layer (no overlay)
+        prop = LopperProp(name='base-prop', value=[1])
+        # _layers already has 'base' from __init__ seeding; no overlay layer added
+        tree['/test'].__props__['base-prop'] = prop
 
         result = tree['/test'].overlay_sourced_properties('*')
         assert result == []
@@ -208,7 +207,7 @@ class TestTreeNodesWithOverlaySources:
 
         # Add overlay property to node1 only
         prop = LopperProp(name='overlay-prop', value=[1])
-        prop._source = 'overlay:test.dtsi'
+        prop._set_layer_value('test', [1], priority=500)
         tree['/node1'].__props__['overlay-prop'] = prop
 
         result = tree.nodes_with_overlay_sources()
@@ -228,12 +227,12 @@ class TestTreeNodesWithOverlaySources:
 
         # Add overlay property from 'a.dtsi' to node1
         prop1 = LopperProp(name='prop1', value=[1])
-        prop1._source = 'overlay:a.dtsi'
+        prop1._set_layer_value('a', [1], priority=500)
         tree['/node1'].__props__['prop1'] = prop1
 
         # Add overlay property from 'b.dtsi' to node2
         prop2 = LopperProp(name='prop2', value=[2])
-        prop2._source = 'overlay:b.dtsi'
+        prop2._set_layer_value('b', [2], priority=500)
         tree['/node2'].__props__['prop2'] = prop2
 
         # Filter for a.dtsi
@@ -257,7 +256,7 @@ class TestTreeNodesWithOverlaySources:
         # Add multiple overlay properties
         for i in range(3):
             prop = LopperProp(name=f'prop{i}', value=[i])
-            prop._source = 'overlay:test.dtsi'
+            prop._set_layer_value('test', [i], priority=500)
             tree['/test'].__props__[f'prop{i}'] = prop
 
         result = tree.nodes_with_overlay_sources()
@@ -495,17 +494,17 @@ class TestFragmentAddForOverlaySources:
 
         # Add overlay-sourced properties
         prop1 = LopperProp(name='status', value=["okay"])
-        prop1._source = 'overlay:test.dtsi'
+        prop1._set_layer_value('test', ["okay"], priority=500)
         tree['/device'].__props__['status'] = prop1
 
         prop2 = LopperProp(name='clocks', value=[0x20, 0x0])
-        prop2._source = 'overlay:test.dtsi'
+        prop2._set_layer_value('test', [0x20, 0x0], priority=500)
         tree['/device'].__props__['clocks'] = prop2
 
         # Create overlay tree
         overlay = LopperTree()
 
-        # Add fragments for overlay sources
+        # Add fragments for overlay layers
         fragments = tree.fragment_add_for_overlay_sources(overlay)
 
         assert len(fragments) == 1
@@ -521,12 +520,12 @@ class TestFragmentAddForOverlaySources:
         tree.sync()
         tree.resolve()
 
-        # Add one overlay-sourced property
+        # Add one overlay-layer property
         prop1 = LopperProp(name='status', value=["okay"])
-        prop1._source = 'overlay:test.dtsi'
+        prop1._set_layer_value('test', ["okay"], priority=500)
         tree['/device'].__props__['status'] = prop1
 
-        # Add one non-sourced property
+        # Add one base-only property (no overlay layer)
         prop2 = LopperProp(name='reg', value=[0x0, 0x1000])
         tree['/device'].__props__['reg'] = prop2
 
@@ -548,12 +547,12 @@ class TestFragmentAddForOverlaySources:
         tree.sync()
         tree.resolve()
 
-        # Add one overlay-sourced property
+        # Add one overlay-layer property
         prop1 = LopperProp(name='status', value=["okay"])
-        prop1._source = 'overlay:test.dtsi'
+        prop1._set_layer_value('test', ["okay"], priority=500)
         tree['/device'].__props__['status'] = prop1
 
-        # Add one non-sourced property
+        # Add one base-only property
         prop2 = LopperProp(name='reg', value=[0x0, 0x1000])
         tree['/device'].__props__['reg'] = prop2
 
@@ -575,13 +574,13 @@ class TestFragmentAddForOverlaySources:
         tree.sync()
         tree.resolve()
 
-        # Add properties from different overlays
+        # Add properties from different overlay layers
         prop1 = LopperProp(name='prop_a', value=[1])
-        prop1._source = 'overlay:a.dtsi'
+        prop1._set_layer_value('a', [1], priority=500)
         tree['/device'].__props__['prop_a'] = prop1
 
         prop2 = LopperProp(name='prop_b', value=[2])
-        prop2._source = 'overlay:b.dtsi'
+        prop2._set_layer_value('b', [2], priority=500)
         tree['/device'].__props__['prop_b'] = prop2
 
         overlay = LopperTree()
@@ -624,9 +623,9 @@ class TestFragmentAddForOverlaySources:
         tree.sync()
         tree.resolve()
 
-        # Add overlay-sourced property
+        # Add overlay-layer property
         prop = LopperProp(name='status', value=["okay"])
-        prop._source = 'overlay:test.dtsi'
+        prop._set_layer_value('test', ["okay"], priority=500)
         tree['/device'].__props__['status'] = prop
 
         # Create overlay with existing fragment for same node
@@ -666,7 +665,7 @@ class TestFragmentAddForOverlaySources:
         tree.resolve()
 
         prop = LopperProp(name='status', value=["okay"])
-        prop._source = 'overlay:test.dtsi'
+        prop._set_layer_value('test', ["okay"], priority=500)
         tree['/device'].__props__['status'] = prop
 
         overlay = LopperTree()
@@ -724,7 +723,7 @@ class TestOverlaySourceIntegration:
 
             # Step 4: Tag properties as coming from overlay
             # (simulating what _tag_overlay_properties does after merge)
-            source_tag = f"overlay:{os.path.basename(overlay_file)}"
+            overlay_layer = os.path.splitext(os.path.basename(overlay_file))[0]
             for label, target_info in targets.items():
                 # Find node by label - use __nodes__ to avoid iterator state issues
                 node = None
@@ -743,7 +742,7 @@ class TestOverlaySourceIntegration:
                         else:
                             prop = LopperProp(name=prop_name, value=[0x20, 0x0])
 
-                        prop._source = source_tag
+                        prop._set_layer_value(overlay_layer, prop.__dict__.get('value', []), priority=500)
                         node.__props__[prop_name] = prop
 
             # Step 5: Verify properties are tagged
@@ -817,7 +816,7 @@ class TestOverlaySourceIntegration:
             # Tag properties from each overlay
             for overlay_file in [display_file, audio_file]:
                 targets = extract_overlay_targets(overlay_file)
-                source_tag = f"overlay:{os.path.basename(overlay_file)}"
+                overlay_layer = os.path.splitext(os.path.basename(overlay_file))[0]
 
                 for label, target_info in targets.items():
                     # Use __nodes__ to avoid iterator state issues
@@ -830,7 +829,7 @@ class TestOverlaySourceIntegration:
                     if node:
                         for prop_name in target_info['props']:
                             prop = LopperProp(name=prop_name, value=["okay"])
-                            prop._source = source_tag
+                            prop._set_layer_value(overlay_layer, ["okay"], priority=500)
                             node.__props__[prop_name] = prop
 
             # Generate fragments for only display.dtsi
@@ -879,11 +878,11 @@ class TestOverlaySourceIntegration:
         # 1. clocks property referencing PL node (phandle ref)
         # 2. status property (non-phandle, just overlay source)
         clocks_prop = LopperProp(name='clocks', value=[0x50, 0x0])
-        clocks_prop._source = 'overlay:mmi_dc.dtsi'
+        clocks_prop._set_layer_value('mmi_dc', [0x50, 0x0], priority=500)
         tree['/amba/mmi_dc@fd4a0000'].__props__['clocks'] = clocks_prop
 
         status_prop = LopperProp(name='status', value=["okay"])
-        status_prop._source = 'overlay:mmi_dc.dtsi'
+        status_prop._set_layer_value('mmi_dc', ["okay"], priority=500)
         tree['/amba/mmi_dc@fd4a0000'].__props__['status'] = status_prop
 
         # Create output overlay (simulating extracted PL nodes)
@@ -944,7 +943,7 @@ class TestOverlaySourceIntegration:
 
         for name, value in props_from_overlay:
             prop = LopperProp(name=name, value=value)
-            prop._source = 'overlay:mmi_dc.dtsi'
+            prop._set_layer_value('mmi_dc', value, priority=500)
             tree['/amba/mmi_dc@fd4a0000'].__props__[name] = prop
 
         # Generate fragment
@@ -1019,7 +1018,7 @@ class TestOverlaySourceIntegration:
 
             # Step 3: Simulate merge - add overlay properties to base tree
             # (In real flow, DTC does this during concatenated compilation)
-            source_tag = f"overlay:{overlay_basename}"
+            overlay_layer = os.path.splitext(overlay_basename)[0]
             for label, target_info in targets.items():
                 node = None
                 for n in base_tree.__nodes__.values():
@@ -1032,7 +1031,7 @@ class TestOverlaySourceIntegration:
                         # Create property with value from expected_props
                         value = expected_props.get(prop_name, ["unknown"])
                         prop = LopperProp(name=prop_name, value=value)
-                        prop._source = source_tag
+                        prop._set_layer_value(overlay_layer, value, priority=500)
                         node.__props__[prop_name] = prop
 
             # Step 4: Extract overlay content back out
@@ -1120,7 +1119,7 @@ class TestOverlaySourceIntegration:
 
             # === STEP 1: Tag user overlay properties (done by LopperSDT.setup) ===
             targets = extract_overlay_targets(overlay_file)
-            source_tag = f"overlay:{os.path.basename(overlay_file)}"
+            overlay_layer = os.path.splitext(os.path.basename(overlay_file))[0]
 
             for label, target_info in targets.items():
                 node = None
@@ -1141,7 +1140,7 @@ class TestOverlaySourceIntegration:
                         else:
                             prop = LopperProp(name=prop_name, value=["unknown"])
 
-                        prop._source = source_tag
+                        prop._set_layer_value(overlay_layer, prop.__dict__.get('value', []), priority=500)
                         node.__props__[prop_name] = prop
 
             # === STEP 2: Extract PL nodes to overlay (done by assist) ===
@@ -1276,21 +1275,21 @@ class TestOverlaySourceIntegration:
 
             # === STEP 2: LopperSDT._tag_overlay_properties tags props AND child subtrees ===
             overlay_basename = os.path.basename(overlay_file)
-            source_tag = f"overlay:{overlay_basename}"
+            overlay_layer = os.path.splitext(overlay_basename)[0]
 
             sdt = LopperSDT("")
             sdt.tree = base_tree
             sdt._overlay_targets = {overlay_basename: targets}
             sdt._tag_overlay_properties()
 
-            # Verify tagging reached the deep endpoint node
+            # Verify tagging reached the deep endpoint node (layer key present)
             ep_props = base_tree['/amba/mmi_dc@fd4a0000/ports/port@0/endpoint'].__props__
-            assert ep_props['remote-endpoint']._source == source_tag, \
-                "remote-endpoint inside nested endpoint should be tagged as overlay-sourced"
+            assert overlay_layer in ep_props['remote-endpoint']._layers, \
+                "remote-endpoint inside nested endpoint should have overlay layer"
 
             ports_props = base_tree['/amba/mmi_dc@fd4a0000/ports'].__props__
-            assert ports_props['#address-cells']._source == source_tag, \
-                "#address-cells on ports node should be tagged as overlay-sourced"
+            assert overlay_layer in ports_props['#address-cells']._layers, \
+                "#address-cells on ports node should have overlay layer"
 
             # === STEP 3: fragment generation pulls both flat props and child content ===
             output_overlay = LopperTree()
@@ -1383,7 +1382,7 @@ class TestOverlaySourceIntegration:
 
             # === STEP 2: LopperSDT._tag_overlay_properties tags props AND child subtrees ===
             overlay_basename = os.path.basename(overlay_file)
-            source_tag = f"overlay:{overlay_basename}"
+            overlay_layer = os.path.splitext(overlay_basename)[0]
 
             sdt = LopperSDT("")
             sdt.tree = base_tree
@@ -1392,8 +1391,8 @@ class TestOverlaySourceIntegration:
 
             # Endpoint's data-lanes must be tagged even though it has no PL ref
             ep_props = base_tree['/amba/mmi_dc@fd4a0000/ports/port@0/endpoint'].__props__
-            assert ep_props['data-lanes']._source == source_tag, \
-                "data-lanes inside nested endpoint should be tagged as overlay-sourced"
+            assert overlay_layer in ep_props['data-lanes']._layers, \
+                "data-lanes inside nested endpoint should have overlay layer"
 
             # === STEP 3: Fragment generation captures flat properties ===
             output_overlay = LopperTree()

--- a/tests/test_overlay_sources.py
+++ b/tests/test_overlay_sources.py
@@ -1441,3 +1441,97 @@ _BASE_DTS = """\
 """
 
 
+class TestOverlayE2E:
+    """End-to-end CLI tests: lopper processes a user overlay DTSI alongside
+    a base DTS, just as a user would invoke it on the command line."""
+
+    def run_lopper(self, tmp_path, base_dts, overlay_dtsi, extra_args=None):
+        """Run lopper with a base DTS and a user overlay DTSI.
+
+        Mirrors the user command:
+            lopper.py -f -i <user-overlay.dtsi> <system-top.dts> <output.dts>
+        """
+        base_file = tmp_path / "system-top.dts"
+        base_file.write_text(base_dts)
+
+        overlay_file = tmp_path / "user-overlay.dtsi"
+        overlay_file.write_text(overlay_dtsi)
+
+        output_file = tmp_path / "output.dts"
+
+        cmd = ["./lopper.py", "-f"]
+        if extra_args:
+            cmd.extend(extra_args)
+        cmd.extend(["-i", str(overlay_file),
+                    str(base_file), str(output_file)])
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            cwd=os.getcwd()
+        )
+        return result, output_file
+
+    def test_overlay_properties_appear_in_output(self, tmp_path):
+        """User overlay properties are merged into the output DTS.
+
+        The user provides a .dtsi that sets status = "okay" on mmi_dc.
+        After lopper processes both files, the output DTS must contain
+        the property from the overlay.
+        """
+        overlay = '&mmi_dc { status = "okay"; };\n'
+
+        result, output_file = self.run_lopper(tmp_path, _BASE_DTS, overlay)
+
+        assert result.returncode == 0, \
+            f"lopper failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        assert output_file.exists(), "output DTS was not created"
+
+        content = output_file.read_text()
+        assert 'status = "okay"' in content, \
+            f"User overlay property 'status = okay' not found in output:\n{content}"
+
+    def test_overlay_with_nested_nodes_no_error(self, tmp_path):
+        """User overlay with nested child nodes is processed without error.
+
+        Onkar's use case: ports/endpoint hierarchy inside the user overlay.
+        Lopper must handle this without crashing.
+        """
+        overlay = """\
+&mmi_dc {
+    status = "okay";
+    ports {
+        port@0 {
+            endpoint {
+                remote-endpoint = <&mmi_dc>;
+            };
+        };
+    };
+};
+"""
+        result, output_file = self.run_lopper(tmp_path, _BASE_DTS, overlay)
+
+        assert result.returncode == 0, \
+            f"lopper failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        assert output_file.exists(), "output DTS was not created"
+
+    def test_overlay_listed_in_system_device_tree(self, tmp_path):
+        """Lopper includes the user overlay DTSI in the system device tree list.
+
+        The overlay file is concatenated with the base DTS before compilation.
+        Verbose output lists all inputs under 'system device tree:' — the overlay
+        must appear there, confirming lopper accepted it as an input.
+        """
+        overlay = '&mmi_dc { xlnx,dc-pixel-format = "rgb888"; };\n'
+
+        result, _ = self.run_lopper(
+            tmp_path, _BASE_DTS, overlay, extra_args=["-v"]
+        )
+
+        assert result.returncode == 0, \
+            f"lopper failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+
+        combined = result.stdout + result.stderr
+        assert "user-overlay.dtsi" in combined, \
+            f"Expected user-overlay.dtsi to appear in lopper output:\n{combined}"

--- a/tests/test_tree_tracking.py
+++ b/tests/test_tree_tracking.py
@@ -1,0 +1,312 @@
+"""
+Tests for unified tree tracking in Lopper core.
+
+Tests the _metadata infrastructure on LopperTree that enables:
+- Automatic capture of deleted nodes in extracted trees
+- Registration of overlays with parent trees
+- Backward compatibility with _external_trees
+- Child tree access helpers
+"""
+
+import pytest
+from lopper.tree import LopperTree, LopperNode
+
+
+class TestMetadataInitialization:
+    """Test that _metadata is properly initialized."""
+
+    def test_metadata_exists_on_new_tree(self):
+        """New trees should have _metadata dict initialized."""
+        tree = LopperTree()
+        assert hasattr(tree, '_metadata')
+        assert isinstance(tree._metadata, dict)
+
+    def test_metadata_has_required_keys(self):
+        """_metadata should have all required keys."""
+        tree = LopperTree()
+        required_keys = ['type', 'name', 'source', 'parent', 'child_trees', 'external_trees']
+        for key in required_keys:
+            assert key in tree._metadata, f"Missing key: {key}"
+
+    def test_metadata_default_type_is_primary(self):
+        """New trees should default to type 'primary'."""
+        tree = LopperTree()
+        assert tree._metadata['type'] == 'primary'
+
+    def test_metadata_child_trees_starts_empty(self):
+        """child_trees should start as empty list."""
+        tree = LopperTree()
+        assert tree._metadata['child_trees'] == []
+
+    def test_metadata_external_trees_starts_empty(self):
+        """external_trees should start as empty list."""
+        tree = LopperTree()
+        assert tree._metadata['external_trees'] == []
+
+
+class TestExternalTreesBackwardCompatibility:
+    """Test backward compatibility of _external_trees property."""
+
+    def test_external_trees_property_returns_metadata_list(self):
+        """_external_trees property should delegate to metadata."""
+        tree = LopperTree()
+        # Add a tree to external_trees via metadata
+        other_tree = LopperTree()
+        tree._metadata['external_trees'].append(other_tree)
+
+        # Property should return the same list
+        assert other_tree in tree._external_trees
+
+    def test_external_trees_setter_updates_metadata(self):
+        """Setting _external_trees should update metadata."""
+        tree = LopperTree()
+        other_tree = LopperTree()
+
+        tree._external_trees = [other_tree]
+
+        assert tree._metadata['external_trees'] == [other_tree]
+
+    def test_external_trees_append_works(self):
+        """Appending to _external_trees should work."""
+        tree = LopperTree()
+        other_tree = LopperTree()
+
+        tree._external_trees.append(other_tree)
+
+        assert other_tree in tree._metadata['external_trees']
+
+
+class TestChildTreeHelpers:
+    """Test child_trees(), extracted_trees(), overlay_trees() helpers."""
+
+    def test_child_trees_returns_all_children(self):
+        """child_trees() without filter returns all children."""
+        tree = LopperTree()
+        child1 = LopperTree()
+        child1._metadata['type'] = 'extracted'
+        child2 = LopperTree()
+        child2._metadata['type'] = 'overlay'
+
+        tree._metadata['child_trees'] = [child1, child2]
+
+        assert len(tree.child_trees()) == 2
+        assert child1 in tree.child_trees()
+        assert child2 in tree.child_trees()
+
+    def test_child_trees_filters_by_type(self):
+        """child_trees(type) should filter by type."""
+        tree = LopperTree()
+        child1 = LopperTree()
+        child1._metadata['type'] = 'extracted'
+        child2 = LopperTree()
+        child2._metadata['type'] = 'overlay'
+
+        tree._metadata['child_trees'] = [child1, child2]
+
+        extracted = tree.child_trees('extracted')
+        assert len(extracted) == 1
+        assert child1 in extracted
+
+        overlays = tree.child_trees('overlay')
+        assert len(overlays) == 1
+        assert child2 in overlays
+
+    def test_extracted_trees_helper(self):
+        """extracted_trees() should return only extracted type."""
+        tree = LopperTree()
+        child1 = LopperTree()
+        child1._metadata['type'] = 'extracted'
+        child2 = LopperTree()
+        child2._metadata['type'] = 'overlay'
+
+        tree._metadata['child_trees'] = [child1, child2]
+
+        assert tree.extracted_trees() == [child1]
+
+    def test_overlay_trees_helper(self):
+        """overlay_trees() should return only overlay type."""
+        tree = LopperTree()
+        child1 = LopperTree()
+        child1._metadata['type'] = 'extracted'
+        child2 = LopperTree()
+        child2._metadata['type'] = 'overlay'
+
+        tree._metadata['child_trees'] = [child1, child2]
+
+        assert tree.overlay_trees() == [child2]
+
+
+class TestDeleteCapture:
+    """Test that delete() captures nodes in extracted trees."""
+
+    def test_delete_creates_extracted_tree(self):
+        """Deleting a node should create an extracted tree."""
+        tree = LopperTree()
+        # Create a node and add it
+        foo = LopperNode(-1, "/foo")
+        tree.add(foo)
+        tree.sync()
+        tree.resolve()
+
+        # Delete the node
+        tree.delete(tree['/foo'])
+
+        # Check that an extracted tree was created
+        assert len(tree.extracted_trees()) == 1
+        extracted = tree.extracted_trees()[0]
+        assert extracted._metadata['name'] == 'extracted_foo'
+        assert extracted._metadata['type'] == 'extracted'
+
+    def test_delete_with_capture_false_no_extraction(self):
+        """delete(capture=False) should not create extracted tree."""
+        tree = LopperTree()
+        foo = LopperNode(-1, "/foo")
+        tree.add(foo)
+        tree.sync()
+        tree.resolve()
+
+        tree.delete(tree['/foo'], capture=False)
+
+        assert len(tree.extracted_trees()) == 0
+
+    def test_extracted_tree_not_created_for_already_extracted(self):
+        """Extracted trees should not create child extracted trees."""
+        tree = LopperTree()
+        tree._metadata['type'] = 'extracted'  # Mark as extracted
+
+        foo = LopperNode(-1, "/foo")
+        tree.add(foo)
+        tree.sync()
+        tree.resolve()
+
+        tree.delete(tree['/foo'])
+
+        # Should not create nested extracted tree
+        assert len(tree.extracted_trees()) == 0
+
+    def test_subtraction_operator_creates_extracted_tree(self):
+        """tree - node should create extracted tree via capture."""
+        tree = LopperTree()
+        foo = LopperNode(-1, "/foo")
+        tree.add(foo)
+        tree.sync()
+        tree.resolve()
+
+        tree = tree - tree['/foo']
+
+        assert len(tree.extracted_trees()) == 1
+
+
+class TestOverlayRegistration:
+    """Test that overlay_of() registers overlays with parent."""
+
+    def test_overlay_of_registers_with_parent(self):
+        """overlay_of() should register overlay in parent's child_trees."""
+        base = LopperTree()
+        overlay = LopperTree()
+
+        overlay.overlay_of(base)
+
+        assert overlay in base.child_trees()
+        assert overlay in base.overlay_trees()
+
+    def test_overlay_of_sets_metadata(self):
+        """overlay_of() should set overlay metadata."""
+        base = LopperTree()
+        overlay = LopperTree()
+
+        overlay.overlay_of(base)
+
+        assert overlay._metadata['type'] == 'overlay'
+        assert overlay._metadata['parent'] is base
+        assert overlay._metadata['name'] == 'overlay_1'
+
+    def test_overlay_of_with_custom_name(self):
+        """overlay_of() should accept custom name."""
+        base = LopperTree()
+        overlay = LopperTree()
+
+        overlay.overlay_of(base, name='pl_overlay')
+
+        assert overlay._metadata['name'] == 'pl_overlay'
+
+    def test_overlay_external_trees_for_resolution(self):
+        """overlay should have base in _external_trees for resolution."""
+        base = LopperTree()
+        overlay = LopperTree()
+
+        overlay.overlay_of(base)
+
+        assert base in overlay._external_trees
+        assert base in overlay._metadata['external_trees']
+
+    def test_overlay_of_exclude_props(self):
+        """overlay_of(exclude_props) should remove specified properties."""
+        from lopper.tree import LopperProp
+
+        base = LopperTree()
+        overlay = LopperTree()
+
+        # Add a node with properties to overlay
+        foo = LopperNode(-1, "/foo")
+        overlay.add(foo)
+        overlay.sync()
+        overlay.resolve()
+
+        # Add properties directly to avoid phandle resolution issues
+        overlay['/foo'].__props__['address-map'] = LopperProp(
+            'address-map', -1, overlay['/foo'], [1, 2, 3]
+        )
+        overlay['/foo'].__props__['other-prop'] = LopperProp(
+            'other-prop', -1, overlay['/foo'], "keep"
+        )
+
+        overlay.overlay_of(base, exclude_props=['address-map'])
+
+        # address-map should be removed, other-prop should remain
+        assert 'address-map' not in overlay['/foo'].__props__
+        assert 'other-prop' in overlay['/foo'].__props__
+
+
+class TestSubtreesSync:
+    """Test LopperSDT.subtrees_sync() method."""
+
+    def test_subtrees_sync_populates_from_child_trees(self, lopper_sdt):
+        """subtrees_sync() should copy named child trees to subtrees dict."""
+        # Create a child tree with a name
+        child = LopperTree()
+        child._metadata['name'] = 'test_child'
+        child._metadata['type'] = 'extracted'
+        lopper_sdt.tree._metadata['child_trees'].append(child)
+
+        lopper_sdt.subtrees_sync()
+
+        assert 'test_child' in lopper_sdt.subtrees
+        assert lopper_sdt.subtrees['test_child'] is child
+
+    def test_subtrees_sync_skips_unnamed_children(self, lopper_sdt):
+        """subtrees_sync() should skip children without names."""
+        child = LopperTree()
+        child._metadata['name'] = None
+        lopper_sdt.tree._metadata['child_trees'].append(child)
+
+        initial_count = len(lopper_sdt.subtrees)
+        lopper_sdt.subtrees_sync()
+
+        assert len(lopper_sdt.subtrees) == initial_count
+
+    def test_subtrees_sync_does_not_overwrite(self, lopper_sdt):
+        """subtrees_sync() should not overwrite existing subtrees."""
+        # Add a subtree manually
+        existing = LopperTree()
+        lopper_sdt.subtrees['test_child'] = existing
+
+        # Add a child with same name
+        child = LopperTree()
+        child._metadata['name'] = 'test_child'
+        lopper_sdt.tree._metadata['child_trees'].append(child)
+
+        lopper_sdt.subtrees_sync()
+
+        # Should keep the existing one
+        assert lopper_sdt.subtrees['test_child'] is existing

--- a/tests/test_tree_tracking.py
+++ b/tests/test_tree_tracking.py
@@ -310,3 +310,85 @@ class TestSubtreesSync:
 
         # Should keep the existing one
         assert lopper_sdt.subtrees['test_child'] is existing
+
+
+class TestAutoFragments:
+    """Test that overlay_of() generates auto-fragments for cross-tree references."""
+
+    def test_overlay_of_generates_auto_fragments(self):
+        """overlay_of() should generate fragments for base properties referencing overlay nodes."""
+        from lopper.tree import LopperProp
+
+        # Create base tree with a device that references a clock
+        base = LopperTree()
+        base_root = base['/']
+        base_root + LopperProp(name='#clock-cells', value=[1])
+
+        device = LopperNode(-1, "/device")
+        device.phandle = 0x10
+        device.label = "my_device"
+        device + LopperProp(name='clocks', value=[0x20, 0x0])  # References phandle 0x20
+        device + LopperProp(name='clock-names', value=["pl_clk"])
+        base.add(device)
+        base.sync()
+        base.resolve()
+
+        # Create overlay tree with the referenced clock node
+        overlay = LopperTree()
+        pl_clock = LopperNode(-1, "/pl_clock")
+        pl_clock.phandle = 0x20  # This is what device references
+        pl_clock.label = "pl_clk_0"
+        pl_clock + LopperProp(name='#clock-cells', value=[1])
+        overlay.add(pl_clock)
+        overlay.sync()
+        overlay.resolve()
+
+        # Call overlay_of - should auto-generate fragments
+        overlay.overlay_of(base)
+
+        # Check that auto_fragments metadata is populated
+        assert 'auto_fragments' in overlay._metadata
+        assert isinstance(overlay._metadata['auto_fragments'], list)
+        assert len(overlay._metadata['auto_fragments']) > 0
+
+    def test_auto_fragments_contains_fragment_nodes(self):
+        """auto_fragments metadata should contain the generated fragment nodes."""
+        from lopper.tree import LopperProp
+
+        base = LopperTree()
+        base_root = base['/']
+        base_root + LopperProp(name='#clock-cells', value=[1])
+
+        device = LopperNode(-1, "/device")
+        device.phandle = 0x10
+        device.label = "my_device"
+        device + LopperProp(name='clocks', value=[0x20, 0x0])
+        base.add(device)
+        base.sync()
+        base.resolve()
+
+        overlay = LopperTree()
+        pl_clock = LopperNode(-1, "/pl_clock")
+        pl_clock.phandle = 0x20
+        pl_clock.label = "pl_clk_0"
+        pl_clock + LopperProp(name='#clock-cells', value=[1])
+        overlay.add(pl_clock)
+        overlay.sync()
+        overlay.resolve()
+
+        overlay.overlay_of(base)
+
+        # Fragment nodes should be in auto_fragments list
+        fragments = overlay._metadata['auto_fragments']
+        fragment_names = [f.name for f in fragments]
+        assert "&my_device" in fragment_names
+
+    def test_auto_fragments_empty_when_no_refs(self):
+        """auto_fragments should be empty when no cross-tree references exist."""
+        base = LopperTree()
+        overlay = LopperTree()
+
+        overlay.overlay_of(base)
+
+        assert 'auto_fragments' in overlay._metadata
+        assert overlay._metadata['auto_fragments'] == []


### PR DESCRIPTION
Preserve I2C/SPI device nodes when their parent bus is mapped to CPU cluster After building mapped_nodelist, iterate all mapped nodes and add their children to the preservation list. This ensures devices like RTC on i2c1 bus are kept in the final device tree output