### PR TITLE
lopper:assists:baremetal_xparameters_xlnx: Fix CPU Compatible Detecti…

### DIFF
--- a/lopper/assists/baremetal_xparameters_xlnx.py
+++ b/lopper/assists/baremetal_xparameters_xlnx.py
@@ -471,7 +471,7 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
         srcdir = os.path.join(repo_path_data, "lib", "bsp", "standalone")
     datadir = os.path.join(srcdir, "data")
     yaml_paths = glob.glob(f"{datadir}/*/*.yaml")
-    if re.search("microblaze", match_cpunode.propval('compatible')[0]):
+    if any("microblaze" in comp for comp in match_cpunode.propval('compatible', list)):
         for yamlfile in yaml_paths:
             name = os.path.basename(os.path.dirname(yamlfile))
             schema = utils.load_yaml(yamlfile)
@@ -496,7 +496,7 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
                         prop = prop.replace("xlnx,", "")
                         plat.buf(f'#define XPAR_{ip_name.upper()}_{prop.upper()} {prop_val}\n')
 
-    if re.search("microblaze-riscv", match_cpunode.propval('compatible')[0]):
+    if any("microblaze-riscv" in comp for comp in match_cpunode.propval('compatible', list)):
         cpu_parameters={
         'xlnx,freq':"XPAR_CPU_CORE_CLOCK_FREQ_HZ",
         'xlnx,use-dcache':'XPAR_MICROBLAZE_RISCV_USE_DCACHE',
@@ -518,7 +518,7 @@ def xlnx_generate_xparams(tgt_node, sdt, options):
                                 'xlnx,icache-byte-size','xlnx,use-fpu',]
         add_multi_buf(plat,match_cpunode,cpu_parameters,ignore_else_part_lis)
 
-    elif re.search("microblaze", match_cpunode.propval('compatible')[0]):
+    elif any("microblaze" in comp for comp in match_cpunode.propval('compatible', list)):
         mic_cpu = {'xlnx,freq':'XPAR_CPU_CORE_CLOCK_FREQ_HZ',
                    'xlnx,ddr-reserve-sa':'XPAR_MICROBLAZE_DDR_RESERVE_SA',
                    'xlnx,addr-size':'XPAR_MICROBLAZE_ADDR_SIZE'}


### PR DESCRIPTION
…on in baremetal_xparameters_xlnx by Scanning Full Compatible List

The baremetal_xparameters_xlnx assist previously identified MicroBlaze and MicroBlaze RISC-V CPUs by checking only the first entry of the compatible property (compatible[0]). On newer SDTs, the first compatible string is often a generic CPU identifier (for example, amd,mbv32 or riscv), while the MicroBlaze-specific compatible strings may appear later in the list. As a result, CPU type detection could fail, leading to generation of generic CPU macros instead of the appropriate MicroBlaze or MicroBlaze RISC-V definitions.

Update the CPU detection logic to search the entire compatible list using any()-based matching, ensuring that MicroBlaze and MicroBlaze RISC-V processors are correctly identified regardless of the position of their compatible strings within the property. This improves compatibility with newer SDTs and ensures the correct CPU-specific xparameters are generated.