### PR TITLE
assists: bmcmake_metadata_xlnx: fix type mismatch

### DIFF
--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -202,7 +202,7 @@ struct xtopology_t xtopology[] = {{'''
     }},'''
     topology_str += f'''
     {{
-        NULL
+        0
     }}
 }};'''
     topology_fd.write(topology_str)


### PR DESCRIPTION
Generated lwip xtopology_g.c used NULL to zero-terminate the xtopology array, triggering -Wint-conversion because the field type is long unsigned int, not a pointer. Use integer literal 0 instead.