### PR TITLE
lopper:assists:petalinuxconfig_xlnx: Add DT alias and chosen node chosen node metadata to YAML config

### DIFF
--- a/lopper/assists/petalinuxconfig_xlnx.py
+++ b/lopper/assists/petalinuxconfig_xlnx.py
@@ -32,6 +32,118 @@ def is_compat(node, compat_string_to_test):
         return xlnx_generate_petalinux_config
     return ""
 
+def build_alias_map(sdt, aliases_node):
+    """Build a mapping of node paths to their aliases.
+
+    Uses Lopper's alias_node() method to properly resolve alias references
+    to their canonical node paths, handling both direct paths and label references.
+
+    Args:
+        sdt: The system device tree object
+        aliases_node: The /aliases node from the device tree
+
+    Returns:
+        Dictionary mapping node absolute paths to lists of alias names
+    """
+    alias_map = {}
+    if not aliases_node:
+        return alias_map
+
+    try:
+        for alias_name in aliases_node.__props__.keys():
+            try:
+                # Use Lopper's alias_node() to properly resolve the alias to its node
+                resolved_node = sdt.tree.alias_node(alias_name)
+                if resolved_node:
+                    # Use the resolved node's absolute path as the key
+                    node_path = resolved_node.abs_path
+                    if node_path not in alias_map:
+                        alias_map[node_path] = []
+                    alias_map[node_path].append(alias_name)
+            except (KeyError, AttributeError, TypeError):
+                pass
+    except (KeyError, AttributeError, TypeError):
+        pass
+
+    return alias_map
+
+def get_aliases_for_node(alias_map, node):
+    """Get all aliases that point to a given node.
+
+    Args:
+        alias_map: Dictionary mapping node paths to alias lists
+        node: The node to find aliases for
+
+    Returns:
+        List of alias names that point to this node
+    """
+    if not alias_map or not node:
+        return []
+    return alias_map.get(node.abs_path, [])
+
+def extract_serial_port_from_aliases(alias_list):
+    """Extract serial port identifier from aliases.
+
+    Args:
+        alias_list: List of aliases for a node
+
+    Returns:
+        Serial port identifier (e.g., 'serial0', 'uart1') or None
+    """
+    if not alias_list:
+        return None
+
+    # Look for serial or uart aliases
+    for alias in alias_list:
+        if re.match(r'^(serial|uart)\d+$', alias):
+            return alias
+
+    return None
+
+def extract_chosen_node_properties(chosen_node):
+    """Extract all properties from the /chosen node into a dictionary.
+
+    Args:
+        chosen_node: The /chosen node from the device tree
+
+    Returns:
+        Dictionary of all chosen node properties and their values
+    """
+    chosen_dict = {}
+    if not chosen_node:
+        return chosen_dict
+
+    try:
+        for prop_name in chosen_node.__props__.keys():
+            try:
+                prop_value = chosen_node.propval(prop_name, list)
+                if prop_value and prop_value != ['']:
+                    # Store single values as strings, multiple values as lists
+                    if len(prop_value) == 1:
+                        chosen_dict[prop_name] = prop_value[0]
+                    else:
+                        chosen_dict[prop_name] = prop_value
+            except (KeyError, AttributeError, TypeError, IndexError):
+                pass
+    except (KeyError, AttributeError, TypeError):
+        pass
+
+    return chosen_dict
+
+def add_device_tree_metadata(target_dict, key, alias_map, node):
+    """Add dt_node and aliases metadata to a device entry.
+
+    Args:
+        target_dict: Dictionary to update
+        key: Key in the dictionary to update
+        alias_map: Dictionary mapping node paths to alias lists
+        node: The device tree node
+    """
+    target_dict[key].update({"dt_node": node.abs_path})
+    node_aliases = get_aliases_for_node(alias_map, node)
+    if node_aliases:
+        target_dict[key].update({"aliases": node_aliases})
+
 class YamlDumper(yaml.Dumper):
     def increase_indent(self, flow=False, indentless=False):
         return super(YamlDumper, self).increase_indent(flow, False)
@@ -45,20 +157,42 @@ def xlnx_generate_petalinux_config(tgt_node, sdt, options):
     driver_list = []
     node_list = []
     symbol_node = ""
+    aliases_node = None
+    chosen_node = None
     root_compat = tgt_node.propval('compatible')
     yaml_file = options['args'][1]
 
     # Traverse the tree and find the nodes having status=ok property
     # and create a compatible_list from these nodes.
+    # Also extract the aliases and chosen nodes for this domain
     for node in root_sub_nodes:
         try:
             if node.name == "__symbols__":
                 symbol_node = node
+            elif node.name == "chosen":
+                # Domain-specific chosen node takes precedence
+                chosen_node = node
             status = node["status"].value
             if "okay" in status:
                 node_list.append(node)
-        except:
-           pass
+        except (KeyError, AttributeError):
+            pass
+
+    # Get the aliases node from the device tree root and build alias map
+    try:
+        aliases_node = sdt.tree['/aliases']
+    except (KeyError, AttributeError):
+        aliases_node = None
+
+    # If no domain-specific chosen node found, try global /chosen (for root domain)
+    if not chosen_node:
+        try:
+            chosen_node = sdt.tree['/chosen']
+        except (KeyError, AttributeError):
+            chosen_node = None
+
+    alias_map = build_alias_map(sdt, aliases_node)
+    chosen_properties = extract_chosen_node_properties(chosen_node)
 
     mapped_nodelist = get_mapped_nodes(sdt, node_list, options)
     nodename_list = []
