### PR TITLE
lopper: assists: xlnx_overlay_pl_dt: Validate PL nodes by reg or compatible

### DIFF
--- a/lopper/assists/xlnx_overlay_pl_dt.py
+++ b/lopper/assists/xlnx_overlay_pl_dt.py
@@ -354,7 +354,11 @@ def validate_and_parse_options(options, sdt):
 
 def validate_amba_pl_node(amba_node):
     """
-    Validate that amba_pl node has valid PL nodes with register properties.
+    Return True if /amba_pl has a PL node with a 'reg' or 'compatible' property.
+
+    'compatible' is checked so non-address-mapped nodes like zocl (compatible,
+    no reg) still count. The amba_pl node itself is skipped so its "simple-bus"
+    compatible does not falsely qualify.
 
     Args:
         amba_node: The /amba_pl node from the device tree
@@ -363,13 +367,13 @@ def validate_amba_pl_node(amba_node):
         bool: True if valid PL nodes exist, False otherwise
     """
     has_valid_pl = False
-    for subnode in amba_node.subnodes():
-        if subnode.propval('reg') != ['']:
+    for subnode in amba_node.subnodes(children_only=True):
+        if subnode.propval('reg') != [''] or subnode.propval('compatible') != ['']:
             has_valid_pl = True
             break
 
     if not has_valid_pl:
-        _error(f"No valid PL nodes found in amba_pl (no nodes with reg properties)")
+        _error(f"No valid PL nodes found in amba_pl (no child nodes with reg or compatible)")
 
     return has_valid_pl
 


### PR DESCRIPTION
**Root Cause**:
xlnx_overlay_pl_dt's validate_amba_pl_node() only considered a /amba_pl
child to be a valid PL node if it had a reg property. On designs where
/amba_pl contains only non-address-mapped nodes — e.g. the zocl node
zyxclmm_drm, which has a compatible but no reg — validation failed. As a
result the assist aborted early: it generated no pl.dtsi and, crucially,
did not remove /amba_pl from the base device tree.

Because /amba_pl was left in the base SDT, downstream processing
(gen_domain_dts) carried its nodes into the generated Linux device tree.
The kernel then probed the device even though no PL is present, and the
probe failed at boot.

**Fix**:
Treat a /amba_pl child as a valid PL node if it has reg or compatible, so
non-address-mapped nodes like zocl are recognized. With validation
passing, the assist now:
- emits a pl.dtsi overlay containing such nodes, and
- removes /amba_pl from the base tree as in the normal flow (so the node
  no longer leaks into the Linux DT).

The scan uses children_only=True so the /amba_pl bus node's own compatible
= "simple-bus" is not mistakenly counted (otherwise every /amba_pl,
including an empty one, would pass).