### PR TITLE
base: phandle_safe_name: replace all invalid label characters

### DIFF
--- a/lopper/base.py
+++ b/lopper/base.py
@@ -711,6 +711,9 @@ class lopper_base:
         safe_name = phandle_name.replace( '@', '' )
         safe_name = safe_name.replace( '-', "_" )
         safe_name = safe_name.replace( '/', "_" )
+        safe_name = safe_name.replace( ',', "_" )
+        safe_name = safe_name.replace( '.', "_" )
+        safe_name = safe_name.replace( '+', "_" )
 
         return safe_name
 


### PR DESCRIPTION
DTS labels must be valid C identifiers ([a-zA-Z_][a-zA-Z0-9_]*), but node names can contain characters from the set [0-9a-zA-Z,._+-].

Previously, phandle_safe_name() only replaced '@', '-', and '/'. This left ',' , '.' and '+' in the generated label, producing invalid DTS output (e.g., "pcie0,0:" for node pcie@0,0).

Add replacements for ',', '.', and '+' so that all non-identifier characters in node names are converted to '_'.