### PR TITLE
lops: add lop-prune-domains to strip /domains from final DTS

### DIFF
--- a/lopper/lops/lop-prune-domains.dts
+++ b/lopper/lops/lop-prune-domains.dts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/dts-v1/;
+
+/ {
+        compatible = "system-device-tree-v1";
+        lops {
+                lop_0 {
+                        // Delete the /domains node so it does not leak into the final DTS.
+                        // Done via a code lop so it is a no-op when /domains is absent.
+                        compatible = "system-device-tree-v1,lop,code-v1";
+                        code = "
+                            try:
+                                domains_node = tree['/domains']
+                            except:
+                                domains_node = None
+
+                            if domains_node:
+                                tree.delete(domains_node)
+                                tree.sync()
+                        ";
+                };
+        };
+};


### PR DESCRIPTION
Add a standalone modify lop that deletes /domains ("/domains::"). It is meant to run as the final lop in a chain, after gen_domain_dts and any domain-consuming assists, and is a harmless no-op when no /domains node is present. Safe to append to the linux_dt, zephyr_dt, and baremetal domain flows.