### PR TITLE
lopper: assists: gen_domain_dts: Keep Versal Gen2 USB3 PHY IPs in Lin…

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -428,7 +428,7 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
                             'psv_r5_tcm', 'psv_tcm_global', 'psv_r5_0_atcm_lockstep', 'psv_r5_0_btcm_lockstep']
 
     versal_gen2_linux_ignore_ip_list = ['mmi_udh_pll', 'mmi_common', 'mmi_pipe_gem_slcr',
-                            'mmi_udh_pll', 'mmi_udh_slcr', 'mmi_usb2phy', 'mmi_usb3phy_crpara', 'mmi_usb3phy_tca',
+                            'mmi_udh_pll', 'mmi_udh_slcr', 'mmi_usb2phy',
                             'pmc_rsa', 'pmc_aes', 'pmc_sha2', 'pmc_sha3', "rpu", "apu", "pmc_ppu1_mdm", "pmc_xppu_npi", "pmc_xppu",
                             "pmc_xmpu", "pmc_slave_boot_stream", "pmc_slave_boot", "pmc_ram_npi", "pmc_global", "ocm", "ocm_xmpu",
                             "lpd_xppu", "lpd_systmr_read", "lpd_systmr_ctrl", "lpd_slcr_secure", "lpd_slcr", "lpd_iou_slcr",


### PR DESCRIPTION
Drop mmi_usb3phy_crpara and mmi_usb3phy_tca from versal_gen2 ignore IP list so gen_domain_dts no longer removes those helper blocks when pruning the SDT for Linux. To support USB Type-C reversibility , MMI USB USB3 phy connectivity is needed.