@@ -87,6 +221,10 @@ def xlnx_generate_petalinux_config(tgt_node, sdt, options):
         if device != ['']:
             device_type_dict['device_id'] = device[0]
 
+        # Add chosen node properties early in the output for better organization
+        if chosen_properties:
+            device_type_dict['chosen'] = chosen_properties
+
         # Check if memory device type exists in schema before fetching memory ranges
         has_memory_type = any(re.search("memory", schema[res]['device_type']) for res in res_list)
         if has_memory_type:
@@ -106,6 +244,8 @@ def xlnx_generate_petalinux_config(tgt_node, sdt, options):
                     proc_name = label_name
                     ipname = {"arch": "aarch64", "ip_name":ip_name[0]}
                     device_type_dict['processor'] = {label_name:ipname}
+                    # Add DT node path and aliases
+                    add_device_tree_metadata(device_type_dict['processor'], label_name, alias_map, match_cpunode)
                     device_type_dict['processor'][label_name].update({"slaves_strings": " ".join(nodename_list)})
             elif re.search("memory", dev_type):
                 ### Memory Handling (using pre-fetched mem_ranges and label_names)
@@ -115,10 +255,18 @@ def xlnx_generate_petalinux_config(tgt_node, sdt, options):
                         mem_node = [node for node in memnode_list if re.search(mem_name[:-2], node.propval('xlnx,ip-name', list)[0])]
                     except (IndexError, AttributeError, TypeError):
                         mem_node = None
-                    tmp_dict['slaves'][mem_label] = {"device_type":"memory"}
-                    if mem_node:
-                        if mem_node[0].propval('memory_type') != ['']:
-                            tmp_dict['slaves'][mem_label] = {"device_type":mem_node[0].propval('memory_type', list)[0]}
+
+                    # Determine device_type
+                    device_type = "memory"
+                    if mem_node and len(mem_node) > 0 and mem_node[0].propval('memory_type') != ['']:
+                        device_type = mem_node[0].propval('memory_type', list)[0]
+
+                    tmp_dict['slaves'][mem_label] = {"device_type": device_type}
+
+                    # Add DT node path and aliases for memory nodes if mem_node exists
+                    if mem_node and len(mem_node) > 0:
+                        add_device_tree_metadata(tmp_dict['slaves'], mem_label, alias_map, mem_node[0])
+
                     tmp_dict['slaves'][mem_label].update({"ip_name":mem_name[:-2]})
                     tmp_dict['slaves'][mem_label].update({"baseaddr":hex(mem[0])})
                     tmp_dict['slaves'][mem_label].update({"highaddr":hex(mem[0] + mem[1])})
@@ -150,10 +298,19 @@ def xlnx_generate_petalinux_config(tgt_node, sdt, options):
                                 tmp_dict['slaves'][label_name] = {"device_type":"serial"}
                                 tmp_dict['slaves'][label_name].update({"ip_name":ipname[0]})
                                 tmp_dict['slaves'][label_name].update({"baseaddr":hex(addr)})
+                                # Add DT node path and aliases using helper function
+                                add_device_tree_metadata(tmp_dict['slaves'], label_name, alias_map, node)
+                                # Extract serial port identifier from aliases if available
+                                node_aliases = get_aliases_for_node(alias_map, node)
+                                serial_port = extract_serial_port_from_aliases(node_aliases)
+                                if serial_port:
+                                    tmp_dict['slaves'][label_name].update({"serial_port": serial_port})
                             else:
                                 tmp_dict['slaves'][label_name] = {"device_type":dev_type}
                                 tmp_dict['slaves'][label_name].update({"ip_name":ipname[0]})
-                        except (KeyError, IndexError, TypeError):
+                                # Add DT node path and aliases for non-serial devices
+                                add_device_tree_metadata(tmp_dict['slaves'], label_name, alias_map, node)
+                        except (KeyError, AttributeError, TypeError):
                             pass
                         break
 
@@ -163,6 +320,8 @@ def xlnx_generate_petalinux_config(tgt_node, sdt, options):
                 try:
                     if ipname and ipname[0]:
                         tmp_dict['slaves'][label_name] = {"ip_name": ipname[0]}
+                        # Add DT node path and aliases even for unmatched devices
+                        add_device_tree_metadata(tmp_dict['slaves'], label_name, alias_map, node)
                 except (IndexError, TypeError):
                     pass
         # Only update if processor was configured


### PR DESCRIPTION
Enhance the generated sys_hw_data.yaml configuration to include device tree metadata for improved traceability, device identification.

New YAML fields added:
  - chosen: Dictionary of all /chosen node properties (e.g., bootargs, stdout-path)
  - dt_node: Absolute device tree node path (e.g., /amba_pl/ethernet@40c00000)
  - aliases: List of alias names pointing to the node (e.g., [serial0, uart1])
  - serial_port: Serial port identifier for UART devices (e.g., serial0)

The dt_node and aliases fields are added to all device types:
  - Processor nodes: Full CPU node path and any CPU aliases
  - Memory devices: Memory node paths with aliases when available
  - Serial devices: UART paths plus serial_port identifier from aliases
  - Peripheral devices: Full peripheral node paths and alias mappings
  - Unmatched devices: DT metadata included when IP name is available