### PR TITLE
lopper: gen_domain_dts: fix MBV32 NUM_IRQS calculation and export it in board_Kconfig.defconfigLopper kconfig changes

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -1878,7 +1878,7 @@ def xlnx_generate_zephyr_domain_dts(tgt_node, sdt, options):
                             if val == "axi_intc":
                                 num_intr = node.propval('xlnx,num-intr-inputs', list)[0]
                                 num_intr += 12
-                            else:
+                            elif val == "iomodule":
                                 num_intr = 32
                         is_supported_periph = [value for key,value in schema.items() if key in node["compatible"].value]
                         result = _apply_pl_peripheral_transforms(node, schema,

--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -1540,6 +1540,23 @@ def generate_board_kconfig_defconfig(isa_string, cpu_node, intc_node, num_interr
                 content += "\tdefault y\n\n"
                 added_extensions.add(config_name)
 
+    # Design-specific defaults: NUM_IRQS and PMP only.
+    if cpu_node is not None and cpu_node.propval('xlnx,pmp-entries') != ['']:
+        pmp_entries = cpu_node.propval('xlnx,pmp-entries', list)[0]
+        if pmp_entries % 8 == 0 and pmp_entries != 0:
+            content += "config RISCV_PMP\n"
+            content += "\tdefault y\n\n"
+            content += "config PMP_SLOTS\n"
+            content += f"\tdefault {pmp_entries}\n\n"
+            if cpu_node.propval('xlnx,pmp-granularity') != ['']:
+                pmp_granularity = cpu_node.propval('xlnx,pmp-granularity', list)[0]
+                content += "config PMP_GRANULARITY\n"
+                content += f"\tdefault {pow(pmp_granularity + 2, 2)}\n\n"
+
+    if num_interrupts:
+        content += "config NUM_IRQS\n"
+        content += f"\tdefault {num_interrupts}\n\n"
+
     content += "endif\n"
     return content
 


### PR DESCRIPTION
This PR fixes the amba_pl peripheral loop so num_intr = 32 applies only to IOModule IPs (elif val == "iomodule") instead of very non-axi_intc peripheral, preserving design-specific AXI INTC interrupt counts, and extends generate_board_kconfig_defconfig() to write NUM_IRQS into board_Kconfig.defconfig alongside ISA extensions so design specific interrupt configuration is available at the board level