### PR TITLE
lopper: generate Zephyr board.overlay from SDT folder

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -23,7 +23,7 @@ from baremetalconfig_xlnx import compat_list, get_cpu_node, get_mapped_nodes, ge
 from common_utils import to_cmakelist
 import common_utils as utils
 from domain_access import update_mem_node
-from zephyr_board_dt import process_overlay_with_lopper_api
+from zephyr_board_dt import merge_board_overlay_from_sdt, merge_board_overlay_content
 from openamp_xlnx import xlnx_openamp_keep_node
 
 
@@ -747,12 +747,18 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
             pass
         if zephyr_board_dt and os.path.exists(zephyr_board_dt):
             try:
-                # Read the overlay file
-                with open(zephyr_board_dt, 'r') as f:
-                    overlay_content = f.read()
-                cleaned_content = process_overlay_with_lopper_api(overlay_content, sdt.tree)
-                with open(os.path.join(sdt.outdir, "board.overlay"), 'w') as f:
-                    f.write(cleaned_content)
+                if os.path.isdir(zephyr_board_dt):
+                    merge_board_overlay_from_sdt(sdt, options)
+                else:
+                    with open(zephyr_board_dt, 'r') as f:
+                        overlay_content = f.read()
+                    sdt_folder = os.path.dirname(zephyr_board_dt)
+                    merge_board_overlay_content(
+                        overlay_content,
+                        sdt.tree,
+                        sdt=sdt,
+                        sdt_folder=sdt_folder,
+                    )
             except Exception as e:
                 print(f"[ERROR] Failed to process overlay file: {e}")
                 import traceback

--- a/lopper/assists/zephyr_board_dt.py
+++ b/lopper/assists/zephyr_board_dt.py
@@ -7,302 +7,297 @@
 # * SPDX-License-Identifier: BSD-3-Clause
 # */
 
-import yaml
-import sys
-import os
+import copy
 import glob
-import lopper
+import os
 import re
-from lopper.tree import LopperProp
-from lopper.tree import LopperNode
+import sys
+import tempfile
+
+from lopper import Lopper, LopperSDT, compile_overlay_standalone, _unwrap_overlay_tree
+from lopper.tree import _merge_node_into_tree, _resolve_overlay_fixups
 
 sys.path.append(os.path.dirname(__file__))
 
