### PR TITLE
lopper: assists: gen_domain_dts: Retain xlnx,fclk node in Linux DT

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -532,7 +532,7 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
                     continue
             if node.propval('status') != ['']:
                 if linux_dt and ('disabled' in node.propval('status', list)[0] or "@" not in node.name):
-                    delete_pl_node_in_linux_dt = ["xlnx,afi-fpga", "xlnx,fclk"]
+                    delete_pl_node_in_linux_dt = ["xlnx,afi-fpga"]
                     if any(entry in node.propval('compatible', list) for entry in delete_pl_node_in_linux_dt):
                         sdt.tree.delete(node)
                     else:


### PR DESCRIPTION
In the static PL flow the PL description (amba_pl) is merged directly into the Linux device tree. There the fabric-clock node (compatible "xlnx,fclk", e.g. clocking0) is the only node that assigns and enables the PL reference clock. PL peripherals such as axi_gpio reference that clock via phandle but do not enable it themselves, so once "xlnx,fclk" is deleted nothing keeps the fabric clock running and Linux turns it off, causing AXI access to the PL peripheral to hang.

Drop "xlnx,fclk" from delete_pl_node_in_linux_dt so the fabric-clock node is preserved.

Example Lopper command:
LOPPER_DTC_FLAGS="-b 0 -@" ./lopper.py -O outdir -f --enhanced -i lop-a53-imux.dts system-top.dts cortexa53-linux.dts -- gen_domain_dts psu_cortexa53_0 linux_dt