### PR TITLE
zephyr: restrict board overlay discovery to Zephyr DTSIs

### DIFF
--- a/lopper/assists/zephyr_board_dt.py
+++ b/lopper/assists/zephyr_board_dt.py
@@ -21,7 +21,6 @@ sys.path.append(os.path.dirname(__file__))
 
 OVERLAY_REF_RE = re.compile(r"&\w+\s*{")
 ZEPHYR_BOARD_DTSI_SUFFIX = "_zephyr.dtsi"
-SDT_DTSI_GLOB = "*.dtsi"
 SDT_TOP_DTS = "system-top.dts"
 SDT_BOARD_PROP_RE = re.compile(r'board\s*=\s*"([^"]+)"')
 SDT_INCLUDE_RE = re.compile(r'#include\s+"([^"]+)"')
@@ -250,12 +249,38 @@ def _sdt_included_dtsi_basenames(sdt_folder):
     system_top = os.path.join(sdt_folder, SDT_TOP_DTS)
     if not os.path.isfile(system_top):
         return frozenset()
+
     included = set()
-    with open(system_top, "r", encoding="utf-8") as fh:
-        for line in fh:
-            match = SDT_INCLUDE_RE.match(line.strip())
-            if match:
-                included.add(os.path.basename(match.group(1)))
+    visited = set()
+
+    def collect_includes(path):
+        real_path = os.path.realpath(path)
+        if real_path in visited or not os.path.isfile(real_path):
+            return
+        visited.add(real_path)
+
+        with open(real_path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                match = SDT_INCLUDE_RE.match(line.strip())
+                if not match:
+                    continue
+
+                include = match.group(1)
+                included.add(os.path.basename(include))
+
+                # CPP resolves quoted includes relative to the including file
+                # before consulting include directories. Mirror that behavior
+                # for files copied into the SDT directory.
+                candidates = (
+                    os.path.join(os.path.dirname(real_path), include),
+                    os.path.join(sdt_folder, include),
+                )
+                for candidate in candidates:
+                    if os.path.isfile(candidate):
+                        collect_includes(candidate)
+                        break
+
+    collect_includes(system_top)
     return frozenset(included)
 
 
@@ -269,7 +294,8 @@ def discover_zephyr_board_files(sdt_folder, main_tree):
 
     user_zephyr_dtsi = None
     sdt_includes = _sdt_included_dtsi_basenames(sdt_folder)
-    for path in sorted(glob.glob(os.path.join(sdt_folder, SDT_DTSI_GLOB))):
+    zephyr_glob = f"*{ZEPHYR_BOARD_DTSI_SUFFIX}"
+    for path in sorted(glob.glob(os.path.join(sdt_folder, zephyr_glob))):
         abs_path = os.path.abspath(path)
         if board_dtsi is not None and abs_path == board_dtsi:
             continue
@@ -307,6 +333,7 @@ def merge_board_overlay_from_sdt(sdt, options):
         return False
 
     for path in (p for p in (board_dtsi, user_zephyr_dtsi) if p):
+        print(f"[INFO] Merging Zephyr board content from '{path}'.")
         with open(path, encoding="utf-8") as fh:
             if not merge_board_overlay_content(fh.read(), sdt.tree, sdt=sdt, sdt_folder=sdt_folder):
                 return False

--- a/tests/test_zephyr_board_overlay.py
+++ b/tests/test_zephyr_board_overlay.py
@@ -48,11 +48,11 @@ def test_discover_board_and_user_by_naming(tmp_path):
     sdt_folder.mkdir()
     (sdt_folder / "system-top.dts").write_text('/ { board = "kcu105"; };', encoding="utf-8")
     (sdt_folder / "kcu105_zephyr.dtsi").write_text("/ { };", encoding="utf-8")
-    (sdt_folder / "custom.dtsi").write_text("/ { };", encoding="utf-8")
+    (sdt_folder / "custom_zephyr.dtsi").write_text("/ { };", encoding="utf-8")
 
     files = discover_zephyr_board_files(str(sdt_folder), _make_tree("kcu105"))
     assert files["board_dtsi"].endswith("kcu105_zephyr.dtsi")
-    assert files["user_zephyr_dtsi"].endswith("custom.dtsi")
+    assert files["user_zephyr_dtsi"].endswith("custom_zephyr.dtsi")
 
 
 def test_discover_ignores_sdt_included_dtsi(tmp_path):
@@ -70,7 +70,7 @@ def test_discover_ignores_sdt_included_dtsi(tmp_path):
     assert files["user_zephyr_dtsi"] is None
 
 
-def test_discover_user_only(tmp_path):
+def test_discover_ignores_unrelated_dtsi(tmp_path):
     sdt_folder = tmp_path / "sdt"
     sdt_folder.mkdir()
     (sdt_folder / "system-top.dts").write_text("/ { };", encoding="utf-8")
@@ -78,10 +78,10 @@ def test_discover_user_only(tmp_path):
 
     files = discover_zephyr_board_files(str(sdt_folder), _make_tree())
     assert files["board_dtsi"] is None
-    assert files["user_zephyr_dtsi"].endswith("vek385.dtsi")
+    assert files["user_zephyr_dtsi"] is None
 
 
-def test_discover_user_override_without_board_zephyr_file(tmp_path):
+def test_discover_user_zephyr_override_without_board_zephyr_file(tmp_path):
     sdt_folder = tmp_path / "sdt"
     sdt_folder.mkdir()
     (sdt_folder / "system-top.dts").write_text(
@@ -89,11 +89,45 @@ def test_discover_user_override_without_board_zephyr_file(tmp_path):
         encoding="utf-8",
     )
     (sdt_folder / "pl.dtsi").write_text("/ { };", encoding="utf-8")
-    (sdt_folder / "kcu105.dtsi").write_text("/ { };", encoding="utf-8")
+    (sdt_folder / "custom_zephyr.dtsi").write_text("/ { };", encoding="utf-8")
 
     files = discover_zephyr_board_files(str(sdt_folder), _make_tree("kcu105"))
     assert files["board_dtsi"] is None
-    assert files["user_zephyr_dtsi"].endswith("kcu105.dtsi")
+    assert files["user_zephyr_dtsi"].endswith("custom_zephyr.dtsi")
+
+
+def test_discover_ignores_transitively_included_dtsi(tmp_path):
+    sdt_folder = tmp_path / "sdt"
+    sdt_folder.mkdir()
+    (sdt_folder / "system-top.dts").write_text(
+        '#include "board.dtsi"\n/ { };', encoding="utf-8"
+    )
+    (sdt_folder / "board.dtsi").write_text(
+        '#include "soc_zephyr.dtsi"\n/ { };', encoding="utf-8"
+    )
+    (sdt_folder / "soc_zephyr.dtsi").write_text("/ { };", encoding="utf-8")
+
+    files = discover_zephyr_board_files(str(sdt_folder), _make_tree())
+    assert files["board_dtsi"] is None
+    assert files["user_zephyr_dtsi"] is None
+
+
+def test_discover_include_cycle(tmp_path):
+    sdt_folder = tmp_path / "sdt"
+    sdt_folder.mkdir()
+    (sdt_folder / "system-top.dts").write_text(
+        '#include "first.dtsi"\n/ { };', encoding="utf-8"
+    )
+    (sdt_folder / "first.dtsi").write_text(
+        '#include "second_zephyr.dtsi"\n/ { };', encoding="utf-8"
+    )
+    (sdt_folder / "second_zephyr.dtsi").write_text(
+        '#include "first.dtsi"\n/ { };', encoding="utf-8"
+    )
+    (sdt_folder / "user_zephyr.dtsi").write_text("/ { };", encoding="utf-8")
+
+    files = discover_zephyr_board_files(str(sdt_folder), _make_tree())
+    assert files["user_zephyr_dtsi"].endswith("user_zephyr.dtsi")
 
 
 def test_resolve_sdt_folder_from_args(tmp_path):
@@ -120,7 +154,7 @@ def test_merge_overlay_user_only(tmp_path):
         """
     )
     (sdt_folder / "system-top.dts").write_text("/ { };", encoding="utf-8")
-    (sdt_folder / "custom.dtsi").write_text(user_content, encoding="utf-8")
+    (sdt_folder / "custom_zephyr.dtsi").write_text(user_content, encoding="utf-8")
 
     tree = _make_tree()
     sdt = SimpleNamespace(outdir=str(outdir), tree=tree, tmpdir=str(outdir))
@@ -198,7 +232,7 @@ def test_merge_overlay_board_and_user_merge(tmp_path):
 
     (sdt_folder / "system-top.dts").write_text('/ { board = "kcu105"; };', encoding="utf-8")
     (sdt_folder / "kcu105_zephyr.dtsi").write_text(board_content, encoding="utf-8")
-    (sdt_folder / "custom.dtsi").write_text(user_content, encoding="utf-8")
+    (sdt_folder / "custom_zephyr.dtsi").write_text(user_content, encoding="utf-8")
 
     tree = _make_tree("kcu105")
     existing = LopperNode()


### PR DESCRIPTION
System device-tree generators copy transitively included DTSIs into the SDT directory. The Zephyr board discovery only excluded files listed directly by system-top.dts, so it could select a full-system board fragment and merge it into a pruned domain tree.

Walk the quoted include graph recursively with cycle detection and exclude every included basename from overlay discovery. Restrict user overlays to files ending in _zephyr.dtsi so unrelated board fragments cannot be selected merely because they sort first.

Report each selected overlay path and extend the discovery tests for nested includes, unrelated DTSIs, explicit Zephyr overlays, and include cycles.