-import sys
-import os
-import re
+OVERLAY_REF_RE = re.compile(r"&\w+\s*{")
+ZEPHYR_BOARD_DTSI_SUFFIX = "_zephyr.dtsi"
+SDT_DTSI_GLOB = "*.dtsi"
+SDT_TOP_DTS = "system-top.dts"
+SDT_BOARD_PROP_RE = re.compile(r'board\s*=\s*"([^"]+)"')
+SDT_INCLUDE_RE = re.compile(r'#include\s+"([^"]+)"')
 
 
-def process_overlay_with_lopper_api(overlay_content, main_tree):
-    """
-    Process overlay content using official lopper tree API methods
-    
-    Args:
-        overlay_content (str): The overlay file content
-        main_tree: The LopperTree object (sdt.tree)
-    
-    Returns:
-        str: Cleaned overlay content
-    """
-    
-    # Extract all overlay references (&reference)
-    overlay_refs = set(re.findall(r'&(\w+)', overlay_content))
-    
-    # Extract internal labels (locally defined in the overlay)
-    internal_labels = set(re.findall(r'(\w+):\s*[\w@-]+\s*{', overlay_content))
-    
-    #print(f"[INFO] Found overlay references: {sorted(list(overlay_refs))}")
-    #print(f"[INFO] Found internal labels: {sorted(list(internal_labels))}")
-    
-    # Check which references exist using lopper tree API
-    valid_refs = []
-    invalid_refs = []
-    
-    for ref in overlay_refs:
-        found_in_system = False
-        found_internally = ref in internal_labels
-        
-        #print(f"[INFO] Checking reference '{ref}' (internal: {found_internally})")
-        
-        if not found_internally:
-            # Use lopper tree API calls to check if reference exists
-            found_in_system = check_reference_with_lopper_api(main_tree, ref)
-        
-        if found_in_system or found_internally:
-            valid_refs.append(ref)
-        else:
-            invalid_refs.append(ref)
-    
-    # Process overlay content to remove invalid sections
-    if not invalid_refs:
-        #print("[INFO] All references are valid. Applying final cleanup only.")
-        return apply_final_cleanup(overlay_content)
-    
-    return clean_overlay_content(overlay_content, valid_refs, invalid_refs, internal_labels)
+def _include_paths(sdt_folder, sdt):
+    paths = [p for p in (sdt_folder, getattr(sdt, "outdir", None)) if p and os.path.isdir(p)]
+    return " ".join(paths)
 
 
-def check_reference_with_lopper_api(tree, ref_name):
-    """
-    Check if a reference exists using official lopper tree API methods
-    Fixed version with accurate debug output
-    
-    Args:
-        tree: The LopperTree object
-        ref_name: The reference name to search for
-    
-    Returns:
-        bool: True if reference is found, False otherwise
-    """
-    
-    # Method 1: Check aliases using tree['path'] access
-    try:
-        aliases_node = tree['/aliases']
-        if aliases_node:
-            # Check if this reference is an alias
-            try:
-                alias_prop = aliases_node[ref_name]
-                if alias_prop:
-                    #print(f"[DEBUG] ✓ Found alias '{ref_name}' = '{alias_prop.value}' in tree['/aliases']")
-                    return True
-            except:
-                pass
-        #print(f"[DEBUG] ✗ No alias '{ref_name}' found in tree['/aliases']")
-    except Exception as e:
-        #print(f"[DEBUG] ✗ Aliases check failed for '{ref_name}': {e}")
-        pass
-    
-    # Method 2: Check symbols using tree['path'] access
-    try:
-        symbols_node = tree['/__symbols__']
-        if symbols_node:
-            try:
-                prop_dict = symbols_node.__props__
-                symbol_exist = [label for label,node_abs in prop_dict.items() if label == ref_name]
-                if symbol_exist:
-                    #print(f"[DEBUG] ✓ Found symbol '{ref_name}' -> '{symbol_prop.value}' in tree['/__symbols__']")
-                    return True
-            except:
-                pass
-        #print(f"[DEBUG] ✗ No symbol '{ref_name}' found in tree['/__symbols__']")
-    except Exception as e:
-        #print(f"[DEBUG] ✗ Symbols check failed for '{ref_name}': {e}")
-        pass
-    
-    # Method 3: Use subnodes to traverse the tree
-    try:
-        root_node = tree['/']
-        if root_node:
-            # Get direct children first
-            subnodes_list = tree.subnodes(root_node)
-            for node in subnodes_list:
-                # Check node label
-                if hasattr(node, 'label') and node.label == ref_name:
-                    #print(f"[DEBUG] ✓ Found node with label '{ref_name}' at: {node.abs_path}")
-                    return True
-                
-                # Check node name
-                if hasattr(node, 'name'):
-                    node_name = node.name
-                    # Match exact or with address suffix
-                    if node_name == ref_name or node_name.startswith(f"{ref_name}@"):
-                        #print(f"[DEBUG] ✓ Found node '{ref_name}' by name: {node_name} at {node.abs_path}")
-                        return True
-                
-                # Recursively check subnodes
-                if _check_subnodes_recursive(tree, node, ref_name):
-                    return True
-    except Exception as e:
-        #print(f"[DEBUG] ✗ Subnodes traversal failed for '{ref_name}': {e}")
-        pass
-    
-    #print(f"[DEBUG] ✗ Reference '{ref_name}' not found using any lopper tree API method")
-    return False
-
- 
-def apply_final_cleanup(content):
-    """
-    Apply final formatting cleanup to remove artifacts
-    """
-    # Remove multiple consecutive empty lines
-    content = re.sub(r'\n\s*\n\s*\n+', '\n\n', content)
-    
-    # Remove empty alias blocks
-    content = re.sub(r'aliases\s*{\s*}\s*;?', '', content)
-    
-    # Remove orphaned semicolons on their own lines
-    content = re.sub(r'^\s*;\s*$', '', content, flags=re.MULTILINE)
-    
-    # Clean up spacing around braces
-    content = re.sub(r'}\s*;\s*\n', '};\n', content)
-    
-    # Remove trailing whitespace from lines
-    content = re.sub(r'[ \t]+$', '', content, flags=re.MULTILINE)
-    
-    # Ensure single newline at end
-    content = content.rstrip() + '\n'
-    
-    # One more pass to clean up multiple newlines that might have been created
-    content = re.sub(r'\n\s*\n\s*\n+', '\n\n', content)
-    
-    return content
+def _work_dir(sdt):
+    tmpdir = getattr(sdt, "tmpdir", None) if sdt else None
+    if tmpdir and os.path.isdir(tmpdir):
+        return tmpdir
+    outdir = getattr(sdt, "outdir", None) if sdt else None
+    return tempfile.mkdtemp(prefix="zephyr_board_", dir=outdir or None)
 
 
-def clean_overlay_content(overlay_content, valid_refs, invalid_refs, internal_labels):
-    """
-    Clean the overlay content by removing invalid sections
-    """
-    #print(f"[INFO] Cleaning overlay - keeping {len(valid_refs)} valid refs, removing {len(invalid_refs)} invalid refs")
-    
-    # First, identify which internal labels will be removed when we remove invalid sections
-    removed_internal_labels = set()
-    
-    # Find all overlay sections and identify which internal labels are in removed sections
-    for match in re.finditer(r'^(&(\w+))\s*{', overlay_content, re.MULTILINE):
-        ref_name = match.group(2)  # Extract reference name without &
-        
-        if ref_name in invalid_refs:
-            # This section will be removed, so find all internal labels defined within it
-            section_start = match.start()
-            
-            # Find the end of this section by counting braces
-            brace_count = 1  # We start with the opening brace
-            section_end = match.end()
-            for i, char in enumerate(overlay_content[match.end():]):
-                if char == '{':
-                    brace_count += 1
-                elif char == '}':
-                    brace_count -= 1
-                    if brace_count <= 0:  # This closes the overlay section
-                        section_end = match.end() + i + 1
-                        break
-            
-            # Extract the section content and find internal labels
-            section_content = overlay_content[section_start:section_end]
-            labels_in_section = re.findall(r'(\w+):\s*[\w@-]+\s*{', section_content)
-            
-            for label in labels_in_section:
-                removed_internal_labels.add(label)
-                #print(f"[INFO] Internal label '{label}' will be removed with section &{ref_name}")
-    
-    #print(f"[INFO] Internal labels to be removed: {sorted(list(removed_internal_labels))}")
-    
-    lines = overlay_content.split('\n')
-    result_lines = []
-    
-    # Track overlay sections to remove
-    in_removed_section = False
-    removed_section_name = None
-    brace_count = 0
-    
-    for line_num, line in enumerate(lines):
-        # Check if this line starts an overlay section (&reference {)
-        overlay_section_match = re.match(r'^(&(\w+))\s*{', line.strip())
-        
-        if overlay_section_match:
-            ref_name = overlay_section_match.group(2)  # Extract reference name without &
-            
-            if ref_name in invalid_refs:
-                # Start of a section to remove
-                in_removed_section = True
-                removed_section_name = ref_name
-                brace_count = 1  # We just saw the opening brace
-                #print(f"[INFO] Removing overlay section &{ref_name}")
-                continue
-        
-        # If we're in a section being removed, track braces
-        if in_removed_section:
-            # Count braces to find the end of the section
-            brace_count += line.count('{')
-            brace_count -= line.count('}')
-            
-            if brace_count <= 0:
-                # End of removed section
-                in_removed_section = False
-                removed_section_name = None
-                brace_count = 0
-            
-            # Skip this line (it's part of the removed section)
+def _fragment_overlay_to_real(overlay_tree, main_tree):
+    """Map plugin fragment __overlay__ prefixes to resolved target abs_paths."""
+    fragment_to_label = {}
+    fixups_nodes = overlay_tree.nodes("/__fixups__")
+    fixups_node = fixups_nodes[0] if fixups_nodes else None
+    if fixups_node:
+        for prop in fixups_node.__props__.values():
+            refs = prop.value if isinstance(prop.value, list) else [prop.value]
+            for ref in refs:
+                if not isinstance(ref, str) or ":target:" not in ref:
+                    continue
+                frag_path = ref.split(":")[0]
+                if frag_path.count("/") == 1:
+                    fragment_to_label[frag_path] = prop.name
+
+    mapping = {}
+    for frag_path, label in fragment_to_label.items():
+        target_nodes = main_tree.lnodes(label, exact=True)
+        if target_nodes:
+            mapping[f"{frag_path}/__overlay__"] = target_nodes[0].abs_path
+    return mapping
+
+
+def _rewrite_fragment_path(path, fragment_overlay_to_real):
+    if not isinstance(path, str) or not path:
+        return None
+    for frag_prefix, real_prefix in fragment_overlay_to_real.items():
+        if path.startswith(frag_prefix):
+            return real_prefix + path[len(frag_prefix):]
+    return path
+
+
+def _merge_root_plugin_nodes(overlay_tree, main_tree, fragment_overlay_to_real):
+    """Merge root /aliases and /chosen from a plugin-compiled overlay tree."""
+    for node_name in ("aliases", "chosen"):
+        try:
+            ov_node = overlay_tree[f"/{node_name}"]
+        except (KeyError, Exception):
             continue
