### PR TITLE
zephyr: preserve domain SRAM device identity

### DIFF
--- a/lopper/assists/yaml_to_dts_expansion.py
+++ b/lopper/assists/yaml_to_dts_expansion.py
@@ -1098,11 +1098,30 @@ def memory_expand( tree, subnode, memory_start = 0xbeef, prop_name = 'memory', v
     if verbose:
         print(f"memory_expand: using #address-cells={root_ac}, #size-cells={root_sc}")
 
+    mem = []
+    prop = subnode[prop_name]
+    for i in range(0, len(prop)):
+        mem.append(prop[i])
+
+    # SRAM descriptions carry an explicit device identity because local
+    # processor address spaces can overlap.  Resolve that identity before
+    # flattening YAML so downstream domain pruning and memory-policy assists
+    # do not have to rediscover the node from an ambiguous address range.
+    if prop_name == 'sram' and mem and all(
+            isinstance(entry, dict) and entry.get('dev') for entry in mem):
+        phandles = []
+        for entry in mem:
+            reference = entry['dev']
+            node = resolve_memory_node(tree, reference)
+            if not node.props('reg'):
+                raise LayoutError(
+                    f"{node.abs_path}: SRAM device '{reference}' is missing "
+                    "required 'reg' property")
+            phandles.append(node.phandle_or_create())
+        property_set(prop_name, phandles, subnode)
+        return
+
     try:
-        mem = []
-        prop = subnode[prop_name]
-        for i in range(0,len(prop)):
-            mem.append( prop[i] )
 
         # A "*" entry means "all physical memory/sram": mark the domain
         # keep-all so the specific carveout is not assigned.  For 'memory'

--- a/lopper/assists/zephyr_memory.py
+++ b/lopper/assists/zephyr_memory.py
@@ -245,7 +245,7 @@ def resolve_memory_node(tree, reference):
         matches.append(alias)
     for node in tree:
         aliases = {node.name, node.name.split("@", 1)[0]}
-        for property_name in ("label", "xlnx,ip-name"):
+        for property_name in ("label", "xlnx,ip-name", "xlnx,name"):
             value = node.propval(property_name, list)
             if value and value != [""]:
                 aliases.add(str(value[0]))

--- a/tests/test_zephyr_memory.py
+++ b/tests/test_zephyr_memory.py
@@ -3,8 +3,74 @@
 # Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from lopper.assists.zephyr_memory import _domain_memory_nodes, _normalized_memories
+import pytest
+
+from lopper.assists.yaml_to_dts_expansion import memory_expand
+from lopper.assists.zephyr_memory import (
+    LayoutError,
+    _domain_memory_nodes,
+    _normalized_memories,
+    resolve_memory_node,
+)
 from lopper.tree import LopperNode, LopperTree
+
+
+def test_yaml_sram_device_references_expand_to_phandles():
+    """Explicit SRAM devices retain identity across YAML expansion."""
+    tree = LopperTree()
+    tree + LopperNode(-1, "/axi")
+    tree + LopperNode(-1, "/domains")
+    bank = LopperNode(-1, "/axi/psv_r5_0_atcm@0")
+    bank.label = "psv_r5_0_atcm"
+    bank["reg"] = [0, 0, 0, 0x10000]
+    tree + bank
+    domain = LopperNode(-1, "/domains/R5_0_ZEPHYR")
+    domain["sram"] = [{
+        "dev": "psv_r5_0_atcm@0",
+        "start": 0,
+        "size": 0x10000,
+    }]
+    tree + domain
+    tree.sync()
+
+    memory_expand(tree, domain, prop_name="sram")
+
+    assert domain.propval("sram", list) == [bank.phandle]
+
+
+def test_yaml_sram_device_requires_registers():
+    """Synthetic SRAM nodes without registers are rejected immediately."""
+    tree = LopperTree()
+    tree + LopperNode(-1, "/axi")
+    tree + LopperNode(-1, "/domains")
+    bank = LopperNode(-1, "/axi/psv_r5_0_atcm")
+    bank.label = "psv_r5_0_atcm"
+    tree + bank
+    domain = LopperNode(-1, "/domains/R5_0_ZEPHYR")
+    domain["sram"] = [{
+        "dev": "psv_r5_0_atcm",
+        "start": 0,
+        "size": 0x10000,
+    }]
+    tree + domain
+    tree.sync()
+
+    with pytest.raises(LayoutError, match="missing required 'reg'"):
+        memory_expand(tree, domain, prop_name="sram")
+
+
+def test_canonical_memory_name_resolves_existing_node():
+    """A stable SDT name can alias an implementation-derived TCM node."""
+    tree = LopperTree()
+    tree + LopperNode(-1, "/axi")
+    bank = LopperNode(
+        -1, "/axi/ps_wizard_0_pmcps_0_psv_r5_0_atcm@0")
+    bank["reg"] = [0, 0, 0, 0x10000]
+    bank["xlnx,name"] = ["psv_r5_0_atcm"]
+    tree + bank
+    tree.sync()
+
+    assert resolve_memory_node(tree, "psv_r5_0_atcm") is bank
 
 
 def test_split_r5_local_tcm_range_uses_domain_core():


### PR DESCRIPTION
Domain SRAM descriptions include a dev reference because local processor address spaces can overlap. Resolve each explicit device during YAML expansion and emit its phandle instead of discarding identity and later rediscovering a node from an address and size tuple.

Reject referenced SRAM nodes without a reg property so synthetic, incomplete memory descriptions do not silently reach the final Zephyr devicetree.

Allow memory references to match xlnx,name. This supports stable Versal R5 TCM identities while existing CIPS and PS Wizard node labels remain valid during migration.

Add coverage for phandle expansion, missing-register rejection, and canonical xlnx,name resolution. Existing Zephyr memory and linker tests continue to pass.

Validate current CIPS and PS Wizard domain YAML through OpenAMP, linker, and MPU generation, including synthesized VRK160 local TCM nodes.