### PR TITLE
Zephyr openamp legacy mpu

### DIFF
--- a/demos/openamp/inputs/openamp-overlay-versal-2ve-2vm.yaml
+++ b/demos/openamp/inputs/openamp-overlay-versal-2ve-2vm.yaml
@@ -21,7 +21,7 @@ reserved-memory:
     start: 0x985F000
     size: 0x1000
     no-map: 1
-    mpu-policy!zephyr!append: [ readable, writable, shareable, userspace ]
+    mpu-policy!zephyr!append: [ readable, writable ]
   rpu0vdev0vring0@9860000:
     start: 0x9860000
     size: 0x4000
@@ -38,7 +38,7 @@ reserved-memory:
     start: 0x9800000
     size: 0x100
     no-map: 1
-    mpu-policy!zephyr!append: [ readable, writable, shareable, userspace ]
+    mpu-policy!zephyr!append: [ readable, writable ]
   ipc@9860000:
     start: 0x9860000
     size: 0x48000

--- a/demos/openamp/inputs/openamp-zephyr-versal-r5.yaml
+++ b/demos/openamp/inputs/openamp-zephyr-versal-r5.yaml
@@ -4,31 +4,34 @@ axi:
   CIPS_0_pspmc_0_psv_r5_0_atcm:
     start: 0x0
     size: 0x10000
-    mpu-policy: [ readable, writable, executable, cacheable ]
+    mpu-policy: [ readable, writable, executable, cacheable, static ]
   CIPS_0_pspmc_0_psv_r5_0_btcm:
     start: 0x20000
     size: 0x10000
-    mpu-policy: [ readable, writable, cacheable ]
+    mpu-policy: [ readable, writable, cacheable, static ]
 
 reserved-memory:
   ranges: true
   "#size-cells": 2
   "#address-cells": 2
-  vdev0vring0@9860000: { label: vdev0vring0, start: 0x9860000, size: 0x4000, no-map: 1 }
-  vdev0vring1@9864000: { label: vdev0vring1, start: 0x9864000, size: 0x4000, no-map: 1 }
-  vdev0buffer@9868000: { label: vdev0buffer, start: 0x9868000, size: 0x100000, no-map: 1 }
+  vdev0vring0@9880000:
+    { label: vdev0vring0, start: 0x9880000, size: 0x4000, no-map: 1 }
+  vdev0vring1@9884000:
+    { label: vdev0vring1, start: 0x9884000, size: 0x4000, no-map: 1 }
+  vdev0buffer@9888000:
+    { label: vdev0buffer, start: 0x9888000, size: 0x78000, no-map: 1 }
   trace@985f000:
     label: trace_buffer
     start: 0x0985f000
     size: 0x1000
     no-map: 1
-    mpu-policy: [ readable, writable, shareable, userspace ]
+    mpu-policy: [ readable, writable ]
   rproc0@9800000:
     label: rproc0
     start: 0x09800000
     size: 0x5f000
     no-map: 1
-    mpu-policy: [ readable, writable, executable, cacheable ]
+    mpu-policy: [ readable, writable, executable, cacheable, static ]
 
 chosen:
   zephyr,ram-console: /reserved-memory/trace@985f000
@@ -41,8 +44,8 @@ domains:
       - cluster: cpus_a72
         cpumask: 0xf
         mode: { secure: true, el: 0x3 }