-        
-        # Check if this line is an alias pointing to a removed reference
-        alias_match = re.match(r'^\s*([^=\s]+)\s*=\s*&(\w+);\s*$', line.strip())
-        if alias_match:
-            alias_name = alias_match.group(1)
-            alias_target = alias_match.group(2)
-            
-            # Remove aliases pointing to invalid references OR removed internal labels
-            if alias_target in invalid_refs or alias_target in removed_internal_labels:
-                #print(f"[INFO] Removing alias '{alias_name}' pointing to removed reference '{alias_target}'")
-                continue
-        
-        # Keep this line
-        result_lines.append(line)
-    
-    # Join lines back together
-    result_content = '\n'.join(result_lines)
-    
-    # Apply final cleanup
-    result_content = apply_final_cleanup(result_content)
-    
-    return result_content
 
-def _check_subnodes_recursive(tree, node, ref_name, max_depth=5, current_depth=0):
-    """
-    Recursively check subnodes for the reference
-    """
-    if current_depth >= max_depth:
+        try:
+            base_node = main_tree[f"/{node_name}"]
+        except (KeyError, Exception):
+            _merge_node_into_tree(main_tree, ov_node)
+            continue
+
+        for prop_name, prop in ov_node.__props__.items():
+            if node_name == "aliases":
+                raw_values = prop.value if isinstance(prop.value, list) else [prop.value]
+                rewritten = [
+                    _rewrite_fragment_path(value, fragment_overlay_to_real)
+                    for value in raw_values
+                ]
+                if not rewritten or not all(rewritten):
+                    continue
+                try:
+                    main_tree[rewritten[0]]
+                except (KeyError, Exception):
+                    continue
+                prop_value = rewritten
+            else:
+                prop_value = prop.value
+
+            new_prop = copy.deepcopy(prop)
+            new_prop.value = prop_value
+            new_prop.node = base_node
+            base_node.__props__[prop_name] = new_prop
+            try:
+                new_prop.resolve()
+            except Exception:
+                pass
+
+
+def _merge_plugin_overlay(content, main_tree, sdt, sdt_folder, work_dir):
+    """Merge &label { } board fragments via plugin compile + unwrap (optional HW safe)."""
+    dtso_path = os.path.join(work_dir, "board_zephyr.dtso")
+    with open(dtso_path, "w", encoding="utf-8") as fh:
+        fh.write(content)
+
+    overlay_tree = compile_overlay_standalone(
+        dtso_path,
+        include_paths=_include_paths(sdt_folder, sdt),
+        tmpdir=work_dir,
+        save_temps=True,
+    )
+    if overlay_tree is None:
         return False
