### PR TITLE
lopper:assists: Add support to generate I3C node for Zephyr domain DTS

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -986,6 +986,17 @@ def xlnx_remove_unsupported_nodes(tgt_node, sdt, machine):
                             node["#size-cells"] = LopperProp("#size-cells")
                             node["#size-cells"].value = 0
                             node.add(node["#size-cells"])
+                    # PS-I3C
+                    if "snps,dw-i3c-master-1.00a" in node["compatible"].value:
+                        node["compatible"].value = ["snps,designware-i3c"]
+                        if node.propval('#address-cells') != [3]:
+                            node["#address-cells"] = LopperProp("#address-cells")
+                            node["#address-cells"].value = 3
+                            node.add(node["#address-cells"])
+                        if node.propval('#size-cells') != [0]:
+                            node["#size-cells"] = LopperProp("#size-cells")
+                            node["#size-cells"].value = 0
+                            node.add(node["#size-cells"])
                     #UFS
                     if "amd,versal2-ufs" in node["compatible"].value:
                         new_node = LopperNode()

--- a/lopper/assists/zephyr_supported_comp.yaml
+++ b/lopper/assists/zephyr_supported_comp.yaml
@@ -122,6 +122,17 @@ cdns,i2c-r1p14:
     - '#address-cells'
     - '#size-cells'
 
+snps,dw-i3c-master-1.00a:
+  required:
+    - compatible
+    - status
+    - reg
+    - interrupts
+    - interrupt-parent
+    - clocks
+    - '#address-cells'
+    - '#size-cells'
+
 xlnx,xps-gpio-1.00.a:
   required:
     - compatible


### PR DESCRIPTION
- Add PS-I3C handler to set compatible
- zephyr_supported_comp.yaml: Add snps,dw-i3c-master-1.00a entry with required properties.