### PR TITLE
lopper: assist: zephyr: guard R52 reserved-memory ranges update

### DIFF
--- a/lopper/assists/zephyr_domain_dts.py
+++ b/lopper/assists/zephyr_domain_dts.py
@@ -488,8 +488,9 @@ def xlnx_generate_zephyr_domain_dts_arm(tgt_node, sdt, options, machine):
             if compatible == "arm,armv8-timer" and ('psv_cortexr5' in machine or 'psu_cortexr5' in machine):
                 sdt.tree.delete(node)
         if node.name == 'reserved-memory' and 'r52' in machine:
-            node.delete('ranges')
-            node + LopperProp(name='ranges')
+            if node.propval('ranges') != ['']:
+                node.delete('ranges')
+                node + LopperProp(name='ranges')
 
     board_symbol = board_symbol_for_machine(machine)
     if board_symbol:

--- a/tests/test_xlnx_gen_domain.py
+++ b/tests/test_xlnx_gen_domain.py
@@ -155,6 +155,56 @@ def test_ttc_label_normalization_is_r5_platform_specific():
     assert tree["/__symbols__"].propval("ttc0") == ['']
 
 
+def _minimal_r52_tree(reserved_memory_props=None):
+    """Minimal Versal2 R52 tree with SCMI-style /reserved-memory."""
+    tree = LopperTree()
+    root = tree["/"]
+    root["compatible"] = ["amd,versal2"]
+    for name in ("cpus", "chosen", "aliases", "axi"):
+        tree + LopperNode(-1, f"/{name}")
+    resmem = LopperNode(-1, "/reserved-memory")
+    resmem["#address-cells"] = [2]
+    resmem["#size-cells"] = [2]
+    if reserved_memory_props:
+        for prop_name, prop_value in reserved_memory_props.items():
+            resmem[prop_name] = prop_value
+    buffer_node = LopperNode(-1, "/reserved-memory/memory@20000000")
+    buffer_node["no-map"] = []
+    buffer_node["reg"] = [0, 0x20000000, 0, 0x20000]
+    resmem.add(buffer_node)
+    tree + resmem
+    tree.sync()
+    return tree
+
+
+def test_r52_reserved_memory_without_ranges_does_not_raise(tmp_path):
+    """SCMI /reserved-memory without ranges must not abort R52 domain generation."""
+    tree = _minimal_r52_tree()
+    sdt = SimpleNamespace(tree=tree, outdir=str(tmp_path))
+    options = {"args": ["cortexr52_0"], "verbose": 0}
+
+    assert gen_domain_dts.xlnx_generate_zephyr_domain_dts_arm(
+        "/", sdt, options, "cortexr52_0")
+
+    resmem = tree["/reserved-memory"]
+    assert resmem.propval("ranges") == ['']
+
+
+def test_r52_reserved_memory_malformed_ranges_is_normalized(tmp_path):
+    """Malformed ranges values are rewritten as an empty ranges flag."""
+    tree = _minimal_r52_tree(reserved_memory_props={"ranges": [1]})
+    sdt = SimpleNamespace(tree=tree, outdir=str(tmp_path))
+    options = {"args": ["cortexr52_0"], "verbose": 0}
+
+    gen_domain_dts.xlnx_generate_zephyr_domain_dts_arm(
+        "/", sdt, options, "cortexr52_0")
+
+    ranges_prop = tree["/reserved-memory"].props("ranges")[0]
+    ranges_prop.resolve()
+    assert ranges_prop.value in ([], [''])
+    assert "0x1" not in ranges_prop.string_val
+
+
 def test_rpu_memory_rename_refreshes_path_and_phandle_references():
     """RPU local-view renames preserve chosen, symbol, and phandle refs."""
     tree = LopperTree()


### PR DESCRIPTION
R52 Zephyr domain generation walks top-level nodes in xlnx_generate_zephyr_domain_dts_arm() and, for /reserved-memory, replaces any existing ranges property with an empty flag:
    ranges;
That path was added so a malformed ranges value produced elsewhere in the pipeline -- typically ranges = <0x1> from boolean handling -- could be stripped and rewritten as the empty flag the output is expected to carry.
The rewrite always called node.delete('ranges') first. delete() raises KeyError when the named property is not on the node; it is not a quiet no-op. Platform SDT fragments that introduce /reserved-memory without a ranges property -- SCMI reserved regions are one example -- therefore fail before any rewrite happens:
    assist xlnx_generate_domain_dts failed: 'ranges'
The failure is early enough that it matters for overlay merge. Board overlay content is merged after domain-specific generation in xlnx_generate_domain_dts(); an exception in the R52 arm path aborts the assist and the overlay never runs. Nodes supplied only by the fragment, such as GEM MDIO/PHY content on RPU designs, are dropped from the generated Zephyr domain DTS even when the overlay file is passed on the command line.

Only touch ranges when the node already has the property: delete the existing value and add the empty flag. If ranges is absent, leave the node as the SDT supplied it. That preserves the original normalization for inputs that carry a bad ranges value, and lets R52 RPU generation complete when reserved-memory arrives without ranges at all.