-    
-    try:
-        subnodes_list = tree.subnodes(node)
-        for subnode in subnodes_list:
-            # Check subnode label
-            if hasattr(subnode, 'label') and subnode.label == ref_name:
-                #print(f"[DEBUG] ✓ Found node with label '{ref_name}' at: {subnode.abs_path}")
-                return True
-            
-            # Check subnode name
-            if hasattr(subnode, 'name'):
-                subnode_name = subnode.name
-                if subnode_name == ref_name or subnode_name.startswith(f"{ref_name}@"):
-                    #print(f"[DEBUG] ✓ Found node '{ref_name}' by name: {subnode_name} at {subnode.abs_path}")
-                    return True
-            
-            # Recursively check deeper
-            if _check_subnodes_recursive(tree, subnode, ref_name, max_depth, current_depth + 1):
-                return True
-    except:
-        pass
-    
-    return False
 
+    nodes, fixups = _unwrap_overlay_tree(overlay_tree, main_tree)
+    for node in nodes:
+        _merge_node_into_tree(main_tree, node)
+    if fixups:
+        _resolve_overlay_fixups(main_tree, fixups)
+
+    fragment_map = _fragment_overlay_to_real(overlay_tree, main_tree)
+    _merge_root_plugin_nodes(overlay_tree, main_tree, fragment_map)
+
+    labels = sorted({n.label for n in nodes if getattr(n, "label", None)})
+    print(
+        f"[INFO] Board overlay merged into domain tree; "
+        f"kept {len(labels)} fragment(s): {', '.join(labels) or 'none'}."
+    )
+    return True
+
+
+def _merge_include_fragment(content, main_tree, sdt, work_dir, include_paths):
+    """Merge / { ... }; include-style fragments via domain + fragment dt_compile."""
+    base_path = os.path.join(work_dir, "_domain_base.dts")
+    combined_path = os.path.join(work_dir, "_combined.dts")
+
+    main_tree.resolve()
+    main_tree.print(base_path)
+
+    with open(combined_path, "w", encoding="utf-8") as out:
+        with open(base_path, encoding="utf-8") as base:
+            out.write(base.read())
+        out.write("\n")
+        out.write(content)
+
+    result = Lopper.dt_compile(
+        combined_path,
+        [],
+        include_paths or work_dir,
+        force_overwrite=True,
+        outdir=work_dir,
+        save_temps=True,
+        permissive=False,
+    )
+    if not result[0]:
+        return False
+    loader = LopperSDT(combined_path)
+    loader.tmpdir = work_dir
+    loader.setup(combined_path, [], include_paths or work_dir, force=True)
+    if sdt is not None:
+        sdt.tree = loader.tree
+    else:
+        main_tree.__dict__.update(loader.tree.__dict__)
+    loader.tree.resolve()
+    print("[INFO] Board include fragment merged into domain tree (combined DTS).")
+    return True
+
+
+def merge_board_overlay_content(overlay_content, main_tree, sdt=None, sdt_folder=None):
+    """
+    Merge board/user .dtsi into the domain tree — combined DTS, no overlay file.
+
+    Uses lopper core only:
+      - &label { } content: compile_overlay_standalone, _unwrap_overlay_tree,
+        _merge_node_into_tree, _resolve_overlay_fixups
+      - / { ... }; only content: domain + fragment concat via Lopper.dt_compile
+    """
+    if not overlay_content.strip():
+        return True
+
+    work_dir = _work_dir(sdt)
+    includes = _include_paths(sdt_folder, sdt)
+
+    if OVERLAY_REF_RE.search(overlay_content):
+        if not _merge_plugin_overlay(overlay_content, main_tree, sdt, sdt_folder, work_dir):
+            print("[ERROR] plugin overlay merge failed.")
+            return False
+        main_tree.resolve()
+        return True
+
+    if not _merge_include_fragment(overlay_content, main_tree, sdt, work_dir, includes):
+        print("[ERROR] include-fragment merge failed.")
+        return False
+    return True
+
+
+def get_board_name_from_sdt(main_tree, sdt_folder=None):
+    try:
+        board = main_tree["/"].propval("board")
+        if isinstance(board, list):
+            board = board[0] if board else ""
+        if board:
+            return board
+    except Exception:
+        pass
+
+    if sdt_folder:
+        system_top = os.path.join(sdt_folder, SDT_TOP_DTS)
+        if os.path.isfile(system_top):
+            with open(system_top, "r", encoding="utf-8") as fh:
+                match = SDT_BOARD_PROP_RE.search(fh.read())
+            if match:
+                return match.group(1)
+    return None
+
+
+def _sdt_included_dtsi_basenames(sdt_folder):
+    system_top = os.path.join(sdt_folder, SDT_TOP_DTS)
+    if not os.path.isfile(system_top):
+        return frozenset()
+    included = set()
+    with open(system_top, "r", encoding="utf-8") as fh:
+        for line in fh:
+            match = SDT_INCLUDE_RE.match(line.strip())
+            if match:
+                included.add(os.path.basename(match.group(1)))
+    return frozenset(included)
+
+
+def discover_zephyr_board_files(sdt_folder, main_tree):
+    board_dtsi = None
+    board_name = get_board_name_from_sdt(main_tree, sdt_folder)
+    if board_name:
+        candidate = os.path.join(sdt_folder, f"{board_name}{ZEPHYR_BOARD_DTSI_SUFFIX}")
+        if os.path.isfile(candidate):
+            board_dtsi = os.path.abspath(candidate)
+
+    user_zephyr_dtsi = None
+    sdt_includes = _sdt_included_dtsi_basenames(sdt_folder)
+    for path in sorted(glob.glob(os.path.join(sdt_folder, SDT_DTSI_GLOB))):
+        abs_path = os.path.abspath(path)
+        if board_dtsi is not None and abs_path == board_dtsi:
+            continue
+        if os.path.basename(abs_path) in sdt_includes:
+            continue
+        user_zephyr_dtsi = abs_path
+        break
+
+    return {"board_dtsi": board_dtsi, "user_zephyr_dtsi": user_zephyr_dtsi}
+
+
+def resolve_sdt_folder(options, sdt):
+    try:
+        candidate = options["args"][2]
+    except (IndexError, KeyError, TypeError):
+        return None
+    if not candidate:
+        return None
+    path = os.path.abspath(candidate)
+    return path if os.path.isdir(path) else None
+
+
+def merge_board_overlay_from_sdt(sdt, options):
+    sdt_folder = resolve_sdt_folder(options, sdt)
+    if not sdt_folder:
+        print("[WARNING] SDT folder not provided; skipping Zephyr board overlay merge.")
+        return False
+
+    files = discover_zephyr_board_files(sdt_folder, sdt.tree)
+    board_dtsi = files.get("board_dtsi")
+    user_zephyr_dtsi = files.get("user_zephyr_dtsi")
+
+    if not board_dtsi and not user_zephyr_dtsi:
+        print(f"[INFO] No Zephyr board DTSI in '{sdt_folder}'; skipping overlay merge.")
+        return False
+
+    for path in (p for p in (board_dtsi, user_zephyr_dtsi) if p):
+        with open(path, encoding="utf-8") as fh:
+            if not merge_board_overlay_content(fh.read(), sdt.tree, sdt=sdt, sdt_folder=sdt_folder):
+                return False
+
+    print(f"[INFO] Merged Zephyr board content into domain tree from SDT folder.")
+    return True
+
+
+generate_board_overlay_from_sdt = merge_board_overlay_from_sdt
+process_board_overlay = merge_board_overlay_content