-    reserved-memory: [ vdev0buffer@9868000, vdev0vring1@9864000,
-                       vdev0vring0@9860000, rproc0@9800000,
+    reserved-memory: [ vdev0buffer@9888000, vdev0vring1@9884000,
+                       vdev0vring0@9880000, rproc0@9800000,
                        trace@985f000 ]
     domain-to-domain:
       compatible: openamp,domain-to-domain-v1
@@ -57,18 +60,19 @@ domains:
         compatible: openamp,rpmsg-v1
         relation0:
           remote: R5_0_ZEPHYR
-          carveouts: [ vdev0vring0@9860000, vdev0vring1@9864000,
-                       vdev0buffer@9868000 ]
+          carveouts: [ vdev0vring0@9880000, vdev0vring1@9884000,
+                       vdev0buffer@9888000 ]
           mbox: ipi_3_to_ipi_1
           timer: [ ttc0, ttc1 ]
   R5_0_ZEPHYR:
     os,type: zephyr
+    zephyr-version: "4.3"
     cpus:
       - cluster: cpus_r5_0
         cpumask: 0x1
         mode: { secure: true, el: 0x3 }
-    reserved-memory: [ vdev0buffer@9868000, vdev0vring1@9864000,
-                       vdev0vring0@9860000, rproc0@9800000,
+    reserved-memory: [ vdev0buffer@9888000, vdev0vring1@9884000,
+                       vdev0vring0@9880000, rproc0@9800000,
                        trace@985f000 ]
     sram:
       - { dev: rproc0@9800000, start: 0x9800000, size: 0x5f000 }
@@ -81,8 +85,8 @@ domains:
         relation0:
           host: APU_Linux
           mbox: ipi_1_to_ipi_3
-          carveouts: [ vdev0vring0@9860000, vdev0vring1@9864000,
-                       vdev0buffer@9868000 ]
+          carveouts: [ vdev0vring0@9880000, vdev0vring1@9884000,
+                       vdev0buffer@9888000 ]
           timer: ttc0
     linker:
       linker_file_output_name: versal-r5-openamp.ld

--- a/demos/openamp/inputs/openamp-zephyr-versal-r5.yaml
+++ b/demos/openamp/inputs/openamp-zephyr-versal-r5.yaml
@@ -8,7 +8,7 @@ axi:
   CIPS_0_pspmc_0_psv_r5_0_btcm:
     start: 0x20000
     size: 0x10000
-    mpu-policy: [ readable, writable, cacheable, static ]
+    mpu-policy: [ readable, writable, cacheable ]
 
 reserved-memory:
   ranges: true

--- a/demos/openamp/inputs/openamp-zephyr-versal-r5.yaml
+++ b/demos/openamp/inputs/openamp-zephyr-versal-r5.yaml
@@ -29,9 +29,15 @@ reserved-memory:
   rproc0@9800000:
     label: rproc0
     start: 0x09800000
-    size: 0x5f000
+    size: 0x20000
     no-map: 1
     mpu-policy: [ readable, writable, executable, cacheable, static ]
+  rsctbl@9820000:
+    label: rsctbl
+    start: 0x09820000
+    size: 0x100
+    no-map: 1
+    mpu-policy: [ readable, writable ]
 
 chosen:
   zephyr,ram-console: /reserved-memory/trace@985f000
@@ -46,7 +52,7 @@ domains:
         mode: { secure: true, el: 0x3 }
     reserved-memory: [ vdev0buffer@9888000, vdev0vring1@9884000,
                        vdev0vring0@9880000, rproc0@9800000,
-                       trace@985f000 ]
+                       trace@985f000, rsctbl@9820000 ]
     domain-to-domain:
       compatible: openamp,domain-to-domain-v1
       remoteproc-relation:
@@ -55,7 +61,7 @@ domains:
           remote: R5_0_ZEPHYR
           elfload: [ psv_r5_0_atcm_global@ffe00000,
                      psv_r5_0_btcm_global@ffe20000, rproc0@9800000,
-                     trace@985f000 ]
+                     trace@985f000, rsctbl@9820000 ]
       rpmsg-relation:
         compatible: openamp,rpmsg-v1
         relation0:
@@ -73,9 +79,9 @@ domains:
         mode: { secure: true, el: 0x3 }
     reserved-memory: [ vdev0buffer@9888000, vdev0vring1@9884000,
                        vdev0vring0@9880000, rproc0@9800000,
-                       trace@985f000 ]
+                       trace@985f000, rsctbl@9820000 ]
     sram:
-      - { dev: rproc0@9800000, start: 0x9800000, size: 0x5f000 }
+      - { dev: rproc0@9800000, start: 0x9800000, size: 0x20000 }
       - { dev: CIPS_0_pspmc_0_psv_r5_0_atcm@0, start: 0x0, size: 64K }
       - { dev: CIPS_0_pspmc_0_psv_r5_0_btcm@20000, start: 0x20000, size: 64K }
     domain-to-domain:
