### PR TITLE
openamp: select domain CPUs from the SDT mask

### DIFF
--- a/demos/openamp/inputs/libmetal-overlay-zynqmp.yaml
+++ b/demos/openamp/inputs/libmetal-overlay-zynqmp.yaml
@@ -66,7 +66,7 @@ domains:
     compatible: openamp,domain-v1
     cpus:
       - cluster: cpus_r5_1
-        cpumask: 0x2
+        cpumask: 0x1
         mode:
           secure: true
           el: 0x3

--- a/demos/openamp/inputs/openamp-overlay-versal-2ve-2vm.yaml
+++ b/demos/openamp/inputs/openamp-overlay-versal-2ve-2vm.yaml
@@ -425,7 +425,7 @@ domains:
     cpus:
       - cluster: cpus_r52_1
         cluster_cpu: cortexr52_1
-        cpumask: 0x2
+        cpumask: 0x1
         mode:
           secure: true
           el: 0x3  
@@ -479,7 +479,7 @@ domains:
     compatible: openamp,domain-v1
     cpus:
       - cluster: cpus_r52_8
-        cluster_cpu: cortexr52_9
+        cluster_cpu: cortexr52_8
         cpumask: 0x1
         mode:
           secure: true

--- a/demos/openamp/inputs/openamp-overlay-versal-lockstep.yaml
+++ b/demos/openamp/inputs/openamp-overlay-versal-lockstep.yaml
@@ -113,7 +113,7 @@ domains:
             - "openamp,domain-v1"
         cpus:
             - cluster: cpus_r5_1
-              cpumask: 0x2
+              cpumask: 0x1
               mode:
         access:
             - <<+: *openamp_channel_1_access_srams

--- a/demos/openamp/inputs/openamp-overlay-versal-net-split.yaml
+++ b/demos/openamp/inputs/openamp-overlay-versal-net-split.yaml
@@ -113,7 +113,7 @@ domains:
             - "openamp,domain-v1"
         cpus:
             - cluster: cpus_r52_1
-              cpumask: 0x2
+              cpumask: 0x1
               mode: 0x1
               secure: true
         access:
@@ -168,5 +168,4 @@ domains:
                      - rpu0vdev0vring0
                      - rpu0vdev0vring1
                      - rpu0vdev0buffer
-
 

--- a/demos/openamp/inputs/openamp-overlay-versal-net.yaml
+++ b/demos/openamp/inputs/openamp-overlay-versal-net.yaml
@@ -113,7 +113,7 @@ domains:
             - "openamp,domain-v1"
         cpus:
             - cluster: cpus_r52_1
-              cpumask: 0x2
+              cpumask: 0x1
               mode: 0x1
               secure: true
         access:
@@ -168,5 +168,4 @@ domains:
                      - rpu0vdev0vring0
                      - rpu0vdev0vring1
                      - rpu0vdev0buffer
-
 

--- a/demos/openamp/inputs/openamp-overlay-versal-split.yaml
+++ b/demos/openamp/inputs/openamp-overlay-versal-split.yaml
@@ -109,7 +109,7 @@ domains:
             - "openamp,domain-v1"
         cpus:
             - cluster: cpus_r5_1
-              cpumask: 0x2
+              cpumask: 0x1
               mode: 0x1
               secure: true
         access:

--- a/demos/openamp/inputs/openamp-overlay-zynqmp-dev-mem.yaml
+++ b/demos/openamp/inputs/openamp-overlay-zynqmp-dev-mem.yaml
@@ -119,7 +119,7 @@ domains:
             - "openamp,domain-v1"
         cpus:
             - cluster: cpus_r5_1
-              cpumask: 0x2
+              cpumask: 0x1
               mode: 0x1
               secure: true
         access:

--- a/demos/openamp/inputs/openamp-overlay-zynqmp-lockstep.yaml
+++ b/demos/openamp/inputs/openamp-overlay-zynqmp-lockstep.yaml
@@ -113,7 +113,7 @@ domains:
             - "openamp,domain-v1"
         cpus:
             - cluster: cpus_r5_1
