### PR TITLE
lopper:assists:bmcmake_metadata_xlnx: Set CPM6_SUPPORTED CMake variab…

### DIFF
--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -1,5 +1,5 @@
 #/*
-# * Copyright (c) 2020 - 2025 Xilinx Inc. All rights reserved.
+# * Copyright (c) 2020 - 2026 Xilinx Inc. All rights reserved.
 # *
 # * Author:
 # *       Appana Durga Kedareswara rao <appana.durga.rao@xilinx.com>
@@ -333,7 +333,9 @@ def generate_hwtocmake_medata(sdt, node_list, src_path, repo_path_data, options,
             cmake_submachine = ""
 
             match_cpunode = bm_config.get_cpu_node(sdt, options)
-
+            # check cpm6 is supported
+            if match_cpunode.props('xlnx,cpm6_supported'):
+                fd.write(f'set(CPM6_SUPPORTED "ON" CACHE STRING "CPM6 Supported")\n')
             family = sdt.tree['/'].propval('family', list)
             if family[0]:
                 if family[0] == "Versal_2VE_2VM":


### PR DESCRIPTION
…le from SDT

Detect the xlnx,cpm6_supported property on the matched CPU node in the system device tree and emit CPM6_SUPPORTED=ON in the generated CMake metadata when CPM6 is present in the design. This bridges the SDT CPM6 detection to the embeddedsw xilpm build configuration, enabling automatic inclusion of GPIO proc handler support for CPM6-based Versal designs without manual BSP configuration.