### PR TITLE
lopper: assists: xlnx_overlay_pl_dt: exclude address-map property from overlay

### DIFF
--- a/lopper/assists/xlnx_overlay_pl_dt.py
+++ b/lopper/assists/xlnx_overlay_pl_dt.py
@@ -734,6 +734,9 @@ def write_output_files(overlay_tree, sdt, pl_file, dtso_file):
     # Replace interrupt-parent references from imux to gic
     content = content.replace('interrupt-parent = <&imux>;', 'interrupt-parent = <&gic>;')
 
+    # Remove empty overlay fragments left after property exclusion
+    content = re.sub(r'\n&\w+ \{\n\};\n', '', content)
+
     with open(pl_file, "w") as f:
         f.write(content)
 
@@ -766,6 +769,12 @@ def xlnx_generate_overlay_dt(tgt_node, sdt, options):
     _level(utils.log_setup(options), __name__)
     # Parse and validate options
     platform, config, zynq_platforms, versal_platforms, firmware_override, node_specs, exclude_props, exclude_nodes = validate_and_parse_options(options, sdt)
+
+    # Remove SDT-specific properties from overlay automatically
+    if exclude_props is None:
+        exclude_props = ['address-map']
+    elif 'address-map' not in exclude_props:
+        exclude_props.append('address-map')
 
     overlay_tree = LopperTree()
 


### PR DESCRIPTION
**Current status**:
With latest changes in master branch,
When overlay_of() is called, fragments are now automatically generated for any base tree properties that reference overlay nodes. This ensures cross-tree references remain valid. Hence address-map properties are generated in the overlay which provides the complete address-map including both PS and PL device entries.

**Fix**:
address-map is an SDT-specific property that is not consumed by the Linux kernel at runtime. Automatically exclude it from the generated pl.dtsi and clean up any empty overlay fragments left behind.

Closed [PR #746](https://github.com/devicetree-org/lopper/pull/746) as it was based on old upstream master.

@zeddi,
I confirm that PL overlay use cases pass on master and there are no warnings. Please review.
Should I still keep cleaning up of empty fragments through regex? You were mentioning this last time:

> so the check for empty property is not used, but I guess it is a good safety net if something breaks.

CC: @onkarharsh , @kedareswararao , @sivadur 