### PR TITLE
yaml_to_dts_expansion: fix ranges boolean property in reserved-memory

### DIFF
--- a/lopper/assists/yaml_to_dts_expansion.py
+++ b/lopper/assists/yaml_to_dts_expansion.py
@@ -873,19 +873,26 @@ def reserved_memory_expand( tree, reserved_memory_node ):
     RESERVED_MEMORY_BOOLEAN_PROPS = [
         'no-map',
         'reusable',
+        'ranges',
         'linux,cma-default',
         'linux,dma-default',
     ]
 
+    _BOOL_TRUE_VALUES = (1, True, [1], [True])
+
+    def _fixup_boolean_props(node):
+        for prop in RESERVED_MEMORY_BOOLEAN_PROPS:
+            if node.propval(prop) in _BOOL_TRUE_VALUES:
+                node.delete(prop)
+                node + LopperProp(name=prop)
+
+    # Fix boolean properties on the parent reserved-memory node and children
+    _fixup_boolean_props(res_mem_node)
+
     # read start and size. then form 'reg' property for the node.
     # then remove start and size
     for n in pre_existing_res_mem_nodes:
-        # Handle all boolean properties - convert value=1/True to empty property
-        for bool_prop in RESERVED_MEMORY_BOOLEAN_PROPS:
-            prop_val = n.propval(bool_prop)
-            if prop_val in (1, True, [1], [True]):
-                n.delete(bool_prop)
-                n + LopperProp(name=bool_prop)
+        _fixup_boolean_props(n)
 
         if n.propval("reg") != ['']:
             continue


### PR DESCRIPTION
When ranges: true is specified in YAML, the bool_as_int config causes it to be stored as [1], resulting in ranges = <0x1> in DTS output instead of the correct empty property ranges;

Fix by adding ranges to RESERVED_MEMORY_BOOLEAN_PROPS and applying the boolean-to-empty fixup on both the parent reserved-memory node and its children. Refactor duplicate logic into a shared _fixup_boolean_props helper.