### PR TITLE
overlay: fix child_nodes deserialization in multi-pass lopper invocations

### DIFF
--- a/lopper/__init__.py
+++ b/lopper/__init__.py
@@ -584,7 +584,8 @@ def _deserialize_overlay_node(data, parent=None, tree=None):
 
     for child_data in data.get("children", []):
         child = _deserialize_overlay_node(child_data, parent=node, tree=tree)
-        node.child_nodes.append(child)
+        child.parent = node
+        node.child_nodes[child.abs_path] = child
 
     return node
 


### PR DESCRIPTION
**Issue**:
When an overlay file with child nodes (e.g., updated_zocl.dtsi containing zyxclmm_drm under &amba_pl) is passed via -i in pass 1, Lopper embeds the overlay data into the output DTS for preservation across passes. In pass 2 (e.g., gen_domain_dts), Lopper crashes at startup while reconstructing the embedded overlay data:

AttributeError: 'collections.OrderedDict' object has no attribute 'append'

**Root Cause**:
_deserialize_overlay_node() used node.child_nodes.append(child), but child_nodes is an OrderedDict, not a list.

**Fix**:
Changed to node.child_nodes[child.abs_path] = child with explicit parent assignment, consistent with how child_nodes is managed in tree.py.

**Example Lopper command invocations**:
```
LOPPER_DTC_FLAGS="-b 0 -@" ./lopper.py -O lopper_out -f --enhanced -i updated_zocl.dtsi apu_linux-chosen.dts system-top-no-pl.dts -- xlnx_overlay_pl_dt psv_cortexa72_0 full --firmware-name=gmio_async_xrt.pdi

LOPPER_DTC_FLAGS="-b 0 -@" ./lopper.py -O lopper_out/ -f --enhanced -i lop-a72-imux.dts lopper_out/system-top-no-pl.dts apu_linux.dts -- gen_domain_dts psv_cortexa72_0 linux_dt
```