@@ -91,7 +97,7 @@ domains:
     linker:
       linker_file_output_name: versal-r5-openamp.ld
       linker_memories: [ CIPS_0_pspmc_0_psv_r5_0_atcm,
-                         CIPS_0_pspmc_0_psv_r5_0_btcm, rproc0 ]
+                         CIPS_0_pspmc_0_psv_r5_0_btcm, rproc0, rsctbl ]
       entry: _vector_table
       sections:
         vector_table: { region: CIPS_0_pspmc_0_psv_r5_0_atcm, offset: 0 }
@@ -102,7 +108,7 @@ domains:
         noinit: { region: CIPS_0_pspmc_0_psv_r5_0_btcm }
         heap: { region: CIPS_0_pspmc_0_psv_r5_0_btcm }
         stack: { region: CIPS_0_pspmc_0_psv_r5_0_btcm }
-        resource_table: { region: rproc0, offset: 0x20000 }
+        resource_table: { region: rsctbl, offset: 0 }
   R5_1_BAREMETAL:
     compatible: openamp,domain-v1
     os,type: baremetal

--- a/demos/openamp/inputs/openamp-zephyr-zynqmp-r5.yaml
+++ b/demos/openamp/inputs/openamp-zephyr-zynqmp-r5.yaml
@@ -4,31 +4,34 @@ axi:
   psu_r5_0_atcm:
     start: 0x0
     size: 0x10000
-    mpu-policy: [ readable, writable, executable, cacheable ]
+    mpu-policy!zephyr!append: [ readable, writable, executable, cacheable, static ]
   psu_r5_0_btcm:
     start: 0x20000
     size: 0x10000
-    mpu-policy: [ readable, writable, cacheable ]
+    mpu-policy!zephyr!append: [ readable, writable, cacheable, static ]
 
 reserved-memory:
   ranges: true
   "#size-cells": 2
   "#address-cells": 2
-  vdev0vring0@9860000: { label: vdev0vring0, start: 0x9860000, size: 0x4000, no-map: 1 }
-  vdev0vring1@9864000: { label: vdev0vring1, start: 0x9864000, size: 0x4000, no-map: 1 }
-  vdev0buffer@9868000: { label: vdev0buffer, start: 0x9868000, size: 0x100000, no-map: 1 }
+  vdev0vring0@9880000:
+    { label: vdev0vring0, start: 0x9880000, size: 0x4000, no-map: 1 }
+  vdev0vring1@9884000:
+    { label: vdev0vring1, start: 0x9884000, size: 0x4000, no-map: 1 }
+  vdev0buffer@9888000:
+    { label: vdev0buffer, start: 0x9888000, size: 0x78000, no-map: 1 }
   trace@985f000:
     label: trace_buffer
     start: 0x0985f000
     size: 0x1000
     no-map: 1
-    mpu-policy: [ readable, writable, shareable, userspace ]
+    mpu-policy!zephyr!append: [ readable, writable ]
   rproc0@9800000:
     label: rproc0
     start: 0x09800000
     size: 0x5f000
     no-map: 1
-    mpu-policy: [ readable, writable, executable, cacheable ]
+    mpu-policy!zephyr!append: [ readable, writable, executable, cacheable, static ]
 
 chosen:
   zephyr,ram-console: /reserved-memory/trace@985f000
@@ -41,8 +44,8 @@ domains:
       - cluster: cpus_a53
         cpumask: 0xf
         mode: { secure: true, el: 0x3 }
