### PR TITLE
lops: add lop-prune-domains to strip /domains from final DTS

### DIFF
--- a/lopper/lops/lop-prune-domains.dts
+++ b/lopper/lops/lop-prune-domains.dts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/dts-v1/;
+
+/ {
+        compatible = "system-device-tree-v1";
+        lops {
+                lop_0 {
+                        compatible = "system-device-tree-v1,lop,modify";
+                        modify = "/domains::";
+                };
+        };
+};


### PR DESCRIPTION
Add a standalone modify lop that deletes /domains ("/domains::"). It is meant to run as the final lop in a chain, after gen_domain_dts and any domain-consuming assists.