### PR TITLE
lopper:assists:baremetal_xparameters_xlnx: Add DDRMC5_I2C_MASTER and …

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -1,6 +1,6 @@
 #/*
 # * Copyright (c) 2020 Xilinx Inc. All rights reserved.
-# * Copyright (c) 2024 - 2025 Advanced Micro Devices, Inc.  All rights reserved.
+# * Copyright (c) 2024 - 2026 Advanced Micro Devices, Inc.  All rights reserved.
 # *
 # * Author:
 # *       Appana Durga Kedareswara rao <appana.durga.kedareswara.rao@amd.com>
@@ -553,6 +553,21 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
             plat.buf(f"\n#define DDRMC5_DEVICE_TYPE_RDIMM\n")
         elif val == "UDIMMs":
             plat.buf(f"\n#define DDRMC5_DEVICE_TYPE_UDIMM\n")
+
+    #Define for DDRMC5_I2C_MASTER and DDRMC5_DEBUG_ELF (from axi_noc2 memory node)
+    for node in sdt.tree['/'].subnodes():
+        if node.propval('xlnx,ip-name') == ['axi_noc2']:
+            i2c_master = node.propval('xlnx,ddrmc5-i2c-master')
+            debug_elf = node.propval('xlnx,ddrmc5-debug-elf')
+            if i2c_master != ['']:
+                val = i2c_master[0]
+                plat.buf(f"\n/* DDRMC5_I2C_MASTER */")
+                plat.buf(f'\n#define DDRMC5_I2C_MASTER "{val}"\n')
+            if debug_elf != ['']:
+                val = debug_elf[0]
+                plat.buf(f"\n/* DDRMC5_DEBUG_ELF */")
+                plat.buf(f'\n#define DDRMC5_DEBUG_ELF "{val}"\n')
+            break
 
     #Define for XSEM_CFRSCAN_EN
     if sdt.tree[tgt_node].propval('semmem-scan') != ['']:


### PR DESCRIPTION
…DDRMC5_DEBUG_ELF defines

Generate DDRMC5_I2C_MASTER and DDRMC5_DEBUG_ELF macro definitions in xparameters by reading the corresponding device tree properties from the axi_noc2