### PR TITLE
overlays: separate conditional property activation

### DIFF
--- a/docs/conditional-properties.md
+++ b/docs/conditional-properties.md
@@ -108,6 +108,18 @@ ref-counting, memory filtering, chosen node injection, and pruning.  If
 `lopper,activate` is absent, `os,type` is used as a fallback so existing
 domain YAML files work without modification.
 
+To retain devices outside the selected domain while still activating its
+conditional properties, disable only the device-pruning phase:
+
+```bash
+lopper system-top.dts output.dts -- \
+    domain_access -t /domains/linux-domain --no-device-prune
+```
+
+This option skips refcount-based CPU, bus, and device removal. Domain memory
+processing and chosen-node handling still run. Without the option,
+`domain_access` retains its normal domain-scoped output behavior.
+
 ---
 
 ## Per-Domain Driver Binding ("OpenAMP Pattern")

--- a/lopper/assists/domain_access.py
+++ b/lopper/assists/domain_access.py
@@ -179,8 +179,10 @@ def usage():
     print( """
    Usage: domain_access [OPTION]
 
-      -p       permissive matching on target node (regex)
-      -v       enable verbose debug/processing
+      -p, --permissive       permissive matching on target node (regex)
+      -t, --target NODE      apply the specified domain
+      --no-device-prune      retain devices outside the selected domain
+      -v, --verbose          enable verbose debug/processing
 
     """)
 
@@ -223,9 +225,14 @@ def core_domain_access( tgt_node, sdt, options ):
         args = []
 
     # --permissive means that non-SMID devices/memory will be consulted
-    opts,args2 = getopt.getopt( args, "vt:p", [ "verbose", "target=", "permissive" ] )
+    opts,args2 = getopt.getopt(
+        args,
+        "vt:p",
+        ["verbose", "target=", "permissive", "no-device-prune"],
+    )
 
     permissive = False
+    device_prune = True
     command_line_target=""
     for o,a in opts:
         if o in ('-v', "--verbose"):
@@ -234,6 +241,8 @@ def core_domain_access( tgt_node, sdt, options ):
             permissive = True
         elif o in ("-t", "--target"):
             command_line_target = a
+        elif o == "--no-device-prune":
+            device_prune = False
         elif o in ('-h', "--help"):
             # usage()
             sys.exit(1)
@@ -509,7 +518,7 @@ def core_domain_access( tgt_node, sdt, options ):
 
     if cpu_prop:
         refd_cpus, unrefd_cpus = lopper_lib.cpu_refs( sdt.tree, cpu_prop, verbose )
-        if refd_cpus:
+        if refd_cpus and device_prune:
             ref_nodes = sdt.tree.refd( "/cpus.*/cpu.*" )
 
             # now we do two types of refcount delete
@@ -594,9 +603,11 @@ def core_domain_access( tgt_node, sdt, options ):
                return False
            """
 
-    _info( f"core_domain_access: filtering on:\n------{code}\n-------\n" )
-
-    sdt.tree.filter( "/", LopperAction.DELETE, code, None, verbose )
+    if device_prune:
+        _info( f"core_domain_access: filtering on:\n------{code}\n-------\n" )
+        sdt.tree.filter( "/", LopperAction.DELETE, code, None, verbose )
+    else:
+        _info("core_domain_access: device pruning disabled")
 
     # filter #2:
     #    - starting at simple-bus nodes
@@ -606,7 +617,7 @@ def core_domain_access( tgt_node, sdt, options ):
     #    - starting at reserved memory parent
     #    - drop any unreferenced elements
 
-    for n in nodes_to_filter:
+    for n in nodes_to_filter if device_prune else []:
         code = """
                p = node.ref
                if p <= 0:

--- a/tests/test_overlay_e2e.py
+++ b/tests/test_overlay_e2e.py
@@ -789,6 +789,27 @@ class TestTwoPassSubprocess:
         assert "cdns,ttc" not in content, \
             f"cdns,ttc still present in APU_Linux.dts — replace overlay not applied\n{content[:2000]}"
 
+    def test_no_device_prune_activates_overlay_and_keeps_other_domains(self, tmp_path):
+        """--no-device-prune resolves sigils without cropping the device tree."""
+        result, intermediate = self._setup_pass1(tmp_path)
+        assert result.returncode == 0, f"Pass 1 failed: {result.stderr}"
+
+        output = tmp_path / "APU_Linux-complete.dts"
+        result2 = self._run([
+            "./lopper.py", "-f", "--permissive",
+            str(intermediate), str(output),
+            "--", "domain_access", "-t", "/domains/APU_Linux",
+            "--no-device-prune",
+        ])
+        assert result2.returncode == 0, \
+            f"Pass 2 failed:\nstdout: {result2.stdout}\nstderr: {result2.stderr}"
+
+        content = output.read_text()
+        assert 'compatible = "uio"' in content
+        assert "APU_Linux" in content
+        assert "RPU1_BM" in content
+        assert "__lopper-overlays__" not in content
+
     def test_pass2_output_has_no_lopper_overlays(self, tmp_path):
         """Final APU_Linux.dts must not contain /__lopper-overlays__."""
         result, intermediate = self._setup_pass1(tmp_path)


### PR DESCRIPTION
Add a standalone conditional_properties assist that selects a merged overlay tree without applying domain access filtering or pruning. Support explicit condition selection and activation through a target node's lopper,activate property.

Share the activation helper with domain_access to preserve its existing behavior, document both workflows, and cover standalone activation across the embedded-overlay two-pass flow.