-    reserved-memory: [ vdev0buffer@9868000, vdev0vring1@9864000,
-                       vdev0vring0@9860000, rproc0@9800000,
+    reserved-memory: [ vdev0buffer@9888000, vdev0vring1@9884000,
+                       vdev0vring0@9880000, rproc0@9800000,
                        trace@985f000 ]
     domain-to-domain:
       compatible: openamp,domain-to-domain-v1
@@ -57,19 +60,23 @@ domains:
         compatible: openamp,rpmsg-v1
         relation0:
           remote: R5_0_ZEPHYR
-          carveouts: [ vdev0vring0@9860000, vdev0vring1@9864000,
-                       vdev0buffer@9868000 ]
+          carveouts: [ vdev0vring0@9880000, vdev0vring1@9884000,
+                       vdev0buffer@9888000 ]
           mbox: ipi_7_to_ipi_1
           timer: [ ttc0, ttc1 ]
   R5_0_ZEPHYR:
+    lopper,activate: zephyr
     os,type: zephyr
+    zephyr-version: "4.3"
     cpus:
       - cluster: cpus_r5_0
         cpumask: 0x1
         mode: { secure: true, el: 0x3 }
-    reserved-memory: [ vdev0buffer@9868000, vdev0vring1@9864000,
-                       vdev0vring0@9860000, rproc0@9800000,
+    reserved-memory: [ vdev0buffer@9888000, vdev0vring1@9884000,
+                       vdev0vring0@9880000, rproc0@9800000,
                        trace@985f000 ]
+    access:
+      - dev: "*"
     sram:
       - { dev: rproc0@9800000, start: 0x9800000, size: 0x5f000 }
       - { dev: psu_r5_0_atcm@0, start: 0x0, size: 64K }
@@ -81,8 +88,8 @@ domains:
         relation0:
           host: APU_Linux
           mbox: ipi_1_to_ipi_7
-          carveouts: [ vdev0vring0@9860000, vdev0vring1@9864000,
-                       vdev0buffer@9868000 ]
+          carveouts: [ vdev0vring0@9880000, vdev0vring1@9884000,
+                       vdev0buffer@9888000 ]
           timer: ttc0
     linker:
       linker_file_output_name: zynqmp-r5-openamp.ld

--- a/demos/openamp/inputs/openamp-zephyr-zynqmp-r5.yaml
+++ b/demos/openamp/inputs/openamp-zephyr-zynqmp-r5.yaml
@@ -29,9 +29,15 @@ reserved-memory:
   rproc0@9800000:
     label: rproc0
     start: 0x09800000
-    size: 0x5f000
+    size: 0x20000
     no-map: 1
     mpu-policy!zephyr!append: [ readable, writable, executable, cacheable, static ]
+  rsctbl@9820000:
+    label: rsctbl
+    start: 0x09820000
+    size: 0x100
+    no-map: 1
+    mpu-policy!zephyr!append: [ readable, writable ]
 
 chosen:
   zephyr,ram-console: /reserved-memory/trace@985f000
@@ -46,7 +52,7 @@ domains:
         mode: { secure: true, el: 0x3 }
     reserved-memory: [ vdev0buffer@9888000, vdev0vring1@9884000,
                        vdev0vring0@9880000, rproc0@9800000,
-                       trace@985f000 ]
+                       trace@985f000, rsctbl@9820000 ]
     domain-to-domain:
       compatible: openamp,domain-to-domain-v1
       remoteproc-relation:
@@ -55,7 +61,7 @@ domains:
           remote: R5_0_ZEPHYR
           elfload: [ psu_r5_0_atcm_global@ffe00000,
                      psu_r5_0_btcm_global@ffe20000, rproc0@9800000,
-                     trace@985f000 ]
+                     trace@985f000, rsctbl@9820000 ]
       rpmsg-relation:
         compatible: openamp,rpmsg-v1
         relation0:
@@ -74,11 +80,11 @@ domains:
         mode: { secure: true, el: 0x3 }
     reserved-memory: [ vdev0buffer@9888000, vdev0vring1@9884000,
                        vdev0vring0@9880000, rproc0@9800000,
-                       trace@985f000 ]
+                       trace@985f000, rsctbl@9820000 ]
     access:
       - dev: "*"
     sram:
-      - { dev: rproc0@9800000, start: 0x9800000, size: 0x5f000 }
+      - { dev: rproc0@9800000, start: 0x9800000, size: 0x20000 }
       - { dev: psu_r5_0_atcm@0, start: 0x0, size: 64K }
       - { dev: psu_r5_0_btcm@20000, start: 0x20000, size: 64K }
     domain-to-domain:
