### PR TITLE
lopper: assists: Add xiltimer to third-party OS

### DIFF
--- a/lopper/assists/baremetal_getsupported_comp_xlnx.py
+++ b/lopper/assists/baremetal_getsupported_comp_xlnx.py
@@ -20,6 +20,8 @@ sys.path.append(os.path.dirname(__file__))
 
 _init(__name__)
 
+NATIVE_OS = frozenset(("standalone", "freertos"))
+
 def is_compat( node, compat_string_to_test ):
     if re.search( "module,baremetal_getsupported_comp_xlnx", compat_string_to_test):
         return xlnx_baremetal_getsupported_comp
@@ -176,6 +178,13 @@ def xlnx_baremetal_getsupported_comp(tgt_node, sdt, options):
 
     with open(os.path.join(sdt.outdir, 'app_list.yaml'), 'w') as fd:
         fd.write(yaml.dump(supported_app_dict, sort_keys=False, indent=2, width=32768, Dumper=VerboseSafeDumper))
+
+    # Add xiltimer as a dependency to all thirdparty OS entries.
+    xiltimer_entry = supported_libs_dict[proc_name]["standalone"].get("xiltimer")
+    if xiltimer_entry:
+        for os_key in os_bsp_keys:
+            if os_key not in NATIVE_OS:
+                supported_libs_dict[proc_name][os_key]["xiltimer"] = dict(xiltimer_entry)
 
     with open(os.path.join(sdt.outdir, 'lib_list.yaml'), 'w') as fd:
         fd.write(yaml.dump(supported_libs_dict, sort_keys=False, indent=2, width=32768, Dumper=VerboseSafeDumper))


### PR DESCRIPTION
Extend baremetal_getsupported_comp_xlnx to propagate xiltimer into
  third-party OS buckets in lib_list.yaml.
  Third-party OS BSPs (e.g. ucos) depend on xiltimer, but the library’s YAML
  metadata only lists standalone and freertos under supported_os.
  During lib discovery, xiltimer is therefore added only to the standalone
  bucket and is not carried into third-party OS buckets created from .repo.yaml.

  Before writing lib_list.yaml, copy the standalone xiltimer entry into each
  non-native OS bucket (every key in os_bsp_keys except standalone and freertos),
  using an independent dict copy per bucket.