### PR TITLE
lop-microblaze-riscv: Restore f/d FPU suffix in bsp_archflags

### DIFF
--- a/lopper/lops/lop-microblaze-riscv.dts
+++ b/lopper/lops/lop-microblaze-riscv.dts
@@ -178,8 +178,10 @@
                                    if not fpu_conflict:
                                        if n['xlnx,use-fpu'].value[0] == 1:
                                            archflags.append('f')
+                                           bsp_archflags.append('f')
                                        elif n['xlnx,use-fpu'].value[0] == 2:
                                            archflags.append('d')
+                                           bsp_archflags.append('d')
 
                                    archflags.insert(0, '-march=')
                                    bsp_archflags.insert(0, '-march=')


### PR DESCRIPTION
Commit 22551d463c6c removed bsp_archflags.append('f'/'d') while keeping the equivalent appends for archflags, causing -mabi=lp64 in linkflags instead of -mabi=lp64d for MicroBlaze-V cores with FPU enabled. This results in a link-time failure:

can't link double-float modules with soft-float modules

Restore the missing bsp_archflags.append() calls so that linker flags stay in sync with compiler flags when FPU is present.