@@ -93,7 +99,7 @@ domains:
           timer: ttc0
     linker:
       linker_file_output_name: zynqmp-r5-openamp.ld
-      linker_memories: [ psu_r5_0_atcm, psu_r5_0_btcm, rproc0 ]
+      linker_memories: [ psu_r5_0_atcm, psu_r5_0_btcm, rproc0, rsctbl ]
       entry: _vector_table
       sections:
         vector_table: { region: psu_r5_0_atcm, offset: 0 }
@@ -104,7 +110,7 @@ domains:
         noinit: { region: psu_r5_0_btcm }
         heap: { region: psu_r5_0_btcm }
         stack: { region: psu_r5_0_btcm }
-        resource_table: { region: rproc0, offset: 0x20000 }
+        resource_table: { region: rsctbl, offset: 0 }
   R5_1_BAREMETAL:
     compatible: openamp,domain-v1
     os,type: baremetal

--- a/demos/openamp/inputs/openamp-zephyr-zynqmp-r5.yaml
+++ b/demos/openamp/inputs/openamp-zephyr-zynqmp-r5.yaml
@@ -8,7 +8,7 @@ axi:
   psu_r5_0_btcm:
     start: 0x20000
     size: 0x10000
-    mpu-policy!zephyr!append: [ readable, writable, cacheable, static ]
+    mpu-policy!zephyr!append: [ readable, writable, cacheable ]
 
 reserved-memory:
   ranges: true

--- a/lopper/assists/zephyr_memory.py
+++ b/lopper/assists/zephyr_memory.py
@@ -514,8 +514,7 @@ def _memory_policy(node, kind):
     """
     values = node.propval("mpu-policy", list)
     if (not values or values == [""]) and kind == "IPC_SHM":
-        return (MemoryPolicy.READABLE | MemoryPolicy.WRITABLE |
-                MemoryPolicy.SHAREABLE | MemoryPolicy.USERSPACE)
+        return MemoryPolicy.READABLE | MemoryPolicy.WRITABLE
     if not values or values == [""]:
         raise LayoutError(
             f"{node.abs_path}: missing required 'mpu-policy' property")
@@ -539,6 +538,7 @@ def _memory_policy(node, kind):
         if property_name in values:
             policy |= policy_bit
     supported = {
+        MemoryPolicy.READABLE | MemoryPolicy.WRITABLE,
         MemoryPolicy.READABLE | MemoryPolicy.WRITABLE | MemoryPolicy.CACHEABLE,
         MemoryPolicy.READABLE | MemoryPolicy.CACHEABLE,
         MemoryPolicy.READABLE | MemoryPolicy.EXECUTABLE | MemoryPolicy.CACHEABLE,

--- a/lopper/assists/zephyr_mpu.py
+++ b/lopper/assists/zephyr_mpu.py
@@ -16,7 +16,15 @@ from zephyr_memory import (
 )
 
 
+DT_MEM_ARM_MPU_RAM = (1 << 0) << 20
 DT_MEM_ARM_MPU_RAM_NOCACHE = (1 << 1) << 20
+DT_MEM_CACHEABLE = 1 << 0
+DT_MEM_READABLE = 1 << 4
+DT_MEM_WRITABLE = 1 << 5
+DT_MEM_EXECUTABLE = 1 << 6
+DT_MEM_SHAREABLE = 1 << 7
+DT_MEM_NON_CACHEABLE = 1 << 8
+DT_MEM_USERSPACE = 1 << 9
 
 
 def is_compat(node, compat_string_to_test):
@@ -41,11 +49,13 @@ def is_compat(node, compat_string_to_test):
 
 
 def _memory_attributes(memory):
-    """Encode shared-memory policy using Zephyr's legacy ARM attribute.
+    """Encode dynamic memory policy using a legacy ARM RAM attribute.
 
     Description:
-        Uses the existing R-profile non-cacheable RAM type. Static linker-owned
-        memories do not call this helper.
+        Uses the existing cacheable or non-cacheable R-profile RAM types for
+        privileged data memory and retains generic attributes for other
+        supported policies. Static linker-owned memories do not call this
+        helper.
 
     Args:
         memory (Memory): Normalized memory policy.
@@ -54,17 +64,28 @@ def _memory_attributes(memory):
         int: Value for the conventional zephyr,memory-attr property.
 
     Raises:
-        LayoutError: If a dynamic memory policy cannot be represented by the
-            legacy privileged, non-cacheable, execute-never ARM RAM type.
+        None.
     """