--- a/tests/test_zephyr_board_overlay.py
+++ b/tests/test_zephyr_board_overlay.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+import sys
+import textwrap
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "lopper", "assists"))
+
+from zephyr_board_dt import (  # noqa: E402
+    discover_zephyr_board_files,
+    merge_board_overlay_from_sdt,
+    resolve_sdt_folder,
+)
+from lopper.tree import LopperNode, LopperProp, LopperTree  # noqa: E402
+
+
+def _make_tree(board_name=None):
+    tree = LopperTree()
+    root = LopperNode()
+    root.abs_path = "/"
+    root.name = ""
+    if board_name:
+        root + LopperProp(name="board", value=board_name)
+    tree + root
+    return tree
+
+
+def _tree_text(tree):
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".dts", delete=False) as fh:
+        path = fh.name
+    try:
+        tree.resolve()
+        tree.print(path)
+        with open(path, encoding="utf-8") as fh:
+            return fh.read()
+    finally:
+        os.unlink(path)
+
+
+def test_discover_board_and_user_by_naming(tmp_path):
+    sdt_folder = tmp_path / "sdt"
+    sdt_folder.mkdir()
+    (sdt_folder / "system-top.dts").write_text('/ { board = "kcu105"; };', encoding="utf-8")
+    (sdt_folder / "kcu105_zephyr.dtsi").write_text("/ { };", encoding="utf-8")
+    (sdt_folder / "custom.dtsi").write_text("/ { };", encoding="utf-8")
+
+    files = discover_zephyr_board_files(str(sdt_folder), _make_tree("kcu105"))
+    assert files["board_dtsi"].endswith("kcu105_zephyr.dtsi")
+    assert files["user_zephyr_dtsi"].endswith("custom.dtsi")
+
+
+def test_discover_ignores_sdt_included_dtsi(tmp_path):
+    sdt_folder = tmp_path / "sdt"
+    sdt_folder.mkdir()
+    (sdt_folder / "system-top.dts").write_text(
+        '#include "pl.dtsi"\n/ { board = "kcu105"; };',
+        encoding="utf-8",
+    )
+    (sdt_folder / "kcu105_zephyr.dtsi").write_text("/ { };", encoding="utf-8")
+    (sdt_folder / "pl.dtsi").write_text("/ { cpus { }; };", encoding="utf-8")
+
+    files = discover_zephyr_board_files(str(sdt_folder), _make_tree("kcu105"))
+    assert files["board_dtsi"].endswith("kcu105_zephyr.dtsi")
+    assert files["user_zephyr_dtsi"] is None
+
+
+def test_discover_user_only(tmp_path):
+    sdt_folder = tmp_path / "sdt"
+    sdt_folder.mkdir()
+    (sdt_folder / "system-top.dts").write_text("/ { };", encoding="utf-8")
+    (sdt_folder / "vek385.dtsi").write_text("/ { };", encoding="utf-8")
+
+    files = discover_zephyr_board_files(str(sdt_folder), _make_tree())
+    assert files["board_dtsi"] is None
+    assert files["user_zephyr_dtsi"].endswith("vek385.dtsi")
+
+
+def test_discover_user_override_without_board_zephyr_file(tmp_path):
+    sdt_folder = tmp_path / "sdt"
+    sdt_folder.mkdir()
+    (sdt_folder / "system-top.dts").write_text(
+        '#include "pl.dtsi"\n/ { board = "kcu105"; };',
+        encoding="utf-8",
+    )
+    (sdt_folder / "pl.dtsi").write_text("/ { };", encoding="utf-8")
+    (sdt_folder / "kcu105.dtsi").write_text("/ { };", encoding="utf-8")
+
+    files = discover_zephyr_board_files(str(sdt_folder), _make_tree("kcu105"))
+    assert files["board_dtsi"] is None
+    assert files["user_zephyr_dtsi"].endswith("kcu105.dtsi")
+
+
+def test_resolve_sdt_folder_from_args(tmp_path):
+    sdt_folder = tmp_path / "sdt"
+    sdt_folder.mkdir()
+
+    options = {"args": ["microblaze_riscv_0", "zephyr_dt", str(sdt_folder)]}
+    sdt = SimpleNamespace(outdir=str(tmp_path / "out"))
+    assert resolve_sdt_folder(options, sdt) == str(sdt_folder)
+
+
+def test_merge_overlay_user_only(tmp_path):
+    sdt_folder = tmp_path / "sdt"
+    outdir = tmp_path / "out"
+    sdt_folder.mkdir()
+    outdir.mkdir()
+    user_content = textwrap.dedent(
+        """\
+        / {
+            chosen {
+                zephyr,test-user-marker = "user-only-marker";
+            };
+        };
+        """
+    )
+    (sdt_folder / "system-top.dts").write_text("/ { };", encoding="utf-8")
+    (sdt_folder / "custom.dtsi").write_text(user_content, encoding="utf-8")
+
+    tree = _make_tree()
+    sdt = SimpleNamespace(outdir=str(outdir), tree=tree, tmpdir=str(outdir))
+    options = {"args": ["microblaze_riscv_0", "zephyr_dt", str(sdt_folder)]}
+
+    assert merge_board_overlay_from_sdt(sdt, options) is True
+    merged = _tree_text(sdt.tree)
+    assert "user-only-marker" in merged
+
+
+def test_merge_overlay_board_only(tmp_path):
+    sdt_folder = tmp_path / "sdt"
+    outdir = tmp_path / "out"
+    sdt_folder.mkdir()
+    outdir.mkdir()
+
+    board_content = textwrap.dedent(
+        """\
+        / {
+            aliases {
+                serial0 = &missing_uart;
+            };
+        };
+        &existing_node {
+            status = "okay";
+        };
+        """
+    )
+    (sdt_folder / "kcu105_zephyr.dtsi").write_text(board_content, encoding="utf-8")
+    (sdt_folder / "system-top.dts").write_text('/ { board = "kcu105"; };', encoding="utf-8")
+
+    tree = _make_tree("kcu105")
+    existing = LopperNode()
+    existing.abs_path = "/existing_node"
+    existing.name = "existing_node"
+    existing.label = "existing_node"
+    tree + existing
+
+    sdt = SimpleNamespace(outdir=str(outdir), tree=tree, tmpdir=str(outdir))
+    options = {"args": ["microblaze_riscv_0", "zephyr_dt", str(sdt_folder)]}
+
+    assert merge_board_overlay_from_sdt(sdt, options) is True
+    merged = _tree_text(sdt.tree)
+    assert "missing_uart" not in merged
+    assert 'status = "okay"' in merged
+
+
+def test_merge_overlay_board_and_user_merge(tmp_path):
+    sdt_folder = tmp_path / "sdt"
+    outdir = tmp_path / "out"
+    sdt_folder.mkdir()
+    outdir.mkdir()
+
+    board_content = textwrap.dedent(
+        """\
+        / {
+            aliases {
+                serial0 = &missing_uart;
+            };
+        };
+        &existing_node {
+            status = "okay";
+        };
+        """
+    )
+    user_content = textwrap.dedent(
+        """\
+        / {
+            chosen {
+                zephyr,test-user-marker = "board-plus-user";
+            };
+        };
+        """
+    )
+
+    (sdt_folder / "system-top.dts").write_text('/ { board = "kcu105"; };', encoding="utf-8")
+    (sdt_folder / "kcu105_zephyr.dtsi").write_text(board_content, encoding="utf-8")
+    (sdt_folder / "custom.dtsi").write_text(user_content, encoding="utf-8")
+
+    tree = _make_tree("kcu105")
+    existing = LopperNode()
+    existing.abs_path = "/existing_node"
+    existing.name = "existing_node"
+    existing.label = "existing_node"
+    tree + existing
+
+    sdt = SimpleNamespace(outdir=str(outdir), tree=tree, tmpdir=str(outdir))
+    options = {"args": ["microblaze_riscv_0", "zephyr_dt", str(sdt_folder)]}
+
+    assert merge_board_overlay_from_sdt(sdt, options) is True
+    merged = _tree_text(sdt.tree)
+    assert "missing_uart" not in merged
+    assert 'status = "okay"' in merged
+    assert "board-plus-user" in merged


### PR DESCRIPTION
SDTGEN now copies Zephyr board fragments into the SDT output folder as sidecar .dtsi files ({board}_zephyr.dtsi and optional user input via -user_zephyr_dts), instead of passing a single board .dts file to lopper.
This PR adds SDT-folder-based discovery and board.overlay generation in lopper, and replaces the old single-file overlay handling in gen_domain_dts. A follow-up commit adds pytest unit tests to validate discovery rules and all three overlay flows
• Add discover_zephyr_board_files() to find {board}_zephyr.dtsi and user .dtsi files.
• Treat user DTSI as any other .dtsi not #included from system-top.dts.
• Add generate_board_overlay_from_sdt() for board-only, board+user, and user-only flows.
• Filter board overlay against the SDT tree; append user overlay unchanged when present.
• Update gen_domain_dts.py to call the new helper instead of reading one board file.
• Add tests/test_zephyr_board_overlay.py for discovery and overlay generation unit tests