### PR TITLE
petalinuxconfig: rename output file to sys_hw_data.yaml

### DIFF
--- a/lopper/assists/petalinuxconfig_xlnx.py
+++ b/lopper/assists/petalinuxconfig_xlnx.py
@@ -169,7 +169,7 @@ def xlnx_generate_petalinux_config(tgt_node, sdt, options):
         if 'processor' in device_type_dict and proc_name and proc_name in device_type_dict['processor']:
             device_type_dict['processor'][proc_name].update(tmp_dict)
 
-        with open("petalinux_config.yaml", "w") as fd:
+        with open("sys_hw_data.yaml", "w") as fd:
             fd.write(yaml.dump(device_type_dict, Dumper=YamlDumper, default_flow_style=False, sort_keys=False, indent=4, width=32768))
 
     return True


### PR DESCRIPTION
Change the generated config output filename from petalinux_config.yaml to sys_hw_data.yaml in xlnx_generate_petalinux_config() as it is used by Gen-Machine-Conf.