### PR TITLE
lopper: assists: add TRNGPSX Zephyr DTS support for Spartan UltraScale+

### DIFF
--- a/lopper/assists/zephyr_supported_comp.yaml
+++ b/lopper/assists/zephyr_supported_comp.yaml
@@ -6,6 +6,12 @@ amd,mbv32:
     - riscv,isa
     - clock-frequency
 
+xlnx,pmcl-trng-11.0:
+  required:
+    - compatible
+    - status
+    - reg
+
 xlnx,xps-intc-1.00.a:
   required:
     - compatible


### PR DESCRIPTION
- zephyr_supported_comp.yaml: add TRNG compatible entry