### PR TITLE
lopper: assists: zephyr: Ensure nodes are proper for versal R5 zephyr-helloworld build

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -1223,6 +1223,11 @@ def xlnx_remove_unsupported_nodes(tgt_node, sdt, machine, options=None):
                             node["#size-cells"] = LopperProp("#size-cells")
                             node["#size-cells"].value = 0
                             node.add(node["#size-cells"])
+
+                        if node.propval("xlnx,clock-freq") != ['']:
+                            node + LopperProp(name="clock-frequency",
+                                              value=node["xlnx,clock-freq"].value)
+
                     # SPIPS
                     if "cdns,spi-r1p6" in node["compatible"].value:
                         node["compatible"] = "cdns,spi"

--- a/lopper/assists/zephyr_supported_comp.yaml
+++ b/lopper/assists/zephyr_supported_comp.yaml
@@ -332,6 +332,7 @@ xlnx,versal-ospi-1.0:
     - cdns,fifo-width
     - '#address-cells'
     - '#size-cells'
+    - clock-frequency
 
 cdns,spi-r1p6:
   required:


### PR DESCRIPTION


SPI node needs right clock-frequency per inherited binding of https://docs.zephyrproject.org/latest/build/dts/api/bindings/flash_controller/cdns%2Cqspi-nor.html