### PR TITLE
lopper: assists: zephyr: Drop bootph-all property from generated doma…

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -2068,6 +2068,8 @@ def xlnx_generate_zephyr_domain_dts(tgt_node, sdt, options):
             sdt.tree[node].delete('reg')
         if node.propval('clock-output-names') != ['']:
             sdt.tree[node].delete('clock-output-names')
+        if node.props('bootph-all') != []:
+            sdt.tree[node].delete('bootph-all')
         node.name = node.name.split('@')[0]
 
     match_cpunode = get_cpu_node(sdt, options)


### PR DESCRIPTION
…in DTS

Zephyr enforces strict property checks on DTS nodes and does not recognize bootph-all. Its presence causes build-time errors when the generated domain DTS is consumed by Zephyr.

Strip the bootph-all property from clock nodes during domain DTS generation, consistent with how reg and clock-output-names are already excluded.