### PR TITLE
lopper:assist: Generate xparameters and CMake variables from the misc…

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -576,6 +576,9 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
         val = sdt.tree[tgt_node].propval('semnpi-scan', list)[0]
         plat.buf(f'\n#define XSEM_NPISCAN_EN {val}\n')
 
+    #Define for new properties added under misc_props in pcw.dtsi
+    utils.gen_misc_props_macros(plat, sdt)
+
     if is_fpd_coherent:
         plat.buf("\n#define XPAR_FPD_IS_CACHE_COHERENT \n")
     if is_lpd_coherent:

--- a/lopper/assists/bmcmake_metadata_xlnx.py
+++ b/lopper/assists/bmcmake_metadata_xlnx.py
@@ -319,6 +319,8 @@ def generate_hwtocmake_medata(sdt, node_list, src_path, repo_path_data, options,
             if sdt.tree['/'].propval('speed_grade') != ['']:
                 val = sdt.tree['/'].propval('speed_grade', list)[0]
                 fd.write(f'set(SPEED_GRADE "{val}" CACHE STRING "Speed Grade")\n')
+            #Generate cmake variable for the properties added under misc_props in pcw.dtsi
+            utils.gen_misc_props_cmake_vars(fd, sdt)
             if sdt.tree['/'].propval('board') != ['']:
                 val = sdt.tree['/'].propval('board', list)[0]
                 fd.write(f'set(BOARD "{val}" CACHE STRING "BOARD")\n')

--- a/lopper/assists/common_utils.py
+++ b/lopper/assists/common_utils.py
@@ -222,3 +222,67 @@ def run_exec(yaml_condition, proc_ip_name, family, variant=None, return_list="ex
         _warning(f"The condition in the {yaml_file} file has failed. -> {e}")
     finally:
         return local_scope[return_list]
+
+def _misc_prop_var_name(prop_name):
+    """Map a DT property name to a valid C/CMake identifier."""
+    name = prop_name.replace('xlnx,', '').replace('amd,', '')
+    name = re.sub(r'[^A-Za-z0-9_]', '_', name)
+    if name and name[0].isdigit():
+        name = f'_{name}'
+    return name.upper()
+
+def _iter_misc_props(sdt):
+    """Yield (prop_name, var_name, value) tuples from the misc_props node."""
+    for node in sdt.tree['/'].subnodes():
+        if node.name != "misc_props":
+            continue
+        for prop_name in node.__props__:
+            prop_val = node.propval(prop_name, list)
+            var_name = _misc_prop_var_name(prop_name)
+            if prop_val == [''] or prop_val == []:
+                yield prop_name, var_name, None
+            elif len(prop_val) == 1:
+                yield prop_name, var_name, prop_val[0]
+            else:
+                yield prop_name, var_name, prop_val
+        return
+
+def gen_misc_props_macros(plat, sdt):
+    """Generate xparameters macros for properties under misc_props."""
+    for prop_name, var_name, val in _iter_misc_props(sdt):
+        plat.buf(f"\n/* {prop_name} */\n")
+        if val is None:
+            plat.buf(f"#define {var_name}\n")
+        elif isinstance(val, int):
+            plat.buf(f"#define {var_name} {hex(val)}\n")
+        elif isinstance(val, str):
+            bool_val = str(val).lower()
+            if bool_val in ("true", "false"):
+                plat.buf(f"#define {var_name} {bool_val}\n")
+            else:
+                plat.buf(f"#define {var_name} {val}\n")
+        elif isinstance(val, list):
+            formatted = ' '.join(hex(v) if isinstance(v, int) else str(v) for v in val)
+            plat.buf(f"#define {var_name} {formatted}\n")
+        else:
+            plat.buf(f"#define {var_name} {val}\n")
+
+def gen_misc_props_cmake_vars(fd, sdt):
+    """Generate CMake variables for properties under misc_props."""
+    for prop_name, var_name, val in _iter_misc_props(sdt):
+        if val is None:
+            fd.write(f'set({var_name} "ON" CACHE STRING "{prop_name}")\n')
+        elif isinstance(val, int):
+            fd.write(f'set({var_name} {hex(val)} CACHE STRING "{prop_name}")\n')
+        elif isinstance(val, str):
+            bool_val = str(val).lower()
+            if bool_val in ("true", "false"):
+                cmake_val = "ON" if bool_val == "true" else "OFF"
+                fd.write(f'set({var_name} "{cmake_val}" CACHE STRING "{prop_name}")\n')
+            else:
+                fd.write(f'set({var_name} "{val}" CACHE STRING "{prop_name}")\n')
+        elif isinstance(val, list):
+            items = [hex(v) if isinstance(v, int) else str(v) for v in val]
+            fd.write(f'set({var_name} {to_cmakelist(items)} CACHE STRING "{prop_name}")\n')
+        else:
+            fd.write(f'set({var_name} "{val}" CACHE STRING "{prop_name}")\n')

--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -632,6 +632,9 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
 
     mapped_children_nodes = []
     for node in root_sub_nodes:
+        if (linux_dt or zephyr_dt) and node.name == "misc_props":
+            sdt.tree.delete(node)
+            continue
         if linux_dt:
             if node.propval('xlnx,ip-name') != ['']:
                 val = node.propval('xlnx,ip-name', list)[0]


### PR DESCRIPTION
…_props node

Update Lopper to consume the misc_props node generated by SDT in pcw.dtsi and automatically propagate its properties into bare-metal xparameters.h macros and CMake metadata. This enables new user-defined properties added under misc_props to flow through to the BSP without requiring additional Lopper assist changes.