-              cpumask: 0x2
+              cpumask: 0x1
               mode:
         access:
             - <<+: *openamp_channel_1_access_srams

--- a/demos/openamp/inputs/openamp-overlay-zynqmp-split.yaml
+++ b/demos/openamp/inputs/openamp-overlay-zynqmp-split.yaml
@@ -109,7 +109,7 @@ domains:
             - "openamp,domain-v1"
         cpus:
             - cluster: cpus_r5_1
-              cpumask: 0x2
+              cpumask: 0x1
               mode: 0x0
               secure: true
         access:

--- a/demos/openamp/inputs/openamp-overlay-zynqmp.yaml
+++ b/demos/openamp/inputs/openamp-overlay-zynqmp.yaml
@@ -109,7 +109,7 @@ domains:
             - "openamp,domain-v1"
         cpus:
             - cluster: cpus_r5_1
-              cpumask: 0x2
+              cpumask: 0x1
               mode: 0x1
               secure: true
         access:
@@ -164,5 +164,4 @@ domains:
                      - rpu0vdev0vring0
                      - rpu0vdev0vring1
                      - rpu0vdev0buffer
-
 

--- a/demos/openamp/inputs/openamp-zephyr-versal-r5.yaml
+++ b/demos/openamp/inputs/openamp-zephyr-versal-r5.yaml
@@ -114,6 +114,6 @@ domains:
     os,type: baremetal
     cpus:
       - cluster: cpus_r5_1
-        cpumask: 0x2
+        cpumask: 0x1
         mode: { secure: true, el: 0x3 }
         cluster_cpu: psv_cortexr5_1

--- a/demos/openamp/inputs/openamp-zephyr-zynqmp-r5.yaml
+++ b/demos/openamp/inputs/openamp-zephyr-zynqmp-r5.yaml
@@ -116,6 +116,6 @@ domains:
     os,type: baremetal
     cpus:
       - cluster: cpus_r5_1
-        cpumask: 0x2
+        cpumask: 0x1
         mode: { secure: true, el: 0x3 }
         cluster_cpu: psu_cortexr5_1

--- a/lopper/assists/lopper_lib.py
+++ b/lopper/assists/lopper_lib.py
@@ -63,6 +63,22 @@ def chunks(l, n):
         yield l[i:i+n]
 
 
+def cpu_nodes_from_mask(cluster, mask):
+    """Return CPU children selected by a cluster-relative CPU mask."""
+    if cluster is None or mask is None:
+        return []
+
+    try:
+        mask = int(mask)
+    except (TypeError, ValueError):
+        return []
+
+    cpus = [node for node in cluster.subnodes(children_only=True)
+            if re.match(r"cpu@.*", node.name)]
+    return [cpu for index, cpu in enumerate(cpus)
+            if check_bit_set(mask, index)]
+
+
 def json_expand( node ):
     lopper.log._debug( f"========> json expanding node: {node.name}", level=lopper.log.TRACE )
     for p in node:
@@ -942,20 +958,10 @@ def cpu_refs( tree, cpu_prop, verbose = 0 ):
         lopper.log._info( f"cpu node: {cpu_node}" )
         lopper.log._info( f"sub cpus: {sub_cpus}" )
 
-        # we'll now walk from 0 -> 31. Checking the mask to see if access is
-        # allowed. If it is allowed, we'll check to see if there's a sub-cpu at
-        # the same offset. If so, we refcount it AND the parent. For sub-cpus
-        # that are available, but have no access, we log them to be delete later
-        # (we don't delete them now, since it will shift node numbers.
-        for idx in range( 0, 32 ):
-            if check_bit_set( cpu_mask, idx ):
-                try:
-                    sub_cpu_node = sub_cpus[idx]
-                    # refcount it AND the parent
-                    tree.ref_all( sub_cpu_node, True )
-                    refd_cpus.append( sub_cpu_node )
-                except:
-                    pass
+        for sub_cpu_node in cpu_nodes_from_mask(cpu_node, cpu_mask):
+            # refcount it AND the parent
+            tree.ref_all(sub_cpu_node, True)
+            refd_cpus.append(sub_cpu_node)
 
     unrefd_cpus = []
     for s in sub_cpus_all:

