### PR TITLE
Clk wiz zephyr support

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -438,6 +438,10 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
                 elif (xlnx_openamp_keep_node(linux_dt, False, node, sdt.tree) or
                       _node_must_be_preserved(node, sdt.tree)):
                     continue
+                # dual-mapped 8-cell reg won't match either domain's address-map; preserve here so
+                # zephyr_domain_dts.py's xlnx_remove_unsupported_nodes can slice it
+                elif node.propval('compatible') != [''] and any('clkx5-wiz' in c for c in node.propval('compatible', list)) and len(node.propval('reg', list)) == 8:
+                    continue
                 else:
                     sdt.tree.delete(node)
         elif node.propval('compatible') != [''] and linux_dt:

--- a/lopper/assists/zephyr_domain_dts.py
+++ b/lopper/assists/zephyr_domain_dts.py
@@ -581,6 +581,57 @@ def _apply_pl_peripheral_transforms(node, schema, rename_timer=None, stdout_baud
         return [value for key, value in schema.items() if key in node["compatible"].value]
     return None
 
+def _compact_clk_wiz_node(node, machine, sdt):
+    from lopper.tree import LopperProp
+
+    reg_val = node.propval('reg', list)
+    if not reg_val or reg_val == ['']:
+        return
+
+    n = len(reg_val)
+    # n==8 paired with the 8-cell preserve guard in xlnx_generate_domain_dts; both must stay in sync
+    if n == 8:
+        # [APU 4-cell][RPU 4-cell]; amba_pl uses #address-cells=2, #size-cells=2
+        # APU/RPU split uses the same "a78"/"a72" substring convention as the rest of this file
+        if "a78" in machine or "a72" in machine:
+            final_reg = reg_val[0:4]
+        else:
+            final_reg = reg_val[4:8]
+        addr_hex = (f"{final_reg[0]:x}{final_reg[1]:08x}".lstrip('0') or '0')
+    elif n == 4:
+        final_reg = reg_val
+        addr_hex = (f"{reg_val[0]:x}{reg_val[1]:08x}".lstrip('0') or '0')
+    else:
+        return
+
+    phandle_val  = node.propval('phandle', list)
+    compatible   = node.propval('compatible', list)
+    clocks_val   = node.propval('clocks', list)
+    clk_cells    = node.propval('#clock-cells', list)
+    num_out_clks = node.propval('xlnx,num-out-clks', list)
+    status_val   = node.propval('status', list)
+
+    # Zephyr's clock-controller binding only permits these properties; drop everything
+    # else the Vivado-generated node carries (power-domains, resets, xlnx,* vendor props, etc.)
+    for prop in list(node.__props__.keys()):
+        node.delete(prop)
+
+    if phandle_val and phandle_val != ['']:
+        node + LopperProp(name="phandle", value=phandle_val)
+    node + LopperProp(name="compatible", value=compatible)
+    node + LopperProp(name="reg", value=final_reg)
+    if clocks_val and clocks_val != ['']:
+        node + LopperProp(name="clocks", value=clocks_val)
+    if clk_cells and clk_cells != ['']:
+        node + LopperProp(name="#clock-cells", value=clk_cells)
+    if num_out_clks and num_out_clks != ['']:
+        node + LopperProp(name="xlnx,num-out-clks", value=num_out_clks)
+    if status_val and status_val != ['']:
+        node + LopperProp(name="status", value=status_val)
+
+    node.name = f"clock-controller@{addr_hex}"
+    sdt.tree.sync()
+
 def xlnx_remove_unsupported_nodes(tgt_node, sdt, machine, options=None):
     root_node = sdt.tree['/']
     root_sub_nodes = root_node.subnodes()
@@ -605,6 +656,13 @@ def xlnx_remove_unsupported_nodes(tgt_node, sdt, machine, options=None):
                             num_intr += 12
 
                     is_supported_periph = [value for key,value in schema.items() if key in node["compatible"].value]
+                    # clkx5-wiz needs domain-specific reg slicing; bypass the standard peripheral pipeline.
+                    # Unsupported clk-wiz compatibles fall through to the normal deletion path below.
+                    if (any('clkx5-wiz' in c for c in node.propval('compatible', list))
+                            and is_supported_periph):
+                        _compact_clk_wiz_node(node, machine, sdt)
+                        valid_alias_proplist.append(node.name)
+                        continue
                     # UARTNS550
                     if "xlnx,axi-uart16550-2.0" in node["compatible"].value:
                         node["compatible"].value = ["ns16550"]

--- a/lopper/assists/zephyr_supported_comp.yaml
+++ b/lopper/assists/zephyr_supported_comp.yaml
@@ -528,3 +528,12 @@ xlnx,versal-sysmon:
     - status
     - interrupts
     - xlnx,numchannels
+
+xlnx,clkx5-wiz-1.0:
+  required:
+    - compatible
+    - reg
+    - clocks
+    - '#clock-cells'
+    - xlnx,num-out-clks
+    - status


### PR DESCRIPTION
This patch series adds support for dual-mapped AMD/Xilinx Clocking Wizard (xlnx,clkx5-wiz-1.0) nodes in Lopper.

  The first patch updates the Zephyr supported compatibility list to
  include the "xlnx,clkx5-wiz-1.0" compatible entry, allowing proper
  recognition of the Clocking Wizard node during device tree processing.

  The second patch extends the gen_domain_dts assist script to handle
  Clocking Wizard nodes whose reg property spans both the APU and RPU
  domains, slicing it to the correct per-domain address instead of
  dropping the node.

  Tested on a Versal Gen2 platform with Lopper-generated dts.