-    required = MemoryPolicy.READABLE | MemoryPolicy.WRITABLE
-    unsupported = (MemoryPolicy.EXECUTABLE | MemoryPolicy.CACHEABLE |
-                   MemoryPolicy.SHAREABLE | MemoryPolicy.USERSPACE)
-    if not memory.has_policy(required) or memory.policy & unsupported:
-        raise LayoutError(
-            f"{memory.node.abs_path}: non-static R-profile memory must be "
-            "privileged read/write, non-cacheable, and execute-never")
-    return DT_MEM_ARM_MPU_RAM_NOCACHE
+    data_policy = MemoryPolicy.READABLE | MemoryPolicy.WRITABLE
+    if memory.policy == data_policy | MemoryPolicy.CACHEABLE:
+        return DT_MEM_ARM_MPU_RAM
+    if memory.policy == data_policy:
+        return DT_MEM_ARM_MPU_RAM_NOCACHE
+
+    value = 0
+    translations = ((MemoryPolicy.READABLE, DT_MEM_READABLE),
+                    (MemoryPolicy.WRITABLE, DT_MEM_WRITABLE),
+                    (MemoryPolicy.EXECUTABLE, DT_MEM_EXECUTABLE),
+                    (MemoryPolicy.SHAREABLE, DT_MEM_SHAREABLE),
+                    (MemoryPolicy.USERSPACE, DT_MEM_USERSPACE))
+    for policy, attribute in translations:
+        if memory.has_policy(policy):
+            value |= attribute
+    if memory.has_policy(MemoryPolicy.CACHEABLE):
+        value |= DT_MEM_CACHEABLE
+    else:
+        value |= DT_MEM_NON_CACHEABLE
+    return value
 
 
 def _apply_memory(memory, emit_mpu=True):

--- a/lopper/assists/zephyr_mpu.py
+++ b/lopper/assists/zephyr_mpu.py
@@ -16,13 +16,7 @@ from zephyr_memory import (
 )
 
 
-DT_MEM_CACHEABLE = 1 << 0
-DT_MEM_READABLE = 1 << 4
-DT_MEM_WRITABLE = 1 << 5
-DT_MEM_EXECUTABLE = 1 << 6
-DT_MEM_SHAREABLE = 1 << 7
-DT_MEM_NON_CACHEABLE = 1 << 8
-DT_MEM_USERSPACE = 1 << 9
+DT_MEM_ARM_MPU_RAM_NOCACHE = (1 << 1) << 20
 
 
 def is_compat(node, compat_string_to_test):
@@ -47,11 +41,11 @@ def is_compat(node, compat_string_to_test):
 
 
 def _memory_attributes(memory):
-    """Encode normalized policy as zephyr,memory-attr flags.
+    """Encode shared-memory policy using Zephyr's legacy ARM attribute.
 
     Description:
-        Converts the architecture-independent execution-domain memory policy to
-        the generic Zephyr memory attribute bit field.
+        Uses the existing R-profile non-cacheable RAM type. Static linker-owned
+        memories do not call this helper.
 
     Args:
         memory (Memory): Normalized memory policy.
@@ -60,22 +54,17 @@ def _memory_attributes(memory):
         int: Value for the conventional zephyr,memory-attr property.
 
     Raises:
