### PR TITLE
lopper: assists: yaml_bindings: Add xlnx,vpss to HDMI 2.1 TXSS

### DIFF
--- a/lopper/assists/yaml_bindings/xlnx,v-hdmi-txss1.yaml
+++ b/lopper/assists/yaml_bindings/xlnx,v-hdmi-txss1.yaml
@@ -117,6 +117,11 @@ properties:
       hdcp1x keymgmt registers.
     $ref: /schemas/types.yaml#/definitions/phandle
 
+  xlnx,vpss:
+    description: |
+      vpss phandle. Requied only when vpss is connected to HDMI as bridge.
+    $ref: /schemas/types.yaml#/definitions/phandle
+
   ports:
     type: object
 
@@ -186,6 +191,7 @@ examples:
         xlnx,include-hdcp-1-4;
         xlnx,include-hdcp-2-2;
         xlnx,hdcp1x-keymgmt = <&hdcp_keymngmt_blk_0>;
+        xlnx,vpss = <&v_proc_ss_0>;
         phy-names = "hdmi-phy0", "hdmi-phy1", "hdmi-phy2", "hdmi-phy3";
         phys = <&hdmiphy_lane0 0 1 1 1>, <&hdmiphy_lane1 0 1 1 1>,
                <&hdmiphy_lane2 0 1 1 1>, <&hdmiphy_lane3 0 1 1 1>;
@@ -206,4 +212,7 @@ examples:
         compatible = "xlnx,hdcp-keymngmt-blk-1.0", "syscon";
         reg = <0x80030000 0x10000>;
     };
+
+# Documentation of "v_proc_ss_0" node is located at
+# Documentation/devicetree/bindings/display/xlnx/xlnx,vpss-scaler.txt
 ...


### PR DESCRIPTION
Add the optional xlnx,vpss property to the Xilinx HDMI 2.1 TX Subsystem dt-binding. The property holds a phandle to the VPSS node and is required only when VPSS is connected to HDMI as a bridge.