### PR TITLE
lopper:assists: Add RV32E (embedded) compiler/ABI support for MicroBlaze-V.

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -1451,12 +1451,7 @@ def generate_board_kconfig_defconfig(isa_string, cpu_node, intc_node, num_interr
     # Track added extensions to avoid duplicates
     added_extensions = set()
 
-    # Base ISA configurations - always add RV32I for MicroBlaze RISC-V
-    content += "config RISCV_ISA_RV32I\n"
-    content += "\tdefault y\n\n"
-    added_extensions.add('RISCV_ISA_RV32I')  # Track it to avoid duplicates
-
-    # Process ISA string to generate configs in the exact order: RV32I, M, A, C, ZICSR, ZIFENCEI
+    # Process ISA string to generate configs in the exact order: RV32I/RV32E, M, A, C, ZICSR, ZIFENCEI
     if isa_string:
         # Define the exact order matching the existing board defconfig
         ordered_extensions = [
@@ -1469,6 +1464,13 @@ def generate_board_kconfig_defconfig(isa_string, cpu_node, intc_node, num_interr
 
         # Process base ISA part for M, A, C detection
         isa_base = isa_string.split('_')[0]  # Same as SOC level
+
+        # Base ISA configuration - RV32E for embedded (reduced register set) MB-V
+        # cores (xlnx,use-embedded), RV32I otherwise.
+        base_isa_config = 'RISCV_ISA_RV32E' if isa_base.startswith('rv32e') else 'RISCV_ISA_RV32I'
+        content += f"config {base_isa_config}\n"
+        content += "\tdefault y\n\n"
+        added_extensions.add(base_isa_config)  # Track it to avoid duplicates
 
         # Process each extension in the defined order
         for key, config_name in ordered_extensions:
@@ -1512,6 +1514,12 @@ def generate_board_kconfig_defconfig(isa_string, cpu_node, intc_node, num_interr
                 content += f"config {config_name}\n"
                 content += "\tdefault y\n\n"
                 added_extensions.add(config_name)
+    else:
+        # No ISA string available - fall back to the default RV32I base,
+        # matching the prior (pre-RV32E) unconditional behavior.
+        content += "config RISCV_ISA_RV32I\n"
+        content += "\tdefault y\n\n"
+        added_extensions.add('RISCV_ISA_RV32I')
 
     content += "endif\n"
     return content
@@ -2215,7 +2223,8 @@ def xlnx_generate_zephyr_domain_dts(tgt_node, sdt, options):
 
                     isa = isa.split('_')[0]
 
-                    data_dict={'rv32i':"\tselect RISCV_ISA_RV32I\n",
+                    data_dict={'rv32e':"\tselect RISCV_ISA_RV32E\n",
+                        'rv32i':"\tselect RISCV_ISA_RV32I\n",
                         'm':"\tselect RISCV_ISA_EXT_M\n",
                         'a':"\tselect RISCV_ISA_EXT_A\n",
                         'c':"\tselect RISCV_ISA_EXT_C\n",

--- a/lopper/lops/lop-microblaze-riscv.dts
+++ b/lopper/lops/lop-microblaze-riscv.dts
@@ -89,8 +89,14 @@
                                from pprint import pprint
                                for n in tree.__selected__:
                                    pprint(vars(n['xlnx,data-size']))
+                                   use_embedded = n.propval('xlnx,use-embedded')
+                                   is_embedded = use_embedded != [''] and use_embedded[0] == 1
                                    if n['xlnx,data-size'].value[0] == 64:
+                                       if is_embedded:
+                                           print('WARNING: {}: xlnx,use-embedded is set but xlnx,data-size is 64; RV32E is a 32-bit-only ISA. Ignoring xlnx,use-embedded and generating rv64i flags.'.format(n.abs_path))
                                        n['xlnx,data-size'].tunes = 'rv64i'
+                                   elif is_embedded:
+                                       n['xlnx,data-size'].tunes = 'rv32e'
                                    else:
                                        n['xlnx,data-size'].tunes = 'rv32i'
                           ";
@@ -108,7 +114,14 @@
                                import os
 
                                for n in tree.__selected__:
+                                   use_embedded = n.propval('xlnx,use-embedded')
+                                   is_embedded = use_embedded != [''] and use_embedded[0] == 1 and n['xlnx,data-size'].value[0] != 64
+                                   fpu_conflict = is_embedded and n['xlnx,use-fpu'].value[0] != 0
+
                                    proplist= ['xlnx,data-size', 'xlnx,use-muldiv', 'xlnx,use-atomic', 'xlnx,use-fpu', 'xlnx,use-compression']
+                                   if fpu_conflict:
+                                       print('WARNING: {}: RV32E has no hard-float ABI; ignoring xlnx,use-fpu={}'.format(n.abs_path, n['xlnx,use-fpu'].value[0]))
+                                       proplist.remove('xlnx,use-fpu')
 
                                    archflags = []
                                    bsp_archflags = []
@@ -153,15 +166,21 @@
                                        bsp_archflags.append('_zicbom')
 
                                    if n['xlnx,data-size'].value[0] == 64:
-                                       archflags.append(' -mabi=lp64') 
+                                       archflags.append(' -mabi=lp64')
+                                       bsp_archflags.append(' -mabi=lp64')
+                                   elif is_embedded:
+                                       archflags.append(' -mabi=ilp32e')
+                                       bsp_archflags.append(' -mabi=ilp32e')
                                    else:
-                                       archflags.append(' -mabi=ilp32') 
+                                       archflags.append(' -mabi=ilp32')
+                                       bsp_archflags.append(' -mabi=ilp32')
 
-                                   if n['xlnx,use-fpu'].value[0] == 1:
-                                       archflags.append('f') 
-                                   elif n['xlnx,use-fpu'].value[0] == 2:
-                                       archflags.append('d') 
-                                   
+                                   if not fpu_conflict:
+                                       if n['xlnx,use-fpu'].value[0] == 1:
+                                           archflags.append('f')
+                                       elif n['xlnx,use-fpu'].value[0] == 2:
+                                           archflags.append('d')
+
                                    archflags.insert(0, '-march=')
                                    bsp_archflags.insert(0, '-march=')
                                    n.tunes = archflags


### PR DESCRIPTION
Propagate the xlnx,use-embedded CPU property (set by SDTGen for MicroBlaze-V cores with C_USE_EMBEDDED) through to the generated build flags:

- lop-microblaze-riscv.dts: emit rv32e/-mabi=ilp32e in cflags.yaml instead of rv32i/ilp32 when the core is configured as embedded, and apply the ABI flag to linkflags as well as cflags so BSP link-time multilib selection matches. Guard against the invalid use-embedded + hardware-FPU combination (RV32E has no standard hard-float ABI) and warn if use-embedded is set alongside a 64-bit data size (RV32E is 32-bit only).
- gen_domain_dts.py: select RISCV_ISA_RV32E instead of RISCV_ISA_RV32I in the generated Zephyr SoC and board Kconfig when the parsed ISA string indicates an embedded (rv32e) core.

Signed-off-by: sushilkumar.singh@amd.com