--- a/lopper/assists/openamp_xlnx.py
+++ b/lopper/assists/openamp_xlnx.py
@@ -33,6 +33,10 @@ from lopper.log import _init, _warning, _info, _error
 
 sys.path.append(os.path.dirname(__file__))
 from openamp_xlnx_common import *
+from openamp_xlnx_common import (
+    _openamp_domain_processor,
+    _openamp_domain_selects_cpu,
+)
 from baremetalconfig_xlnx import get_cpu_node
 from string import ascii_lowercase as alc
 
@@ -119,7 +123,9 @@ def xlnx_openamp_trim_timers(sdt, target_os, machine):
     else:
         # otherwise filter by machine
         match_cpunode = get_cpu_node(sdt, {'args':[machine]})
-        domains = [ n for n in tree["/domains"].subnodes(children_only=True) if match_cpunode.parent == sdt.tree.pnode(n.parent.parent.propval("cpus")[0]) ]
+        domains = [n for n in tree["/domains"].subnodes(children_only=True)
+                   if _openamp_domain_selects_cpu(tree, n.parent.parent,
+                                                  match_cpunode)]
 
     if not domains:
         return False
@@ -200,7 +206,7 @@ def xlnx_handle_relations(sdt, machine, find_only = True, os = None):
             continue
 
         # ensure target domain matches
-        if match_cpunode.parent == sdt.tree.pnode(n.parent.parent.propval("cpus")[0]):
+        if _openamp_domain_selects_cpu(tree, n.parent.parent, match_cpunode):
             if find_only:
                  return n
             else: # do processing on found nodes
@@ -329,7 +335,7 @@ def xlnx_openamp_get_ddr_elf_load(machine, sdt):
             continue
 
         # ensure target domain matches
-        if match_cpunode.parent == sdt.tree.pnode(n.parent.parent.propval("cpus")[0]):
+        if _openamp_domain_selects_cpu(sdt.tree, n.parent.parent, match_cpunode):
              target_node = n
              break
 
