### PR TITLE
lopper: assists: Remove xlnx,bus-width for ADMA

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -1235,8 +1235,6 @@ def xlnx_remove_unsupported_nodes(tgt_node, sdt, machine, options=None):
                                 node["clock-names"].value = desired_clock_names
                         if node.props("#dma-cells") != [] and node.propval("#dma-cells") != [1]:
                             node['#dma-cells'].value = [1]
-                        if node.props("xlnx,bus-width") != [] and node.propval("xlnx,bus-width") != [64]:
-                            node["xlnx,bus-width"].value = [64]
                     # GPIOPS
                     if any(version in node["compatible"].value for version in ("xlnx,pmc-gpio-1.0", "xlnx,versal-gpio-1.0")):
                         version = lambda x: x in node["compatible"].value

--- a/lopper/assists/zephyr_supported_comp.yaml
+++ b/lopper/assists/zephyr_supported_comp.yaml
@@ -248,7 +248,6 @@ xlnx,zynqmp-dma-1.0:
     - interrupts
     - clocks
     - clock-names
-    - xlnx,bus-width
 
 amd,versal2-dma-1.0:
   required:
@@ -258,7 +257,6 @@ amd,versal2-dma-1.0:
     - interrupts
     - clocks
     - clock-names
-    - xlnx,bus-width
 
 xlnx,versal-gpio-1.0:
   required:


### PR DESCRIPTION
Remove xlnx,bus-width from the yaml and gen_domain_dts file