### PR TITLE
lopper: assists: restore misc_props pruning after Zephyr split

### DIFF
--- a/lopper/assists/gen_domain_dts.py
+++ b/lopper/assists/gen_domain_dts.py
@@ -404,7 +404,7 @@ def xlnx_generate_domain_dts(tgt_node, sdt, options):
 
     mapped_children_nodes = []
     for node in root_sub_nodes:
-        if node.name == "misc_props":
+        if linux_dt and node.name == "misc_props":
             sdt.tree.delete(node)
             continue
         if linux_dt:

--- a/lopper/assists/zephyr_domain_dts.py
+++ b/lopper/assists/zephyr_domain_dts.py
@@ -2349,6 +2349,13 @@ def xlnx_zephyr_domain_dts(tgt_node, sdt, options):
     if not _generate_domain_tree_for_zephyr(tgt_node, sdt, options, machine):
         return False
 
+    # misc_props holds SDT metadata that only the bare-metal flows consume, so
+    # gen_domain_dts keeps it; it has no Zephyr binding.
+    try:
+        sdt.tree.delete(sdt.tree['/misc_props'])
+    except KeyError:
+        pass
+
     memnode_list = sdt.tree.nodes('/memory@.*')
     memnode_list = [node for node in memnode_list if node.propval('device_type') == ["memory"]]
     xlnx_zephyr_fixup_rpu_memory_names(sdt.tree, machine, memnode_list)


### PR DESCRIPTION
misc_props is SDT metadata from pcw.dtsi. Bare-metal domain generation must keep it so baremetal_xparameters_xlnx and bmcmake_metadata_xlnx can emit the corresponding macros and CMake variables. Linux and Zephyr have no binding for the node and should drop it.

When Zephyr handling moved out of gen_domain_dts, the original guard
    if (linux_dt or zephyr_dt) and node.name == "misc_props"
became an unconditional delete. That removed misc_props from the bare-metal prune as well, so the xparameters/CMake properties never appeared.

Restore the linux_dt-only delete in gen_domain_dts, and drop the node in zephyr_domain_dts after the shared domain prune.