-        None.
+        LayoutError: If a dynamic memory policy cannot be represented by the
+            legacy privileged, non-cacheable, execute-never ARM RAM type.
     """
-    value = 0
-    translations = ((MemoryPolicy.READABLE, DT_MEM_READABLE),
-                    (MemoryPolicy.WRITABLE, DT_MEM_WRITABLE),
-                    (MemoryPolicy.EXECUTABLE, DT_MEM_EXECUTABLE),
-                    (MemoryPolicy.SHAREABLE, DT_MEM_SHAREABLE),
-                    (MemoryPolicy.USERSPACE, DT_MEM_USERSPACE))
-    for policy, attribute in translations:
-        if memory.has_policy(policy):
-            value |= attribute
-    if not memory.has_policy(MemoryPolicy.CACHEABLE):
-        value |= DT_MEM_NON_CACHEABLE
-    else:
-        value |= DT_MEM_CACHEABLE
-    return value
+    required = MemoryPolicy.READABLE | MemoryPolicy.WRITABLE
+    unsupported = (MemoryPolicy.EXECUTABLE | MemoryPolicy.CACHEABLE |
+                   MemoryPolicy.SHAREABLE | MemoryPolicy.USERSPACE)
+    if not memory.has_policy(required) or memory.policy & unsupported:
+        raise LayoutError(
+            f"{memory.node.abs_path}: non-static R-profile memory must be "
+            "privileged read/write, non-cacheable, and execute-never")
+    return DT_MEM_ARM_MPU_RAM_NOCACHE
 
 
 def _apply_memory(memory, emit_mpu=True):
@@ -123,11 +112,11 @@ def _uses_static_mpu(memory):
                         memory.node.propval("mpu-policy", list)]
 
 
-def _r5_ddr_aperture(memory, local_memories):
-    """Calculate a representable ARMv7-R DDR MPU aperture.
+def _r5_mpu_aperture(memory, local_memories):
+    """Calculate a representable ARMv7-R MPU aperture.
 
     Description:
-        Expands the policy DDR range to the smallest naturally aligned
+        Expands the policy range to the smallest naturally aligned
         power-of-two window that contains it. Rejects an expansion that would
         cover a configured local TCM range.
 
@@ -155,13 +144,13 @@ def _r5_ddr_aperture(memory, local_memories):
         origin = memory.origin & ~(length - 1)
     if origin + length > 1 << 32:
         raise LayoutError(
-            f"DDR memory '{memory.name}' cannot be represented in the "
+            f"memory '{memory.name}' cannot be represented in the "
             "32-bit R5 MPU address space")
     for local in local_memories:
         local_end = local.origin + local.length
         if origin < local_end and local.origin < origin + length:
             raise LayoutError(
-                f"R5 DDR MPU aperture 0x{origin:x}-"
+                f"R5 MPU aperture 0x{origin:x}-"
                 f"0x{origin + length:x} overlaps {local.name} at "
                 f"0x{local.origin:x}-0x{local_end:x}")
     return origin, length
@@ -197,17 +186,18 @@ def _set_memory_range(memory, origin, length):
     memory.node["reg"] = reg
 
 
-def _prepare_r5_ddr(processor, memories):
-    """Make R5 DDR policy ranges representable by the ARMv7-R MPU.
+def _prepare_r5_mpu_ranges(processor, memories, dynamic_memories):
+    """Make R5 DT policy ranges representable by the ARMv7-R MPU.
 
     Description:
-        Rounds each DDR policy node before conventional Zephyr MPU metadata is
-        emitted. R52 ranges are unchanged because ARMv8-R uses base/limit
-        regions instead of power-of-two regions.
+        Rounds each dynamic DDR or consolidated IPC policy node before
+        conventional Zephyr MPU metadata is emitted. R52 ranges are unchanged
+        because ARMv8-R uses base/limit regions.
 
     Args:
         processor (str): Canonical processor class.
-        memories (tuple[Memory]): Normalized domain-owned memories.
+        memories (tuple[Memory]): All normalized domain-owned memories.
+        dynamic_memories (tuple[Memory]): Memories requiring DT MPU regions.
 
     Returns:
         None.
@@ -220,10 +210,15 @@ def _prepare_r5_ddr(processor, memories):
         return
     local = tuple(memory for memory in memories
                   if memory.kind in ("ATCM", "BTCM", "CTCM"))
-    for memory in memories:
-        if memory.kind != "DDR":
+    for memory in dynamic_memories:
+        if memory.kind not in ("DDR", "IPC_SHM"):
             continue
-        origin, length = _r5_ddr_aperture(memory, local)
+        origin, length = _r5_mpu_aperture(memory, local)
+        if (memory.kind == "IPC_SHM" and
+                (origin != memory.origin or length != memory.length)):
+            raise LayoutError(
+                f"{memory.node.abs_path}: consolidated R5 IPC range must "
+                "already be naturally aligned and power-of-two sized")
         _set_memory_range(memory, origin, length)
         _info(
             f"zephyr_mpu: {memory.name} R5 MPU aperture "
@@ -310,9 +305,9 @@ def generate_mpu_tree(root_node, sdt, options):
             options.get("args", []))
         layout = parse_layout(sdt.tree, args.domain, args.zephyr_version)
         _, processor, memories = parse_mpu_memories(sdt.tree, args.domain)
-        _prepare_r5_ddr(processor, memories)
         dynamic_memories = tuple(memory for memory in memories
                                  if not _uses_static_mpu(memory))
+        _prepare_r5_mpu_ranges(processor, memories, dynamic_memories)
         _validate_memory_overlaps(dynamic_memories)
         for memory in memories:
             _apply_memory(memory, emit_mpu=not _uses_static_mpu(memory))

--- a/lopper_sanity.py
+++ b/lopper_sanity.py
@@ -2244,7 +2244,7 @@ def zephyr_linker_generator_sanity_test():
             "VECTOR_REGION ATCM", "DATA_REGION BTCM",
         )) and ".resource_table" not in linker_contents and \
             'zephyr,memory-attr = <0x71>' in mpu_contents and \
-            'zephyr,memory-attr = <0x31>' in mpu_contents and \
+            'zephyr,memory-attr = <0x100000>' in mpu_contents and \
             "openamp," not in mpu_contents
     else:
         standalone_passed = False
@@ -2322,7 +2322,7 @@ def zephyr_linker_generator_sanity_test():
             'zephyr,memory-region = "PSU_R5_0_BTCM"',
             'zephyr,memory-region = "RPROC0"',
             'zephyr,memory-attr = <0x71>',
-            'zephyr,memory-attr = <0x31>',
+            'zephyr,memory-attr = <0x100000>',
             'zephyr,sram = "/axi/psu_r5_0_atcm@0"',
             'reg = <0x0 0x9800000 0x0 0x80000>',
         ]
@@ -2679,7 +2679,7 @@ def openamp_zephyr_pipeline_sanity_test():
             'zephyr,memory-region = "PSU_R5_0_BTCM"',
             'zephyr,memory-region = "RPROC0"',
             'zephyr,memory-attr = <0x71>',
-            'zephyr,memory-attr = <0x31>',
+            'zephyr,memory-attr = <0x100000>',
             'zephyr,sram = "/axi/psu_r5_0_atcm@0"',
         ],
         "/tmp/openamp-zephyr-linker-sanity.ld": [

--- a/tests/test_openamp.py
+++ b/tests/test_openamp.py
@@ -131,9 +131,9 @@ def test_zephyr_ipc_shm_replaces_domain_carveout_references():
     tree + LopperNode(-1, "/domains")
     carveouts = []
     for name, address, size in (
-            ("vring0", 0x9860000, 0x4000),
-            ("vring1", 0x9864000, 0x4000),
-            ("buffer", 0x9868000, 0x40000)):
+            ("vring0", 0x9880000, 0x4000),
+            ("vring1", 0x9884000, 0x4000),
+            ("buffer", 0x9888000, 0x78000)):
         node = LopperNode(-1, f"/reserved-memory/{name}@{address:x}")
         node["reg"] = [0, address, 0, size]
         tree + node
@@ -158,6 +158,7 @@ def test_zephyr_ipc_shm_replaces_domain_carveout_references():
         ipc.phandle, firmware.phandle]
     assert tree["/chosen"].propval("zephyr,ipc_shm", list) == [
         ipc.abs_path]
+    assert ipc.propval("reg", list) == [0, 0x9880000, 0, 0x80000]
 
 
 def test_libmetal_missing_processor_lists_supported_targets(monkeypatch, caplog):


### PR DESCRIPTION
Fixups to ensure existing zephyr MPU attributes are usable for r5 