@@ -1368,19 +1374,14 @@ def openamp_nontree_outputs_handler(sdt, output_file_name, openamp_args, verbose
         domain_node = n.parent.parent
         domain_os = domain_node.propval("os,type")
         domain_os = domain_os[0] if domain_os and domain_os != [''] else "unspecified"
-        domain_processor = n.parent.propval("cluster_cpu")
-        if domain_processor and domain_processor != ['']:
-            domain_processor = domain_processor[0]
-        else:
-            cpu_ref = domain_node.propval("cpus")
-            cpu_cluster = sdt.tree.pnode(cpu_ref[0]) if cpu_ref and cpu_ref != [''] else None
-            domain_processor = cpu_cluster.label if cpu_cluster and cpu_cluster.label else \
-                cpu_cluster.name if cpu_cluster else "unspecified"
+        domain_processor = _openamp_domain_processor(sdt.tree, domain_node)
         supported_targets.append("%s (os=%s, processor=%s)" %
                                  (domain_node.name, domain_os, domain_processor))
 
         # ensure target domain matches
-        if os != "linux_dt" and match_cpunode.parent != sdt.tree.pnode(domain_node.propval("cpus")[0]):
+        if (os != "linux_dt" and
+                not _openamp_domain_selects_cpu(sdt.tree, domain_node,
+                                                match_cpunode)):
             continue
 
         # filter based on name

--- a/lopper/assists/openamp_xlnx_common.py
+++ b/lopper/assists/openamp_xlnx_common.py
@@ -15,6 +15,7 @@ import sys
 from pathlib import Path
 
 from baremetalconfig_xlnx import get_cpu_node
+from lopper.assists.lopper_lib import cpu_nodes_from_mask
 
 IPI_MAILBOX_COMPATIBLES = {
     "xlnx,versal-ipi-mailbox",
@@ -82,13 +83,50 @@ def _openamp_ipi_controllers(tree):
     return controllers
 
 
-def _openamp_domain_processor(tree, domain):
+def _openamp_domain_cpu_assignment(tree, domain):
+    """Resolve a domain's cluster and cores from the standard cpus tuple."""
+    cpus = domain.propval("cpus")
+    if cpus == [""] or not cpus:
+        return None, None, []
+    cluster = tree.pnode(cpus[0])
+    if len(cpus) < 2:
+        return cluster, None, []
+    try:
+        mask = int(cpus[1])
+    except (TypeError, ValueError):
+        return cluster, None, []
+    if cluster is None:
+        return None, mask, []
+    return cluster, mask, cpu_nodes_from_mask(cluster, mask)
+
+
+def _openamp_legacy_domain_processor(domain):
+    """Read the historical OpenAMP core label, when present."""
     dtd = next((n for n in domain.subnodes(children_only=True)
                 if n.name == "domain-to-domain"), None)
-    if dtd and dtd.propval("cluster_cpu") != [""]:
-        return dtd.propval("cluster_cpu")[0]
-    cpus = domain.propval("cpus")
-    cluster = tree.pnode(cpus[0]) if cpus != [""] else None
+    value = dtd.propval("cluster_cpu") if dtd else [""]
+    return value[0] if value != [""] and value else None
+
+
+def _openamp_domain_selects_cpu(tree, domain, cpu):
+    """Test CPU membership, preferring the SDT mask over the legacy label."""
+    cluster, mask, _ = _openamp_domain_cpu_assignment(tree, domain)
+    if cluster is not None and mask:
+        return cpu in cpu_nodes_from_mask(cluster, mask)
+
+    legacy = _openamp_legacy_domain_processor(domain)
+    if legacy:
+        return legacy in (cpu.label, cpu.name)
+    return cluster is not None and cpu.parent == cluster
+
+
+def _openamp_domain_processor(tree, domain):
+    cluster, _, selected = _openamp_domain_cpu_assignment(tree, domain)
+    if selected:
+        return ", ".join(cpu.label or cpu.name for cpu in selected)
+    legacy = _openamp_legacy_domain_processor(domain)
+    if legacy:
+        return legacy
     return (cluster.label or cluster.name) if cluster else "unspecified"
 
 
@@ -105,7 +143,7 @@ def _openamp_configured_relations(tree):
             continue
         dtd = next((n for n in domain.subnodes(children_only=True)
                     if n.name == "domain-to-domain"), None)
-        if not dtd or dtd.propval("cluster_cpu") == [""]:
+        if not dtd:
             continue
         for relation in dtd.subnodes(children_only=True):
             compatible = relation.propval("compatible")

--- a/lopper/assists/yaml_to_dts_expansion.py
+++ b/lopper/assists/yaml_to_dts_expansion.py
@@ -1191,6 +1191,11 @@ def openamp_remote_cpu_expand( tree, subnode, cluster_cpu, cluster_node, verbose
         subnode + LopperProp(name="core_num", value=cluster_node.name[-1])
 
 
+def _cpu_mask_value(mask):
+    """Parse either a YAML-native integer or a string CPU mask."""
+    return int(mask, 0) if isinstance(mask, str) else int(mask)
+
+
 def cpu_expand( tree, subnode, verbose = 0):
     """Expand compact CPU descriptors into fully fledged domain properties.
 
@@ -1292,7 +1297,7 @@ def cpu_expand( tree, subnode, verbose = 0):
 
             try:
                 mask = c['cpumask']
-                mask = int(mask,16)
+                mask = _cpu_mask_value(mask)
             except:
                 mask = 0
         else:

--- a/lopper/assists/yaml_to_dts_expansion.py
+++ b/lopper/assists/yaml_to_dts_expansion.py
@@ -32,7 +32,9 @@ from lopper.yaml import LopperYAML
 import lopper
 import json
 
-from .lopper_lib import check_bit_set, clear_bit, chunks, property_set, set_bit, expand_start_size_to_reg
+from .lopper_lib import (check_bit_set, clear_bit, chunks,
+                         cpu_nodes_from_mask, property_set, set_bit,
+                         expand_start_size_to_reg)
 from lopper.log import _init, _warning, _info, _error, _debug
 from .zephyr_memory import (
     LINKER_SCALAR_PROPERTIES,
@@ -1167,28 +1169,54 @@ def openamp_remote_cpu_expand( tree, subnode, cluster_cpu, cluster_node, verbose
     Args:
         tree (LopperTree): Device tree being modified.
         subnode (LopperNode): Node describing CPU resources to attach.
-        cluster_cpu (arr): None or array to check for cluster CPU information
+        cluster_cpu (arr): Optional legacy core label used as a fallback.
         cluster_node (LopperNode): Node for core CPU information
         verbose (int): Verbosity level for diagnostic output.
 
     Returns:
         None
     """
-    if cluster_cpu == None:
-        return
+    # Preserve the historical property for inputs that still provide it, but
+    # derive core-specific data from the standard cpus mask first.
+    if cluster_cpu is not None:
+        for n in subnode.subnodes():
+            if n.name == "domain-to-domain":
+                n + LopperProp(name="cluster_cpu", value=cluster_cpu)
 
-    for n in subnode.subnodes():
-        if n.name == "domain-to-domain":
-            n + LopperProp(name="cluster_cpu", value=cluster_cpu)
+    cpus = subnode.propval("cpus")
+    cpu_mask = cpus[1] if cpus != [''] and len(cpus) > 1 else None
+    selected_cores = cpu_nodes_from_mask(cluster_node, cpu_mask)
 
-    if cluster_node is not None:
-        pd_prop_node = [ n for n in cluster_node.subnodes() if n.propval("power-domains") != [''] ]
-        if len(pd_prop_node) == 1:
-            subnode + LopperProp(name="rpu_pd_val", value=pd_prop_node[0].propval("power-domains"))
+    # Fall back to the legacy label only when the mask did not resolve a core.
+    if not selected_cores and cluster_cpu is not None:
+        legacy_label = (cluster_cpu[0]
+                        if isinstance(cluster_cpu, list) else cluster_cpu)
+        try:
+            selected_cores = [tree.lnodes(legacy_label)[0]]
+        except (IndexError, KeyError):
+            selected_cores = []
 
-    if cluster_node != None and "r5" in cluster_node.name:
+    if selected_cores and cluster_cpu is not None:
+        legacy_label = (cluster_cpu[0]
+                        if isinstance(cluster_cpu, list) else cluster_cpu)
+        if legacy_label not in (selected_cores[0].label,
+                                selected_cores[0].name):
+            _warning(f"{subnode.abs_path}: cluster_cpu '{legacy_label}' "
+                     f"does not match cpumask-selected CPU "
+                     f"'{selected_cores[0].label or selected_cores[0].name}'")
+
+    if len(selected_cores) == 1:
+        power_domains = selected_cores[0].propval("power-domains")
+        if power_domains != ['']:
+            subnode + LopperProp(name="rpu_pd_val", value=power_domains)
+
+    if cluster_node is not None and "r5" in cluster_node.name:
         subnode + LopperProp(name="cpu_config_str", value="lockstep" if check_bit_set(subnode.propval("cpus")[2], 30) else "split")
-        subnode + LopperProp(name="core_num", value=cluster_node.name[-1])
+        if len(selected_cores) == 1:
+            subnode + LopperProp(name="core_num", value=selected_cores[0].propval("reg")[0])
+        elif cluster_cpu is not None:
+            # Compatibility for legacy trees whose CPU child cannot be resolved.
+            subnode + LopperProp(name="core_num", value=cluster_node.name[-1])
 
 
 def _cpu_mask_value(mask):
@@ -1315,7 +1343,7 @@ def cpu_expand( tree, subnode, verbose = 0):
     if cpus_list:
         cpus[0].value = cpus_list
 
-    # This is a no-op if cluster_cpu and cluster_node are not set up.
+    # Derive OpenAMP CPU metadata from the mask, with cluster_cpu as fallback.
     openamp_remote_cpu_expand(tree, subnode, cluster_cpu, cluster_node, verbose)
 
 # sdt: is the system device tree

--- a/tests/test_openamp.py
+++ b/tests/test_openamp.py
@@ -17,7 +17,11 @@ Author:
 import os
 import pytest
 
-from lopper.assists import openamp_xlnx
+from lopper.assists import (
+    openamp_xlnx,
+    openamp_xlnx_common,
+    yaml_to_dts_expansion,
+)
 from lopper.tree import LopperNode, LopperTree
 
 
@@ -165,7 +169,10 @@ def test_libmetal_missing_processor_lists_supported_targets(monkeypatch, caplog)
     """A processor without a Libmetal relation gets an actionable error."""
     apu_cluster = _FakeNode("cpus-a53@0", label="cpus_a53")
     r5_0_cluster = _FakeNode("cpus-r5@0", label="cpus_r5_0")
-    r5_1_cluster = _FakeNode("cpus-r5@1", label="cpus_r5_1")
+    r5_1_cpu = _FakeNode("cpu@1", {"reg": [1]}, label="psu_cortexr5_1")
+    r5_1_cluster = _FakeNode(
+        "cpus-r5@1", label="cpus_r5_1", children=[r5_1_cpu])
+    r5_1_cpu.parent = r5_1_cluster
 
     apu_domain = _FakeNode("APU_Linux", {"cpus": [1], "os,type": ["linux"]})
     apu_parent = _FakeNode("domain-to-domain", parent=apu_domain)
@@ -173,7 +180,8 @@ def test_libmetal_missing_processor_lists_supported_targets(monkeypatch, caplog)
         "libmetal-relation", {"compatible": ["libmetal,ipc-v1"]}, apu_parent)
 
     r5_1_domain = _FakeNode(
-        "R5_1_BAREMETAL", {"cpus": [3], "os,type": ["baremetal"]})
+        "R5_1_BAREMETAL", {"cpus": [3, 0x1, 0],
+                            "os,type": ["baremetal"]})
     r5_1_parent = _FakeNode(
         "domain-to-domain", {"cluster_cpu": ["psu_cortexr5_1"]}, r5_1_domain)
     r5_1_relation = _FakeNode(
@@ -205,3 +213,100 @@ def test_libmetal_missing_processor_lists_supported_targets(monkeypatch, caplog)
     assert "no libmetal,ipc-v1 relation found for processor 'psu_cortexr5_0'" in caplog.text
     assert "APU_Linux (os=linux, processor=cpus_a53)" in caplog.text
     assert "R5_1_BAREMETAL (os=baremetal, processor=psu_cortexr5_1)" in caplog.text
+
+
+def test_domain_cpu_mask_is_preferred_over_legacy_cluster_cpu():
+    """The SDT cpus mask is authoritative when the legacy label disagrees."""
+    cpu0 = _FakeNode("cpu@0", {"reg": [0]}, label="psu_cortexr5_0")
+    cpu1 = _FakeNode("cpu@1", {"reg": [1]}, label="psu_cortexr5_1")
+    cluster = _FakeNode("cpus-r5@0", label="cpus_r5",
+                        children=[cpu0, cpu1])
+    cpu0.parent = cluster
+    cpu1.parent = cluster
+    domain = _FakeNode("R5_1", {"cpus": [1, 0x2, 0]})
+    dtd = _FakeNode("domain-to-domain",
+                    {"cluster_cpu": ["psu_cortexr5_0"]}, domain)
+    domain._children = [dtd]
+    tree = _FakeTree(_FakeNode("domains"), {1: cluster})
+
+    assert not openamp_xlnx_common._openamp_domain_selects_cpu(
+        tree, domain, cpu0)
+    assert openamp_xlnx_common._openamp_domain_selects_cpu(
+        tree, domain, cpu1)
+    assert openamp_xlnx_common._openamp_domain_processor(
+        tree, domain) == "psu_cortexr5_1"
+
+    domain._props["cpus"] = [1]
+    assert openamp_xlnx_common._openamp_domain_selects_cpu(
+        tree, domain, cpu0)
+    assert not openamp_xlnx_common._openamp_domain_selects_cpu(
+        tree, domain, cpu1)
+    assert openamp_xlnx_common._openamp_domain_processor(
+        tree, domain) == "psu_cortexr5_0"
+
+
+def test_yaml_openamp_cpu_metadata_comes_from_mask_without_legacy_label():
+    """YAML expansion derives RPU metadata without cluster_cpu."""
+    tree = LopperTree()
+    tree + LopperNode(-1, "/domains")
+    cluster = LopperNode(-1, "/cpus-r5@1")
+    cluster.label = "cpus_r5_1"
+    tree + cluster
+    cpu = LopperNode(-1, "/cpus-r5@1/cpu@1")
+    cpu.label = "psu_cortexr5_1"
+    cpu["reg"] = [1]
+    cpu["power-domains"] = [99, 8]
+    tree + cpu
+    domain = LopperNode(-1, "/domains/R5_1")
+    tree + domain
+    dtd = LopperNode(-1, "/domains/R5_1/domain-to-domain")
+    tree + dtd
+    cluster.phandle_or_create()
+    domain["cpus"] = [cluster.phandle, 0x1, 0]
+    tree.sync()
+
+    yaml_to_dts_expansion.openamp_remote_cpu_expand(
+        tree, domain, None, cluster)
+
+    assert domain.propval("core_num", list) == [1]
+    assert domain.propval("cpu_config_str", list) == ["split"]
+    assert domain.propval("rpu_pd_val", list) == [99, 8]
+    assert dtd.propval("cluster_cpu") == [""]
+
+
+@pytest.mark.parametrize("mask", [0x2, "0x2"])
+def test_yaml_cpu_expand_preserves_numeric_and_string_masks(mask):
+    """YAML-native integers and quoted hexadecimal masks expand identically."""
+    assert yaml_to_dts_expansion._cpu_mask_value(mask) == 0x2
+
+
+def test_domain_cpu_mask_is_cluster_relative_not_reg_value():
+    """Mask bits identify a CPU's position even when reg encodes MPIDR."""
+    cpu0 = _FakeNode("cpu@0", {"reg": [0]}, label="cortexa78_0")
+    cpu1 = _FakeNode("cpu@100", {"reg": [0x100]}, label="cortexa78_1")
+    cluster = _FakeNode("cpus-a78@0", label="cpus_a78",
+                        children=[cpu0, cpu1])
+    cpu0.parent = cluster
+    cpu1.parent = cluster
+    domain = _FakeNode("APU", {"cpus": [1, 0x2, 0]})
+    tree = _FakeTree(_FakeNode("domains"), {1: cluster})
+
+    assert not openamp_xlnx_common._openamp_domain_selects_cpu(
+        tree, domain, cpu0)
+    assert openamp_xlnx_common._openamp_domain_selects_cpu(
+        tree, domain, cpu1)
+
+
+def test_zero_cpu_mask_falls_back_to_legacy_cluster_cpu():
+    """A zero mask is unspecified for compatibility with legacy overlays."""
+    cpu = _FakeNode("cpu@6", {"reg": [6]}, label="cortexr52_6")
+    cluster = _FakeNode("cpus-r52@6", label="cpus_r52_6", children=[cpu])
+    cpu.parent = cluster
+    domain = _FakeNode("RPU", {"cpus": [1, 0, 0]})
+    dtd = _FakeNode("domain-to-domain",
+                    {"cluster_cpu": ["cortexr52_6"]}, domain)
+    domain._children = [dtd]
+    tree = _FakeTree(_FakeNode("domains"), {1: cluster})
+
+    assert openamp_xlnx_common._openamp_domain_selects_cpu(
+        tree, domain, cpu)


### PR DESCRIPTION
Decode the CPU mask in the standard cpus tuple when matching OpenAMP domains and reporting processors. Retain cluster_cpu as a fallback for legacy inputs.

Derive RPU metadata from the selected CPU during YAML expansion and accept both integer and string CPU masks.